### PR TITLE
 Adjust constraints on ddof for var_axis and std_axis

### DIFF
--- a/src/numeric/impl_numeric.rs
+++ b/src/numeric/impl_numeric.rs
@@ -164,7 +164,7 @@ impl<A, S, D> ArrayBase<S, D>
     /// ```
     ///
     /// **Panics** if `ddof` is greater than or equal to the length of the
-    /// axis, if `axis` is out of bounds, or if the length of the axis is zero.
+    /// axis or if `axis` is out of bounds.
     ///
     /// # Example
     ///
@@ -228,7 +228,7 @@ impl<A, S, D> ArrayBase<S, D>
     /// ```
     ///
     /// **Panics** if `ddof` is greater than or equal to the length of the
-    /// axis, if `axis` is out of bounds, or if the length of the axis is zero.
+    /// axis or if `axis` is out of bounds.
     ///
     /// # Example
     ///

--- a/src/numeric/impl_numeric.rs
+++ b/src/numeric/impl_numeric.rs
@@ -7,7 +7,7 @@
 // except according to those terms.
 
 use std::ops::{Add, Div, Mul};
-use libnum::{self, One, Zero, Float};
+use libnum::{self, One, Zero, Float, FromPrimitive};
 use itertools::free::enumerate;
 
 use imp_prelude::*;
@@ -163,8 +163,11 @@ impl<A, S, D> ArrayBase<S, D>
     ///     n  i=1
     /// ```
     ///
-    /// **Panics** if `ddof` is less than zero or greater than the length of
-    /// the axis or if `axis` is out of bounds.
+    /// and `n` is the length of the axis.
+    ///
+    /// **Panics** if `ddof` is less than zero or greater than `n`, if `axis`
+    /// is out of bounds, or if `A::from_usize()` fails for any any of the
+    /// numbers in the range `0..=n`.
     ///
     /// # Example
     ///
@@ -179,26 +182,27 @@ impl<A, S, D> ArrayBase<S, D>
     /// ```
     pub fn var_axis(&self, axis: Axis, ddof: A) -> Array<A, D::Smaller>
     where
-        A: Float,
+        A: Float + FromPrimitive,
         D: RemoveAxis,
     {
-        let mut count = A::zero();
+        let zero = A::from_usize(0).expect("Converting 0 to `A` must not fail.");
+        let n = A::from_usize(self.len_of(axis)).expect("Converting length to `A` must not fail.");
+        assert!(
+            !(ddof < zero || ddof > n),
+            "`ddof` must not be less than zero or greater than the length of \
+             the axis",
+        );
+        let dof = n - ddof;
         let mut mean = Array::<A, _>::zeros(self.dim.remove_axis(axis));
         let mut sum_sq = Array::<A, _>::zeros(self.dim.remove_axis(axis));
-        for subview in self.axis_iter(axis) {
-            count = count + A::one();
+        for (i, subview) in self.axis_iter(axis).enumerate() {
+            let count = A::from_usize(i + 1).expect("Converting index to `A` must not fail.");
             azip!(mut mean, mut sum_sq, x (subview) in {
                 let delta = x - *mean;
                 *mean = *mean + delta / count;
                 *sum_sq = (x - *mean).mul_add(delta, *sum_sq);
             });
         }
-        assert!(
-            !(ddof < A::zero() || ddof > count),
-            "`ddof` must not be less than zero or greater than the length of \
-             the axis",
-        );
-        let dof = count - ddof;
         sum_sq.mapv_into(|s| s / dof)
     }
 
@@ -227,8 +231,11 @@ impl<A, S, D> ArrayBase<S, D>
     ///     n  i=1
     /// ```
     ///
-    /// **Panics** if `ddof` is less than zero or greater than the length of
-    /// the axis or if `axis` is out of bounds.
+    /// and `n` is the length of the axis.
+    ///
+    /// **Panics** if `ddof` is less than zero or greater than `n`, if `axis`
+    /// is out of bounds, or if `A::from_usize()` fails for any any of the
+    /// numbers in the range `0..=n`.
     ///
     /// # Example
     ///
@@ -243,7 +250,7 @@ impl<A, S, D> ArrayBase<S, D>
     /// ```
     pub fn std_axis(&self, axis: Axis, ddof: A) -> Array<A, D::Smaller>
     where
-        A: Float,
+        A: Float + FromPrimitive,
         D: RemoveAxis,
     {
         self.var_axis(axis, ddof).mapv_into(|x| x.sqrt())

--- a/src/numeric/impl_numeric.rs
+++ b/src/numeric/impl_numeric.rs
@@ -163,8 +163,8 @@ impl<A, S, D> ArrayBase<S, D>
     ///     n  i=1
     /// ```
     ///
-    /// **Panics** if `ddof` is greater than or equal to the length of the
-    /// axis or if `axis` is out of bounds.
+    /// **Panics** if `ddof` is less than zero or greater than the length of
+    /// the axis or if `axis` is out of bounds.
     ///
     /// # Example
     ///
@@ -193,13 +193,13 @@ impl<A, S, D> ArrayBase<S, D>
                 *sum_sq = (x - *mean).mul_add(delta, *sum_sq);
             });
         }
