### PR TITLE
Add from_slice methods for 1-D views

### DIFF
--- a/src/impl_views.rs
+++ b/src/impl_views.rs
@@ -25,6 +25,40 @@ use {
 
 use iter::{self, AxisIter, AxisIterMut};
 
+impl<'a, A> ArrayView<'a, A, Ix1> {
+    /// Creates a 1-D read-only array view borrowing its data from a slice.
+    ///
+    /// ```
+    /// use ndarray::{array, ArrayView1};
+    ///
+    /// let s = &[0, 1, 2, 3];
+    /// let a = ArrayView1::from_slice(s);
+    /// assert_eq!(a, array![0, 1, 2, 3].view());
+    /// ```
+    pub fn from_slice(slice: &'a [A]) -> Self {
+        unsafe { Self::new_(slice.as_ptr(), Ix1(slice.len()), Ix1(1)) }
+    }
+}
+
+impl<'a, A> ArrayViewMut<'a, A, Ix1> {
+    /// Creates a 1-D read-write array view borrowing its data from a slice.
+    ///
+    /// ```
+    /// use ndarray::{array, ArrayViewMut1};
+    ///
+    /// let s = &mut [0, 1, 2, 3];
+    /// {
+    ///     let mut a = ArrayViewMut1::from_slice(s);
+    ///     assert_eq!(a, array![0, 1, 2, 3].view_mut());
+    ///     a[1] = 5;
+    /// }
+    /// assert_eq!(s[1], 5);
+    /// ```
+    pub fn from_slice(slice: &'a mut [A]) -> Self {
+        unsafe { Self::new_(slice.as_mut_ptr(), Ix1(slice.len()), Ix1(1)) }
+    }
+}
+
 /// Methods for read-only array views.
 impl<'a, A, D> ArrayView<'a, A, D>
     where D: Dimension,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -865,7 +865,9 @@ pub type Ixs = isize;
 /// ------|--------|--------
 /// `Vec<A>` | `ArrayBase<S: DataOwned, Ix1>` | [`::from_vec()`](#method.from_vec)
 /// `Vec<A>` | `ArrayBase<S: DataOwned, D>` | [`::from_shape_vec()`](#method.from_shape_vec)
+/// `&[A]` | `ArrayView1<A>` | [`::from_slice()`](type.ArrayView.html#method.from_slice)
 /// `&[A]` | `ArrayView<A, D>` | [`::from_shape()`](type.ArrayView.html#method.from_shape)
+/// `&mut [A]` | `ArrayViewMut1<A>` | [`::from_slice()`](type.ArrayViewMut.html#method.from_slice)
 /// `&mut [A]` | `ArrayViewMut<A, D>` | [`::from_shape()`](type.ArrayViewMut.html#method.from_shape)
 /// `&ArrayBase<S, Ix1>` | `Vec<A>` | [`.to_vec()`](#method.to_vec)
 /// `&ArrayBase<S, D>` | `&[A]` | [`.as_slice()`](#method.as_slice)<sup>[1](#req_contig_std)</sup>, [`.as_slice_memory_order()`](#method.as_slice_memory_order)<sup>[2](#req_contig)</sup>


### PR DESCRIPTION
These are convenience methods so that you can write e.g. `ArrayView1::from_slice(s)` instead of `ArrayView1::from_shape(s.len(), s)`.