### PR TITLE
Attempt to document usage of ref in azip

### DIFF
--- a/src/zip/zipmacro.rs
+++ b/src/zip/zipmacro.rs
@@ -56,9 +56,9 @@
 ///
 /// type M = Array2<f32>;
 ///
-/// // Since this function borrows its inputs, captures must use ref
+/// // Since this function borrows its inputs, captures must use the x (x) pattern
 /// fn borrow_multiply(a: &mut M, b: &M, c: &M) {
-///     azip!(mut a (a), ref b, ref c in { *a = b * c });
+///     azip!(mut a (a), b (b), c (c) in { *a = b * c });
 /// }
 ///
 /// fn main() {
@@ -86,6 +86,8 @@
 ///     });
 ///
 ///     assert_eq!(a, &b - &c);
+///
+///     // Example of azip!() on borrowed values
 ///
 ///     borrow_multiply(&mut a, &b, &c);
 ///

--- a/src/zip/zipmacro.rs
+++ b/src/zip/zipmacro.rs
@@ -56,6 +56,11 @@
 ///
 /// type M = Array2<f32>;
 ///
+/// // Since this function borrows its inputs, captures must use ref
+/// fn borrow_multiply(a: &mut M, b: &M, c: &M) {
+///     azip!(mut a (a), ref b, ref c in { *a = b * c });
+/// }
+///
 /// fn main() {
 ///     let mut a = M::zeros((16, 16));
 ///     let mut b = M::zeros(a.dim());
@@ -81,6 +86,10 @@
 ///     });
 ///
 ///     assert_eq!(a, &b - &c);
+///
+///     borrow_multiply(&mut a, &b, &c);
+///
+///     assert_eq!(a, &b * &c);
 /// }
 /// ```
 macro_rules! azip {


### PR DESCRIPTION
Hi, I was recently confused when trying to use the `azip` macro in a function that borrowed its input. I've tried to document how to correctly do this, but I have not been able to figure out how to get it to compile. Could someone help me figure out what line 61 of this file needs to look like?