### PR TITLE
Bump to Rust 1.30, add macros to preludes, and switch macro_use to use

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: required
 dist: trusty
 matrix:
   include:
-    - rust: 1.27.0
+    - rust: 1.30.0
       env:
        - FEATURES='test docs'
     - rust: stable

--- a/benches/bench1.rs
+++ b/benches/bench1.rs
@@ -2,7 +2,6 @@
 #![allow(unused_imports)]
 
 extern crate test;
-#[macro_use(s, azip)]
 extern crate ndarray;
 
 use ndarray::{
@@ -13,7 +12,7 @@ use ndarray::{
     Array2,
     Zip,
 };
-use ndarray::{arr0, arr1, arr2};
+use ndarray::{arr0, arr1, arr2, azip, s};
 use ndarray::ShapeBuilder;
 
 use test::black_box;

--- a/benches/chunks.rs
+++ b/benches/chunks.rs
@@ -3,7 +3,6 @@
 extern crate test;
 use test::Bencher;
 
-#[macro_use(azip)]
 extern crate ndarray;
 use ndarray::prelude::*;
 use ndarray::NdProducer;

--- a/benches/construct.rs
+++ b/benches/construct.rs
@@ -3,7 +3,6 @@
 extern crate test;
 use test::Bencher;
 
-#[macro_use(s)]
 extern crate ndarray;
 use ndarray::prelude::*;
 

--- a/benches/higher-order.rs
+++ b/benches/higher-order.rs
@@ -5,7 +5,6 @@ extern crate test;
 use test::Bencher;
 use test::black_box;
 
-#[macro_use(s)]
 extern crate ndarray;
 use ndarray::prelude::*;
 

--- a/benches/iter.rs
+++ b/benches/iter.rs
@@ -6,7 +6,6 @@ use test::Bencher;
 use test::black_box;
 use rawpointer::PointerExt;
 
-#[macro_use(s, azip)]
 extern crate ndarray;
 use ndarray::prelude::*;
 use ndarray::{Zip, FoldWhile};

--- a/blas-tests/tests/oper.rs
+++ b/blas-tests/tests/oper.rs
@@ -1,5 +1,5 @@
 #[macro_use] extern crate defmac;
-#[macro_use(s)] extern crate ndarray;
+extern crate ndarray;
 extern crate num_traits;
 
 use ndarray::prelude::*;

--- a/blas-tests/tests/oper.rs
+++ b/blas-tests/tests/oper.rs
@@ -1,4 +1,4 @@
-#[macro_use] extern crate defmac;
+extern crate defmac;
 extern crate ndarray;
 extern crate num_traits;
 
@@ -9,6 +9,7 @@ use ndarray::linalg::general_mat_vec_mul;
 use ndarray::{Ix, Ixs, SliceInfo, SliceOrIndex};
 
 use std::fmt;
+use defmac::defmac;
 use num_traits::Float;
 
 fn assert_approx_eq<F: fmt::Debug + Float>(f: F, g: F, tol: F) -> bool {

--- a/examples/axis_ops.rs
+++ b/examples/axis_ops.rs
@@ -1,10 +1,6 @@
-
-#[macro_use(s)]
 extern crate ndarray;
 
-use ndarray::Array;
-use ndarray::Dimension;
-use ndarray::Axis;
+use ndarray::prelude::*;
 
 fn regularize<A, D>(a: &mut Array<A, D>) -> Result<(), ()>
     where D: Dimension,

--- a/examples/column_standardize.rs
+++ b/examples/column_standardize.rs
@@ -1,5 +1,3 @@
-
-#[macro_use]
 extern crate ndarray;
 
 use ndarray::prelude::*;

--- a/examples/convo.rs
+++ b/examples/convo.rs
@@ -1,5 +1,4 @@
 #![allow(unused)]
-#[macro_use(s)]
 extern crate ndarray;
 extern crate num_traits;
 

--- a/examples/life.rs
+++ b/examples/life.rs
@@ -1,4 +1,3 @@
-#[macro_use]
 extern crate ndarray;
 
 use ndarray::prelude::*;

--- a/examples/rollaxis.rs
+++ b/examples/rollaxis.rs
@@ -1,5 +1,3 @@
-
-#[macro_use]
 extern crate ndarray;
 
 use ndarray::prelude::*;

--- a/examples/zip_many.rs
+++ b/examples/zip_many.rs
@@ -1,5 +1,3 @@
-
-#[macro_use]
 extern crate ndarray;
 
 use ndarray::prelude::*;

--- a/numeric-tests/tests/accuracy.rs
+++ b/numeric-tests/tests/accuracy.rs
@@ -1,5 +1,3 @@
-
-#[macro_use(s)]
 extern crate ndarray;
 extern crate ndarray_rand;
 extern crate rand;

--- a/parallel/benches/rayon.rs
+++ b/parallel/benches/rayon.rs
@@ -7,7 +7,7 @@ use test::Bencher;
 
 extern crate rayon;
 extern crate ndarray;
-#[macro_use] extern crate ndarray_parallel;
+extern crate ndarray_parallel;
 use ndarray::prelude::*;
 use ndarray_parallel::prelude::*;
 

--- a/parallel/benches/rayon.rs
+++ b/parallel/benches/rayon.rs
@@ -6,7 +6,7 @@ extern crate test;
 use test::Bencher;
 
 extern crate rayon;
-#[macro_use] extern crate ndarray;
+extern crate ndarray;
 #[macro_use] extern crate ndarray_parallel;
 use ndarray::prelude::*;
 use ndarray_parallel::prelude::*;

--- a/parallel/src/lib.rs
+++ b/parallel/src/lib.rs
@@ -98,8 +98,10 @@
 pub extern crate ndarray;
 pub extern crate rayon;
 
-/// Into- traits for creating parallelized iterators.
+/// Into- traits for creating parallelized iterators and `par_azip` macro.
 pub mod prelude {
+    pub use par_azip;
+
     // happy and insane; ignorance is bluss
     pub use NdarrayIntoParallelIterator;
     pub use NdarrayIntoParallelRefIterator;

--- a/parallel/src/zipmacro.rs
+++ b/parallel/src/zipmacro.rs
@@ -31,10 +31,10 @@
 ///
 /// ```rust
 /// extern crate ndarray;
-/// #[macro_use(par_azip)]
 /// extern crate ndarray_parallel;
 ///
 /// use ndarray::Array2;
+/// use ndarray_parallel::par_azip;
 ///
 /// type M = Array2<f32>;
 ///

--- a/parallel/tests/azip.rs
+++ b/parallel/tests/azip.rs
@@ -1,10 +1,10 @@
 
 extern crate ndarray;
-#[macro_use]
 extern crate ndarray_parallel;
 extern crate itertools;
 
 use ndarray::prelude::*;
+use ndarray_parallel::par_azip;
 use itertools::{enumerate};
 use std::sync::atomic::{AtomicUsize, Ordering};
 

--- a/parallel/tests/rayon.rs
+++ b/parallel/tests/rayon.rs
@@ -1,6 +1,6 @@
 
 extern crate rayon;
-#[macro_use(s)] extern crate ndarray;
+extern crate ndarray;
 extern crate ndarray_parallel;
 
 use ndarray::prelude::*;

--- a/serialization-tests/tests/serialize.rs
+++ b/serialization-tests/tests/serialize.rs
@@ -1,6 +1,6 @@
 extern crate rustc_serialize as serialize;
 
-#[macro_use] extern crate ndarray;
+extern crate ndarray;
 
 extern crate serde;
 
@@ -14,7 +14,7 @@ extern crate ron;
 use serialize::json;
 
 
-use ndarray::{arr0, arr1, arr2, RcArray, RcArray1, RcArray2, ArrayD, IxDyn};
+use ndarray::{arr0, arr1, arr2, s, RcArray, RcArray1, RcArray2, ArrayD, IxDyn};
 
 #[test]
 fn serial_many_dim()

--- a/src/dimension/dimension_trait.rs
+++ b/src/dimension/dimension_trait.rs
@@ -11,7 +11,7 @@ use std::fmt::Debug;
 use std::ops::{Index, IndexMut};
 use std::ops::{Add, Sub, Mul, AddAssign, SubAssign, MulAssign};
 
-use itertools::{enumerate, zip};
+use itertools::{enumerate, izip, zip};
 
 use {Ix, Ixs, Ix0, Ix1, Ix2, Ix3, Ix4, Ix5, Ix6, IxDyn, Dim, SliceOrIndex, IxDynImpl};
 use IntoDimension;

--- a/src/dimension/mod.rs
+++ b/src/dimension/mod.rs
@@ -429,6 +429,7 @@ mod test {
         can_index_slice, can_index_slice_not_custom, max_abs_offset_check_overflow, IntoDimension
     };
     use error::{from_kind, ErrorKind};
+    use quickcheck::quickcheck;
     use {Dimension, Ix0, Ix1, Ix2, Ix3, IxDyn};
 
     #[test]

--- a/src/dimension/mod.rs
+++ b/src/dimension/mod.rs
@@ -8,6 +8,7 @@
 
 use {Ix, Ixs};
 use error::{from_kind, ErrorKind, ShapeError};
+use itertools::izip;
 
 pub use self::dim::*;
 pub use self::axis::Axis;

--- a/src/doc/ndarray_for_numpy_users/coord_transform.rs
+++ b/src/doc/ndarray_for_numpy_users/coord_transform.rs
@@ -49,7 +49,6 @@
 //! This is a direct translation to `ndarray`:
 //!
 //! ```
-//! #[macro_use]
 //! extern crate ndarray;
 //!
 //! use ndarray::prelude::*;
@@ -97,7 +96,6 @@
 //! this:
 //!
 //! ```
-//! #[macro_use]
 //! extern crate ndarray;
 //!
 //! use ndarray::prelude::*;

--- a/src/doc/ndarray_for_numpy_users/mod.rs
+++ b/src/doc/ndarray_for_numpy_users/mod.rs
@@ -163,7 +163,6 @@
 //! and `ndarray` like this:
 //!
 //! ```
-//! #[macro_use]
 //! extern crate ndarray;
 //!
 //! use ndarray::prelude::*;

--- a/src/doc/ndarray_for_numpy_users/rk_step.rs
+++ b/src/doc/ndarray_for_numpy_users/rk_step.rs
@@ -71,7 +71,6 @@
 //! A direct translation to `ndarray` looks like this:
 //!
 //! ```
-//! #[macro_use]
 //! extern crate ndarray;
 //!
 //! use ndarray::prelude::*;
@@ -130,7 +129,6 @@
 //!   some places, but that's not demonstrated in the example below.
 //!
 //! ```
-//! #[macro_use]
 //! extern crate ndarray;
 //!
 //! use ndarray::prelude::*;

--- a/src/doc/ndarray_for_numpy_users/simple_math.rs
+++ b/src/doc/ndarray_for_numpy_users/simple_math.rs
@@ -23,7 +23,6 @@
 //!
 //!
 //!
-//!
 //! a = np.full((5, 4), 3.)
 //!
 //!
@@ -52,7 +51,6 @@
 //! <td>
 //!
 //! ```
-//! #[macro_use]
 //! extern crate ndarray;
 //!
 //! use ndarray::prelude::*;

--- a/src/free_functions.rs
+++ b/src/free_functions.rs
@@ -16,8 +16,9 @@ use imp_prelude::*;
 /// three dimensions.
 ///
 /// ```
-/// #[macro_use(array)]
 /// extern crate ndarray;
+///
+/// use ndarray::array;
 ///
 /// fn main() {
 ///     let a1 = array![1, 2, 3, 4];
@@ -115,10 +116,9 @@ pub fn aview2<A, V: FixedInitializer<Elem=A>>(xs: &[V]) -> ArrayView2<A> {
 /// Create a one-dimensional read-write array view with elements borrowing `xs`.
 ///
 /// ```
-/// #[macro_use(s)]
 /// extern crate ndarray;
 ///
-/// use ndarray::aview_mut1;
+/// use ndarray::{aview_mut1, s};
 ///
 /// // Create an array view over some data, then slice it and modify it.
 /// fn main() {

--- a/src/impl_constructors.rs
+++ b/src/impl_constructors.rs
@@ -370,10 +370,9 @@ impl<S, A, D> ArrayBase<S, D>
     /// ### Examples
     ///
     /// ```
-    /// #[macro_use(s)]
     /// extern crate ndarray;
     ///
-    /// use ndarray::Array2;
+    /// use ndarray::{s, Array2};
     ///
     /// // Example Task: Let's create a column shifted copy of a in b
     ///

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -10,7 +10,7 @@ use std::cmp;
 use std::ptr as std_ptr;
 use std::slice;
 
-use itertools::zip;
+use itertools::{izip, zip};
 
 use imp_prelude::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,7 +99,7 @@ extern crate blas_src;
 
 extern crate matrixmultiply;
 
-#[macro_use(izip)] extern crate itertools;
+extern crate itertools;
 extern crate num_traits as libnum;
 extern crate num_complex;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@
 //!   + Efficient floating point matrix multiplication even for very large
 //!     matrices; can optionally use BLAS to improve it further.
 //!   + See also the [`ndarray-parallel`] crate for integration with rayon.
-//! - **Requires Rust 1.27**
+//! - **Requires Rust 1.30**
 //!
 //! [`ndarray-parallel`]: https://docs.rs/ndarray-parallel
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,7 +104,6 @@ extern crate num_traits as libnum;
 extern crate num_complex;
 
 #[cfg(test)]
-#[macro_use(quickcheck)]
 extern crate quickcheck;
 
 #[cfg(feature = "docs")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -470,11 +470,9 @@ pub type Ixs = isize;
 /// [`.slice_collapse()`]: #method.slice_collapse
 ///
 /// ```
-/// // import the s![] macro
-/// #[macro_use(s)]
 /// extern crate ndarray;
 ///
-/// use ndarray::{arr2, arr3};
+/// use ndarray::{arr2, arr3, s};
 ///
 /// fn main() {
 ///
@@ -554,9 +552,9 @@ pub type Ixs = isize;
 /// [`.outer_iter_mut()`]: #method.outer_iter_mut
 ///
 /// ```
-/// #[macro_use(s)] extern crate ndarray;
+/// extern crate ndarray;
 ///
-/// use ndarray::{arr3, aview1, aview2, Axis};
+/// use ndarray::{arr3, aview1, aview2, s, Axis};
 ///
 /// # fn main() {
 ///

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -8,8 +8,8 @@
 
 //! ndarray prelude.
 //!
-//! This module contains the most used types, type aliases, traits and
-//! functions that you can import easily as a group.
+//! This module contains the most used types, type aliases, traits, functions,
+//! and macros that you can import easily as a group.
 //!
 //! ```
 //! extern crate ndarray;
@@ -54,6 +54,8 @@ pub use {
     aview0, aview1, aview2,
     aview_mut1,
 };
+
+pub use {array, azip, s};
 
 #[doc(no_inline)]
 pub use {

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -555,7 +555,7 @@ macro_rules! s(
                 #[allow(unsafe_code)]
                 unsafe {
                     $crate::SliceInfo::new_unchecked(
-                        [$($stack)* s!(@convert r, $s)],
+                        [$($stack)* $crate::s!(@convert r, $s)],
                         out_dim,
                     )
                 }
@@ -570,7 +570,7 @@ macro_rules! s(
                 #[allow(unsafe_code)]
                 unsafe {
                     $crate::SliceInfo::new_unchecked(
-                        [$($stack)* s!(@convert r)],
+                        [$($stack)* $crate::s!(@convert r)],
                         out_dim,
                     )
                 }
@@ -579,19 +579,19 @@ macro_rules! s(
     };
     // convert a..b;c into @convert(a..b, c), final item, trailing comma
     (@parse $dim:expr, [$($stack:tt)*] $r:expr;$s:expr ,) => {
-        s![@parse $dim, [$($stack)*] $r;$s]
+        $crate::s![@parse $dim, [$($stack)*] $r;$s]
     };
     // convert a..b into @convert(a..b), final item, trailing comma
     (@parse $dim:expr, [$($stack:tt)*] $r:expr ,) => {
-        s![@parse $dim, [$($stack)*] $r]
+        $crate::s![@parse $dim, [$($stack)*] $r]
     };
     // convert a..b;c into @convert(a..b, c)
     (@parse $dim:expr, [$($stack:tt)*] $r:expr;$s:expr, $($t:tt)*) => {
         match $r {
             r => {
-                s![@parse
+                $crate::s![@parse
                    $crate::SliceNextDim::next_dim(&r, $dim),
-                   [$($stack)* s!(@convert r, $s),]
+                   [$($stack)* $crate::s!(@convert r, $s),]
                    $($t)*
                 ]
             }
@@ -601,9 +601,9 @@ macro_rules! s(
     (@parse $dim:expr, [$($stack:tt)*] $r:expr, $($t:tt)*) => {
         match $r {
             r => {
-                s![@parse
+                $crate::s![@parse
                    $crate::SliceNextDim::next_dim(&r, $dim),
-                   [$($stack)* s!(@convert r),]
+                   [$($stack)* $crate::s!(@convert r),]
                    $($t)*
                 ]
             }
@@ -620,6 +620,6 @@ macro_rules! s(
     ($($t:tt)*) => {
         // The extra `*&` is a workaround for this compiler bug:
         // https://github.com/rust-lang/rust/issues/23014
-        &*&s![@parse ::std::marker::PhantomData::<$crate::Ix0>, [] $($t)*]
+        &*&$crate::s![@parse ::std::marker::PhantomData::<$crate::Ix0>, [] $($t)*]
     };
 );

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -500,10 +500,9 @@ impl_slicenextdim_larger!((), Slice);
 /// # Example
 ///
 /// ```
-/// #[macro_use]
 /// extern crate ndarray;
 ///
-/// use ndarray::{Array2, ArrayView2};
+/// use ndarray::{s, Array2, ArrayView2};
 ///
 /// fn laplacian(v: &ArrayView2<f32>) -> Array2<f32> {
 ///     -4. * &v.slice(s![1..-1, 1..-1])
@@ -533,7 +532,6 @@ impl_slicenextdim_larger!((), Slice);
 /// For example,
 ///
 /// ```
-/// # #[macro_use]
 /// # extern crate ndarray;
 /// #
 /// # use ndarray::prelude::*;

--- a/src/stacking.rs
+++ b/src/stacking.rs
@@ -80,10 +80,9 @@ pub fn stack<'a, A, D>(axis: Axis, arrays: &[ArrayView<'a, A, D>])
 /// ***Panics*** if the `stack` function would return an error.
 ///
 /// ```
-/// #[macro_use(stack)]
 /// extern crate ndarray;
 ///
-/// use ndarray::{arr2, Axis};
+/// use ndarray::{arr2, stack, Axis};
 ///
 /// # fn main() {
 ///

--- a/src/zip/zipmacro.rs
+++ b/src/zip/zipmacro.rs
@@ -49,10 +49,9 @@
 /// ## Examples
 ///
 /// ```rust
-/// #[macro_use(azip)]
 /// extern crate ndarray;
 ///
-/// use ndarray::{Array1, Array2, Axis};
+/// use ndarray::{azip, Array1, Array2, Axis};
 ///
 /// type M = Array2<f32>;
 ///

--- a/src/zip/zipmacro.rs
+++ b/src/zip/zipmacro.rs
@@ -117,11 +117,11 @@
 macro_rules! azip {
     // Build Zip Rule (index)
     (@parse [index => $a:expr, $($aa:expr,)*] $t1:tt in $t2:tt) => {
-        azip!(@finish ($crate::Zip::indexed($a)) [$($aa,)*] $t1 in $t2)
+        $crate::azip!(@finish ($crate::Zip::indexed($a)) [$($aa,)*] $t1 in $t2)
     };
     // Build Zip Rule (no index)
     (@parse [$a:expr, $($aa:expr,)*] $t1:tt in $t2:tt) => {
-        azip!(@finish ($crate::Zip::from($a)) [$($aa,)*] $t1 in $t2)
+        $crate::azip!(@finish ($crate::Zip::from($a)) [$($aa,)*] $t1 in $t2)
     };
     // Build Finish Rule (both)
     (@finish ($z:expr) [$($aa:expr,)*] [$($p:pat,)+] in { $($t:tt)*}) => {
@@ -137,32 +137,32 @@ macro_rules! azip {
     // parsing stack: [expressions] [patterns] (one per operand)
     // index uses empty [] -- must be first
     (@parse [] [] index $i:pat, $($t:tt)*) => {
-        azip!(@parse [index =>] [$i,] $($t)*);
+        $crate::azip!(@parse [index =>] [$i,] $($t)*);
     };
     (@parse [$($exprs:tt)*] [$($pats:tt)*] mut $x:ident ($e:expr) $($t:tt)*) => {
-        azip!(@parse [$($exprs)* $e,] [$($pats)* mut $x,] $($t)*);
+        $crate::azip!(@parse [$($exprs)* $e,] [$($pats)* mut $x,] $($t)*);
     };
     (@parse [$($exprs:tt)*] [$($pats:tt)*] mut $x:ident $($t:tt)*) => {
-        azip!(@parse [$($exprs)* &mut $x,] [$($pats)* mut $x,] $($t)*);
+        $crate::azip!(@parse [$($exprs)* &mut $x,] [$($pats)* mut $x,] $($t)*);
     };
     (@parse [$($exprs:tt)*] [$($pats:tt)*] , $($t:tt)*) => {
-        azip!(@parse [$($exprs)*] [$($pats)*] $($t)*);
+        $crate::azip!(@parse [$($exprs)*] [$($pats)*] $($t)*);
     };
     (@parse [$($exprs:tt)*] [$($pats:tt)*] ref $x:ident ($e:expr) $($t:tt)*) => {
-        azip!(@parse [$($exprs)* $e,] [$($pats)* $x,] $($t)*);
+        $crate::azip!(@parse [$($exprs)* $e,] [$($pats)* $x,] $($t)*);
     };
     (@parse [$($exprs:tt)*] [$($pats:tt)*] ref $x:ident $($t:tt)*) => {
-        azip!(@parse [$($exprs)* &$x,] [$($pats)* $x,] $($t)*);
+        $crate::azip!(@parse [$($exprs)* &$x,] [$($pats)* $x,] $($t)*);
     };
     (@parse [$($exprs:tt)*] [$($pats:tt)*] $x:ident ($e:expr) $($t:tt)*) => {
-        azip!(@parse [$($exprs)* $e,] [$($pats)* &$x,] $($t)*);
+        $crate::azip!(@parse [$($exprs)* $e,] [$($pats)* &$x,] $($t)*);
     };
     (@parse [$($exprs:tt)*] [$($pats:tt)*] $x:ident $($t:tt)*) => {
-        azip!(@parse [$($exprs)* &$x,] [$($pats)* &$x,] $($t)*);
+        $crate::azip!(@parse [$($exprs)* &$x,] [$($pats)* &$x,] $($t)*);
     };
     (@parse [$($exprs:tt)*] [$($pats:tt)*] $($t:tt)*) => { };
     ($($t:tt)*) => {
-        azip!(@parse [] [] $($t)*);
+        $crate::azip!(@parse [] [] $($t)*);
     }
 }
 

--- a/tests/array-construct.rs
+++ b/tests/array-construct.rs
@@ -1,7 +1,7 @@
-#[macro_use]
 extern crate defmac;
 extern crate ndarray;
 
+use defmac::defmac;
 use ndarray::prelude::*;
 
 #[test]

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -1,7 +1,6 @@
 #![allow(non_snake_case)]
 
 extern crate ndarray;
-#[macro_use]
 extern crate defmac;
 extern crate itertools;
 
@@ -12,6 +11,7 @@ use ndarray::{
     arr3,
 };
 use ndarray::indices;
+use defmac::defmac;
 use itertools::{enumerate, zip};
 
 #[test]

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -1,6 +1,5 @@
 #![allow(non_snake_case)]
 
-#[macro_use]
 extern crate ndarray;
 #[macro_use]
 extern crate defmac;

--- a/tests/azip.rs
+++ b/tests/azip.rs
@@ -1,4 +1,3 @@
-#[macro_use]
 extern crate ndarray;
 extern crate itertools;
 

--- a/tests/dimension.rs
+++ b/tests/dimension.rs
@@ -1,6 +1,7 @@
 extern crate ndarray;
-#[macro_use]
 extern crate defmac;
+
+use defmac::defmac;
 
 use ndarray::{
     RcArray,

--- a/tests/iterator_chunks.rs
+++ b/tests/iterator_chunks.rs
@@ -1,5 +1,3 @@
-
-#[macro_use(array, s)]
 extern crate ndarray;
 
 use ndarray::prelude::*;

--- a/tests/iterators.rs
+++ b/tests/iterators.rs
@@ -1,19 +1,9 @@
-#[macro_use(s)]
 extern crate ndarray;
 extern crate itertools;
 
 use ndarray::prelude::*;
 use ndarray::Ix;
-use ndarray::{
-    Data,
-    Dimension,
-    aview1,
-    arr2,
-    arr3,
-    Axis,
-    indices,
-    Slice,
-};
+use ndarray::{arr2, arr3, aview1, indices, s, Axis, Data, Dimension, Slice};
 
 use itertools::assert_equal;
 use itertools::{rev, enumerate};

--- a/tests/oper.rs
+++ b/tests/oper.rs
@@ -1,5 +1,5 @@
 #[macro_use] extern crate defmac;
-#[macro_use(s)] extern crate ndarray;
+extern crate ndarray;
 extern crate num_traits;
 
 use ndarray::prelude::*;

--- a/tests/oper.rs
+++ b/tests/oper.rs
@@ -1,4 +1,4 @@
-#[macro_use] extern crate defmac;
+extern crate defmac;
 extern crate ndarray;
 extern crate num_traits;
 
@@ -11,6 +11,7 @@ use ndarray::{Ix, Ixs, SliceInfo, SliceOrIndex};
 
 use std::fmt;
 use std::ops::Neg;
+use defmac::defmac;
 use num_traits::Float;
 
 fn test_oper(op: &str, a: &[f32], b: &[f32], c: &[f32])

--- a/tests/s.rs
+++ b/tests/s.rs
@@ -1,8 +1,6 @@
-
-#[macro_use(s)]
 extern crate ndarray;
 
-use ndarray::Array;
+use ndarray::{s, Array};
 
 #[test]
 fn test_s()

--- a/tests/stacking.rs
+++ b/tests/stacking.rs
@@ -1,11 +1,10 @@
-
-#[macro_use(stack)]
 extern crate ndarray;
 
 
 use ndarray::{
     aview1,
     arr2,
+    stack,
     Axis,
     Array2,
     ErrorKind,

--- a/tests/windows.rs
+++ b/tests/windows.rs
@@ -1,5 +1,3 @@
-
-#[macro_use(s)]
 extern crate ndarray;
 extern crate itertools;
 


### PR DESCRIPTION
This PR adds the `array`, `azip`, `s`, and `par_azip` macros to their respective crates' preludes. Where possible, it also replaces `macro_use` with normal `use` statements.

This requires Rust 1.30.