### PR TITLE
Add AsRef<[usize]> and AsMut<[usize]> bounds to Dimension trait

### DIFF
--- a/src/dimension/dim.rs
+++ b/src/dimension/dim.rs
@@ -62,6 +62,26 @@ pub fn Dim<T>(index: T) -> T::Dim
     index.into_dimension()
 }
 
+impl<I: ?Sized> AsRef<[usize]> for Dim<I>
+where
+    I: AsRef<[usize]>,
+{
+    #[inline]
+    fn as_ref(&self) -> &[usize] {
+        self.index.as_ref()
+    }
+}
+
+impl<I: ?Sized> AsMut<[usize]> for Dim<I>
+where
+    I: AsMut<[usize]>,
+{
+    #[inline]
+    fn as_mut(&mut self) -> &mut [usize] {
+        self.index.as_mut()
+    }
+}
+
 impl<I: ?Sized> PartialEq<I> for Dim<I>
     where I: PartialEq,
 {

--- a/src/dimension/dimension_trait.rs
+++ b/src/dimension/dimension_trait.rs
@@ -32,6 +32,7 @@ use super::axes_of;
 ///
 /// **Note:** *This trait can not be implemented outside the crate*
 pub trait Dimension : Clone + Eq + Debug + Send + Sync + Default +
+    AsRef<[usize]> + AsMut<[usize]> +
     IndexMut<usize, Output=usize> +
     Add<Self, Output=Self> +
     AddAssign + for<'x> AddAssign<&'x Self> +

--- a/src/dimension/dimension_trait.rs
+++ b/src/dimension/dimension_trait.rs
@@ -90,10 +90,16 @@ pub trait Dimension : Clone + Eq + Debug + Send + Sync + Default +
     }
 
     #[doc(hidden)]
-    fn slice(&self) -> &[Ix];
+    #[inline]
+    fn slice(&self) -> &[Ix] {
+        self.as_ref()
+    }
 
     #[doc(hidden)]
-    fn slice_mut(&mut self) -> &mut [Ix];
+    #[inline]
+    fn slice_mut(&mut self) -> &mut [Ix] {
+        self.as_mut()
+    }
 
     /// Borrow as a read-only array view.
     fn as_array_view(&self) -> ArrayView1<Ix> {
@@ -363,10 +369,6 @@ impl Dimension for Dim<[Ix; 0]> {
     #[inline]
     fn ndim(&self) -> usize { 0 }
     #[inline]
-    fn slice(&self) -> &[Ix] { &[] }
-    #[inline]
-    fn slice_mut(&mut self) -> &mut [Ix] { &mut [] }
-    #[inline]
     fn _fastest_varying_stride_order(&self) -> Self { Ix0() }
     #[inline]
     fn into_pattern(self) -> Self::Pattern { }
@@ -398,10 +400,6 @@ impl Dimension for Dim<[Ix; 1]> {
     type Larger = Ix2;
     #[inline]
     fn ndim(&self) -> usize { 1 }
-    #[inline]
-    fn slice(&self) -> &[Ix] { self.ix() }
-    #[inline]
-    fn slice_mut(&mut self) -> &mut [Ix] { self.ixm() }
     #[inline]
     fn into_pattern(self) -> Self::Pattern {
         get!(&self, 0)
@@ -496,10 +494,6 @@ impl Dimension for Dim<[Ix; 2]> {
     fn into_pattern(self) -> Self::Pattern {
         self.ix().convert()
     }
-    #[inline]
-    fn slice(&self) -> &[Ix] { self.ix() }
-    #[inline]
-    fn slice_mut(&mut self) -> &mut [Ix] { self.ixm() }
     #[inline]
     fn zeros(ndim: usize) -> Self {
         assert_eq!(ndim, 2);
@@ -632,10 +626,6 @@ impl Dimension for Dim<[Ix; 3]> {
     fn into_pattern(self) -> Self::Pattern {
         self.ix().convert()
     }
-    #[inline]
-    fn slice(&self) -> &[Ix] { self.ix() }
-    #[inline]
-    fn slice_mut(&mut self) -> &mut [Ix] { self.ixm() }
 
     #[inline]
     fn size(&self) -> usize {
@@ -751,10 +741,6 @@ macro_rules! large_dim {
                 self.ix().convert()
             }
             #[inline]
-            fn slice(&self) -> &[Ix] { self.ix() }
-            #[inline]
-            fn slice_mut(&mut self) -> &mut [Ix] { self.ixm() }
-            #[inline]
             fn zeros(ndim: usize) -> Self {
                 assert_eq!(ndim, $n);
                 Self::default()
@@ -798,10 +784,6 @@ impl Dimension for IxDyn
     type Larger = Self;
     #[inline]
     fn ndim(&self) -> usize { self.ix().len() }
-    #[inline]
-    fn slice(&self) -> &[Ix] { self.ix() }
-    #[inline]
-    fn slice_mut(&mut self) -> &mut [Ix] { self.ixm() }
     #[inline]
     fn into_pattern(self) -> Self::Pattern {
         self

--- a/src/dimension/dynindeximpl.rs
+++ b/src/dimension/dynindeximpl.rs
@@ -198,6 +198,20 @@ impl<J> IndexMut<J> for IxDynImpl
     }
 }
 
+impl AsRef<[usize]> for IxDynImpl {
+    #[inline]
+    fn as_ref(&self) -> &[usize] {
+        self
+    }
+}
+
+impl AsMut<[usize]> for IxDynImpl {
+    #[inline]
+    fn as_mut(&mut self) -> &mut [usize] {
+        self
+    }
+}
+
 impl Deref for IxDynImpl {
     type Target = [Ix];
     #[inline]


### PR DESCRIPTION
This provides a simple, public way to convert a dimension to a slice. (Before, the only way visible in the docs to do this was `dim.as_array_view().as_slice()` or `dim.as_array_view_mut().as_slice_mut()`.)