### PR TITLE
fold axis: Include panic on axis oob in doc

### DIFF
--- a/src/dimension/remove_axis.rs
+++ b/src/dimension/remove_axis.rs
@@ -19,7 +19,10 @@ pub trait RemoveAxis : Dimension {
 
 impl RemoveAxis for Dim<[Ix; 1]> {
     #[inline]
-    fn remove_axis(&self, _: Axis) -> Ix0 { Ix0() }
+    fn remove_axis(&self, axis: Axis) -> Ix0 {
+        debug_assert!(axis.index() < self.ndim());
+        Ix0()
+    }
 }
 
 impl RemoveAxis for Dim<[Ix; 2]> {
@@ -38,6 +41,7 @@ macro_rules! impl_remove_axis_array(
         {
             #[inline]
             fn remove_axis(&self, axis: Axis) -> Self::Smaller {
+                debug_assert!(axis.index() < self.ndim());
                 let mut tup = Dim([0; $n - 1]);
                 {
                     let mut it = tup.slice_mut().iter_mut();

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -1826,12 +1826,18 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
     /// function and initial value `init`.
     ///
     /// Return the result as an `Array`.
+    ///
+    /// **Panics** if `axis` is out of bounds.
     pub fn fold_axis<B, F>(&self, axis: Axis, init: B, mut fold: F)
         -> Array<B, D::Smaller>
         where D: RemoveAxis,
               F: FnMut(&B, &A) -> B,
               B: Clone,
     {
+        if axis.index() >= self.ndim() {
+            panic!("ndarray: axis {} out of bounds in array of dim {} in fold_axis",
+                   axis.index(), self.ndim());
+        }
         let mut res = Array::from_elem(self.raw_dim().remove_axis(axis), init);
         for subview in self.axis_iter(axis) {
             res.zip_mut_with(&subview, |x, y| *x = fold(x, y));

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -1834,10 +1834,6 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
               F: FnMut(&B, &A) -> B,
               B: Clone,
     {
-        if axis.index() >= self.ndim() {
-            panic!("ndarray: axis {} out of bounds in array of dim {} in fold_axis",
-                   axis.index(), self.ndim());
-        }
         let mut res = Array::from_elem(self.raw_dim().remove_axis(axis), init);
         for subview in self.axis_iter(axis) {
             res.zip_mut_with(&subview, |x, y| *x = fold(x, y));

--- a/tests/higher_order_f.rs
+++ b/tests/higher_order_f.rs
@@ -1,0 +1,11 @@
+
+extern crate ndarray;
+
+use ndarray::prelude::*;
+
+#[test]
+#[should_panic]
+fn test_fold_axis_oob() {
+    let a = arr2(&[[1., 2.], [3., 4.]]);
+    a.fold_axis(Axis(2), 0., |x, y| x + y);
+}


### PR DESCRIPTION
We didn't properly check the axis parameter to this method, now we panic if the axis is out of bounds (before we had partial coverage of debug assertions).

Added new test file for higher order functions like fold_axis, since the existing `tests/array.rs` is very large.

I am adamant to remove and reduce overhead for panic checks and formatting of panic messages. Maybe that's something to look at a different time, for example if the code size overhead can be minimized.