-        if ddof >= count {
-            panic!("`ddof` needs to be strictly smaller than the length \
-                    of the axis you are computing the variance for!")
-        } else {
-            let dof = count - ddof;
-            sum_sq.mapv_into(|s| s / dof)
-        }
+        assert!(
+            !(ddof < A::zero() || ddof > count),
+            "`ddof` must not be less than zero or greater than the length of \
+             the axis",
+        );
+        let dof = count - ddof;
+        sum_sq.mapv_into(|s| s / dof)
     }
 
     /// Return standard deviation along `axis`.
@@ -227,8 +227,8 @@ impl<A, S, D> ArrayBase<S, D>
     ///     n  i=1
     /// ```
     ///
-    /// **Panics** if `ddof` is greater than or equal to the length of the
-    /// axis or if `axis` is out of bounds.
+    /// **Panics** if `ddof` is less than zero or greater than the length of
+    /// the axis or if `axis` is out of bounds.
     ///
     /// # Example
     ///

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -816,10 +816,9 @@ fn var_axis_bad_dof() {
 }
 
 #[test]
-#[should_panic]
 fn var_axis_empty_axis() {
     let a = array![[], []];
-    a.var_axis(Axis(1), 0.);
+    a.var_axis(Axis(1), -1.);
 }
 
 #[test]
@@ -830,10 +829,9 @@ fn std_axis_bad_dof() {
 }
 
 #[test]
-#[should_panic]
 fn std_axis_empty_axis() {
     let a = array![[], []];
-    a.std_axis(Axis(1), 0.);
+    a.std_axis(Axis(1), -1.);
 }
 
 #[test]

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -810,15 +810,32 @@ fn std_axis() {
 
 #[test]
 #[should_panic]
-fn var_axis_bad_dof() {
+fn var_axis_negative_ddof() {
+    let a = array![1., 2., 3.];
+    a.var_axis(Axis(0), -1.);
+}
+
+#[test]
+#[should_panic]
+fn var_axis_too_large_ddof() {
     let a = array![1., 2., 3.];
     a.var_axis(Axis(0), 4.);
 }
 
 #[test]
+fn var_axis_nan_ddof() {
+    let a = Array2::<f64>::zeros((2, 3));
+    let v = a.var_axis(Axis(1), ::std::f64::NAN);
+    assert_eq!(v.shape(), &[2]);
+    v.mapv(|x| assert!(x.is_nan()));
+}
+
+#[test]
 fn var_axis_empty_axis() {
-    let a = array![[], []];
-    a.var_axis(Axis(1), -1.);
+    let a = Array2::<f64>::zeros((2, 0));
+    let v = a.var_axis(Axis(1), 0.);
+    assert_eq!(v.shape(), &[2]);
+    v.mapv(|x| assert!(x.is_nan()));
 }
 
 #[test]
@@ -830,8 +847,10 @@ fn std_axis_bad_dof() {
 
 #[test]
 fn std_axis_empty_axis() {
-    let a = array![[], []];
-    a.std_axis(Axis(1), -1.);
+    let a = Array2::<f64>::zeros((2, 0));
+    let v = a.std_axis(Axis(1), 0.);
+    assert_eq!(v.shape(), &[2]);
+    v.mapv(|x| assert!(x.is_nan()));
 }
 
 #[test]


### PR DESCRIPTION
Requiring `ddof` to not be < 0 allows us to ignore weird edge cases. Allowing `ddof` to be equal to the length of the axis allows computation of the population variance (`ddof` = 0) for a zero-length axis and computation of the sample variance (`ddof` = 1) for an axis of length one. (The result in these cases is an array of NaNs.)

Note that this is a breaking change because of the new constraint that `ddof` must not be less than zero.