### PR TITLE
implement partialord min/max

### DIFF
--- a/benches/numeric.rs
+++ b/benches/numeric.rs
@@ -6,6 +6,7 @@ use test::Bencher;
 
 extern crate ndarray;
 use ndarray::prelude::*;
+use ndarray::{Zip, FoldWhile};
 
 const N: usize = 1024;
 const X: usize = 64;
@@ -24,4 +25,53 @@ fn clip(bench: &mut Bencher)
             x
         })
     });
+}
+
+#[bench]
+fn max_early_return(bench: &mut Bencher)
+{
+    fn max(arr: &Array2<f64>) -> Option<&f64>
+    {
+        if let Some(mut max) = arr.first() {
+            if let Some(slc) = arr.as_slice_memory_order() {
+                for item in slc.iter().skip(1) {
+                    match max.partial_cmp(item) {
+                        None => return None,
+                        Some(::std::cmp::Ordering::Less) => max = item,
+                        _ => {},
+                    }
+                }
+                Some(max)
+            } else {
+                Zip::from(arr).fold_while(Some(max), |acc, x| 
+                match acc.partial_cmp(&Some(x)) {
+                    None => FoldWhile::Done(None),
+                    Some(::std::cmp::Ordering::Less) => FoldWhile::Continue(Some(x)),
+                    _ => FoldWhile::Continue(acc),
+                }).into_inner()
+            }
+        } else {
+            None
+        }
+    }  
+    let mut a = Array::linspace(0., 127., N * 2).into_shape([X, Y * 2]).unwrap();
+    bench.iter(|| max(&a));
+}
+
+#[bench]
+fn max_short(bench: &mut Bencher) {
+    fn max(arr: &Array2<f64>) -> Option<&f64> {
+        if let Some(first) = arr.first() {
+            let max = arr.fold(first, |acc, x| if x>acc {x} else {acc});
+            if max == max {
+                Some(max)
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+    }
+    let mut a = Array::linspace(0., 127., N * 2).into_shape([X, Y * 2]).unwrap();
+    bench.iter(|| max(&a));
 }

--- a/src/numeric/impl_numeric.rs
+++ b/src/numeric/impl_numeric.rs
@@ -46,6 +46,84 @@ impl<A, S, D> ArrayBase<S, D>
         sum
     }
 
+    /// Return a reference to a maximum of all values.
+    /// Return None if a comparison fails or if self is empty.
+    /// 
+    /// # Example
+    /// ```
+    /// use ndarray::arr2;
+    /// use std::f64;
+    /// 
+    /// let a = arr2(&[[1., 2.], [3., 4.]]);
+    /// 
+    /// assert_eq!(a.scalar_max(), Some(&4.));
+    /// 
+    /// let b = arr2(&[[1., f64::NAN], [3., 4.]]);
+    /// 
+    /// assert_eq!(b.scalar_max(), None);
+    /// ```
+    pub fn scalar_max(&self) -> Option<&A>
+    where A: PartialOrd
+    {
+        if let Some(slc) = self.as_slice_memory_order() {
+            let mut max = self.first();
+            for item in slc.iter().skip(1) {
+                match max.partial_cmp(&Some(item)) {
+                    None => return None,
+                    Some(::std::cmp::Ordering::Less) => max = Some(item),
+                    _ => {},
+                }
+            }
+            max
+        } else {
+            Zip::from(self).fold_while(self.first(), |acc, x| 
+            match acc.partial_cmp(&Some(x)) {
+                None => FoldWhile::Done(None),
+                Some(::std::cmp::Ordering::Less) => FoldWhile::Continue(Some(x)),
+                _ => FoldWhile::Continue(acc),
+            }).into_inner()
+        }
+    }  
+
+    /// Return a reference to a minimum of all values.
+    /// Return None if a comparison fails or if self is empty.
+    /// 
+    /// # Example
+    /// ```
+    /// use ndarray::arr2;
+    /// use std::f64;
+    /// 
+    /// let a = arr2(&[[1., 2.], [3., 4.]]);
+    /// 
+    /// assert_eq!(a.scalar_min(), Some(&1.));
+    /// 
+    /// let b = arr2(&[[1., f64::NAN], [3., 4.]]);
+    /// 
+    /// assert_eq!(b.scalar_min(), None);
+    /// ```
+    pub fn scalar_min(&self) -> Option<&A>
+    where A: PartialOrd
+    {
+        if let Some(slc) = self.as_slice_memory_order() {
+            let mut min = self.first();
+            for item in slc.iter().skip(1) {
+                match min.partial_cmp(&Some(item)) {
+                    None => return None,
+                    Some(::std::cmp::Ordering::Greater) => min = Some(item),
+                    _ => {},
+                }
+            }
+            min
+        } else {
+            Zip::from(self).fold_while(self.first(), |acc, x| 
+            match acc.partial_cmp(&Some(x)) {
+                None => FoldWhile::Done(None),
+                Some(::std::cmp::Ordering::Greater) => FoldWhile::Continue(Some(x)),
+                _ => FoldWhile::Continue(acc),
+            }).into_inner()
+        }
+    }  
+
     /// Return sum along `axis`.
     ///
     /// ```


### PR DESCRIPTION
Implements #512 , but for `PartialOrd`. Unorderable cases such as `f64::NAN` result in an early return of `None`. Ideally there is also a variant that ignores unorderable cases, something like `scalar_max_ignore_unorderable()`, but with a more sensible name.