### PR TITLE
Add headings for more sections in ArrayBase docs

### DIFF
--- a/src/impl_1d.rs
+++ b/src/impl_1d.rs
@@ -10,6 +10,7 @@
 //! Methods for one-dimensional arrays.
 use imp_prelude::*;
 
+/// # Methods For 1-D Arrays
 impl<A, S> ArrayBase<S, Ix1>
     where S: Data<Elem=A>,
 {

--- a/src/impl_2d.rs
+++ b/src/impl_2d.rs
@@ -10,6 +10,7 @@
 //! Methods for two-dimensional arrays.
 use imp_prelude::*;
 
+/// # Methods For 2-D Arrays
 impl<A, S> ArrayBase<S, Ix2>
     where S: Data<Elem=A>,
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -240,7 +240,9 @@ pub type Ixs = isize;
 /// + [Conversions Between Array Types](#conversions-between-array-types)
 /// + [Constructor Methods for Owned Arrays](#constructor-methods-for-owned-arrays)
 /// + [Methods For All Array Types](#methods-for-all-array-types)
-///
+/// + [Methods For 1-D Arrays](#methods-for-1-d-arrays)
+/// + [Methods For 2-D Arrays](#methods-for-2-d-arrays)
+/// + [Numerical Methods for Arrays](#numerical-methods-for-arrays)
 ///
 /// ## `Array`
 ///

--- a/src/numeric/impl_numeric.rs
+++ b/src/numeric/impl_numeric.rs
@@ -15,7 +15,7 @@ use numeric_util;
 
 use {FoldWhile, Zip};
 
-/// Numerical methods for arrays.
+/// # Numerical Methods for Arrays
 impl<A, S, D> ArrayBase<S, D>
     where S: Data<Elem=A>,
           D: Dimension,


### PR DESCRIPTION
This more clearly separates the sections. By adding the headings to the Contents, this also makes the methods easier to discover.