### PR TITLE
Matrixmultiply 0.1.13 -> 0.1.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ itertools = { version = "0.7.0", default-features = false }
 cblas-sys = { version = "0.1.4", optional = true, default-features = false }
 blas-src = { version = "0.2.0", optional = true, default-features = false }
 
-matrixmultiply = { version = "0.1.13" }
+matrixmultiply = { version = "0.1.15" }
 # Use via the `serde-1` crate feature!
 serde = { version = "1.0", optional = true }
 


### PR DESCRIPTION
Upgrading `matrixmultiply` to use @jturner314's bugfix - https://github.com/bluss/matrixmultiply/pull/21