### PR TITLE
Implement Iterator::rfold where we can

### DIFF
--- a/benches/iter.rs
+++ b/benches/iter.rs
@@ -10,6 +10,7 @@ use rawpointer::PointerExt;
 extern crate ndarray;
 use ndarray::prelude::*;
 use ndarray::{Zip, FoldWhile};
+use ndarray::Slice;
 
 #[bench]
 fn iter_sum_2d_regular(bench: &mut Bencher)
@@ -342,3 +343,24 @@ fn indexed_iter_3d_dyn(bench: &mut Bencher) {
         }
     })
 }
+
+#[bench]
+fn iter_sum_1d_strided_fold(bench: &mut Bencher)
+{
+    let mut a = Array::<u64, _>::ones(10240);
+    a.slice_axis_inplace(Axis(0), Slice::new(0, None, 2));
+    bench.iter(|| {
+        a.iter().fold(0, |acc, &x| acc + x)
+    });
+}
+
+#[bench]
+fn iter_sum_1d_strided_rfold(bench: &mut Bencher)
+{
+    let mut a = Array::<u64, _>::ones(10240);
+    a.slice_axis_inplace(Axis(0), Slice::new(0, None, 2));
+    bench.iter(|| {
+        a.iter().rfold(0, |acc, &x| acc + x)
+    });
+}
+

--- a/tests/iterators.rs
+++ b/tests/iterators.rs
@@ -2,11 +2,9 @@
 extern crate ndarray;
 extern crate itertools;
 
-use ndarray::{Array0, Array2};
-use ndarray::RcArray;
+use ndarray::prelude::*;
 use ndarray::Ix;
 use ndarray::{
-    ArrayBase,
     Data,
     Dimension,
     aview1,
@@ -14,6 +12,7 @@ use ndarray::{
     arr3,
     Axis,
     indices,
+    Slice,
 };
 
 use itertools::assert_equal;
@@ -497,4 +496,45 @@ fn test_fold() {
     let mut a = Array0::<i32>::default(());
     a += 1;
     assert_eq!(a.iter().fold(0, |acc, &x| acc + x), 1);
+}
+
+#[test]
+fn test_rfold() {
+    {
+        let mut a = Array1::<i32>::default(256);
+        a += 1;
+        let mut iter = a.iter();
+        iter.next();
+        assert_eq!(iter.rfold(0, |acc, &x| acc + x), a.sum() - 1);
+    }
+
+    // Test strided arrays
+    {
+        let mut a = Array1::<i32>::default(256);
+        a.slice_axis_inplace(Axis(0), Slice::new(0, None, 2));
+        a += 1;
+        let mut iter = a.iter();
+        iter.next();
+        assert_eq!(iter.rfold(0, |acc, &x| acc + x), a.sum() - 1);
+    }
+
+    {
+        let mut a = Array1::<i32>::default(256);
+        a.slice_axis_inplace(Axis(0), Slice::new(0, None, -2));
+        a += 1;
+        let mut iter = a.iter();
+        iter.next();
+        assert_eq!(iter.rfold(0, |acc, &x| acc + x), a.sum() - 1);
+    }
+
+    // Test order
+    {
+        let mut a = Array1::from_iter(0..20);
+        a.slice_axis_inplace(Axis(0), Slice::new(0, None, 2));
+        let mut iter = a.iter();
+        iter.next();
+        let output = iter.rfold(Vec::new(),
+            |mut acc, elt| { acc.push(*elt); acc });
+        assert_eq!(Array1::from_vec(output), Array::from_iter((1..10).rev().map(|i| i * 2)));
+    }
 }


### PR DESCRIPTION
This is a new method since Rust 1.27.

Only our 1D iterators are double ended, so the code is relatively simple. We remember that this case is relevant for whenever the iterator does not use the contiguous in-order slice case.

The benchmarks show a small gain for the u64 example included in the PR, but no gain if the example is switched to floats. The compiler can unroll the loop now, so it can have positive effects on other operations than addition.