### PR TITLE
Fix .axis_chunks_iter/_mut() for zero stride and zero sized types

### DIFF
--- a/benches/iter.rs
+++ b/benches/iter.rs
@@ -364,3 +364,30 @@ fn iter_sum_1d_strided_rfold(bench: &mut Bencher)
     });
 }
 
+
+#[bench]
+fn iter_axis_iter_sum(bench: &mut Bencher)
+{
+    let a = Array::<f32, _>::zeros((64, 64));
+    bench.iter(|| {
+        a.axis_iter(Axis(0)).map(|plane| plane.sum()).sum::<f32>()
+    });
+}
+
+#[bench]
+fn iter_axis_chunks_1_iter_sum(bench: &mut Bencher)
+{
+    let a = Array::<f32, _>::zeros((64, 64));
+    bench.iter(|| {
+        a.axis_chunks_iter(Axis(0), 1).map(|plane| plane.sum()).sum::<f32>()
+    });
+}
+
+#[bench]
+fn iter_axis_chunks_5_iter_sum(bench: &mut Bencher)
+{
+    let a = Array::<f32, _>::zeros((64, 64));
+    bench.iter(|| {
+        a.axis_chunks_iter(Axis(0), 5).map(|plane| plane.sum()).sum::<f32>()
+    });
+}

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -98,6 +98,17 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
         }
     }
 
+    /// Return the stride of `axis`.
+    ///
+    /// The axis should be in the range `Axis(` 0 .. *n* `)` where *n* is the
+    /// number of dimensions (axes) of the array.
+    ///
+    /// ***Panics*** if the axis is out of bounds.
+    pub fn stride_of(&self, axis: Axis) -> isize {
+        // strides are reinterpreted as isize
+        self.strides[axis.index()] as isize
+    }
+
     /// Return a read-only view of the array
     pub fn view(&self) -> ArrayView<A, D> {
         debug_assert!(self.pointer_is_inbounds());

--- a/src/iterators/mod.rs
+++ b/src/iterators/mod.rs
@@ -1060,19 +1060,19 @@ clone_bounds!(
 fn chunk_iter_parts<A, D: Dimension>(v: ArrayView<A, D>, axis: Axis, size: usize)
     -> (AxisIterCore<A, D>, usize, D)
 {
-    let axis = axis.index();
-    let axis_len = v.shape()[axis];
+    let axis_len = v.len_of(axis);
     let size = if size > axis_len { axis_len } else { size };
-    let last_index = axis_len / size;
-    let rem = axis_len % size;
-    let iter_len = if rem == 0 { last_index } else { last_index + 1 };
-    let stride = v.strides()[axis] * size as isize;
+    let n_whole_chunks = axis_len / size;
+    let chunk_remainder = axis_len % size;
+    let iter_len = if chunk_remainder == 0 { n_whole_chunks } else { n_whole_chunks + 1 };
+    let stride = v.stride_of(axis) * size as isize;
 
+    let axis = axis.index();
     let mut inner_dim = v.dim.clone();
-    inner_dim.slice_mut()[axis] = size;
+    inner_dim[axis] = size;
 
     let mut last_dim = v.dim;
-    last_dim.slice_mut()[axis] = if rem == 0 { size } else { rem };
+    last_dim[axis] = if chunk_remainder == 0 { size } else { chunk_remainder };
 
     let iter = AxisIterCore {
         index: 0,

--- a/src/iterators/mod.rs
+++ b/src/iterators/mod.rs
@@ -1040,7 +1040,9 @@ impl<'a, A, D: Dimension> NdProducer for AxisIterMut<'a, A, D>
 /// See [`.axis_chunks_iter()`](../struct.ArrayBase.html#method.axis_chunks_iter) for more information.
 pub struct AxisChunksIter<'a, A: 'a, D> {
     iter: AxisIterCore<A, D>,
+    /// Starting length of the iterator (number of chunks)
     original_len: usize,
+    /// Dimension of the last (and possibly uneven) chunk
     last_dim: D,
     life: PhantomData<&'a A>,
 }
@@ -1057,6 +1059,12 @@ clone_bounds!(
     }
 );
 
+/// Computes the information necessary to construct an iterator over chunks
+/// along an axis, given a `view` of the array, the `axis` to iterate over, and
+/// the chunk `size`.
+///
+/// Returns an axis iterator with the correct stride to move between chunks,
+/// the number of chunks, and the shape of the last chunk.
 fn chunk_iter_parts<A, D: Dimension>(v: ArrayView<A, D>, axis: Axis, size: usize)
     -> (AxisIterCore<A, D>, usize, D)
 {

--- a/src/zip/mod.rs
+++ b/src/zip/mod.rs
@@ -314,7 +314,7 @@ impl<'a, A, D: Dimension> NdProducer for ArrayView<'a, A, D>
 
     #[doc(hidden)]
     fn stride_of(&self, axis: Axis) -> isize {
-        self.strides()[axis.index()]
+        self.stride_of(axis)
     }
 
     #[inline(always)]
@@ -365,7 +365,7 @@ impl<'a, A, D: Dimension> NdProducer for ArrayViewMut<'a, A, D> {
 
     #[doc(hidden)]
     fn stride_of(&self, axis: Axis) -> isize {
-        self.strides()[axis.index()]
+        self.stride_of(axis)
     }
 
     #[inline(always)]

--- a/tests/iterators.rs
+++ b/tests/iterators.rs
@@ -363,6 +363,31 @@ fn axis_chunks_iter_corner_cases() {
 }
 
 #[test]
+fn axis_chunks_iter_zero_stride() {
+
+    {
+        // stride 0 case
+        let b = Array::from_vec(vec![0f32; 0]).into_shape((5, 0, 3)).unwrap();
+        let shapes: Vec<_> = b.axis_chunks_iter(Axis(0), 2).map(|v| v.raw_dim()).collect();
+        assert_eq!(shapes, vec![Ix3(2, 0, 3), Ix3(2, 0, 3), Ix3(1, 0, 3)]);
+    }
+
+    {
+        // stride 0 case reverse
+        let b = Array::from_vec(vec![0f32; 0]).into_shape((5, 0, 3)).unwrap();
+        let shapes: Vec<_> = b.axis_chunks_iter(Axis(0), 2).rev().map(|v| v.raw_dim()).collect();
+        assert_eq!(shapes, vec![Ix3(1, 0, 3), Ix3(2, 0, 3), Ix3(2, 0, 3)]);
+    }
+
+    // From issue #542, ZST element
+    {
+        let a = Array::from_vec(vec![(); 3]);
+        let chunks: Vec<_> = a.axis_chunks_iter(Axis(0), 2).collect();
+        assert_eq!(chunks, vec![a.slice(s![0..2]), a.slice(s![2..])]);
+    }
+}
+
+#[test]
 fn axis_chunks_iter_mut() {
     let a = RcArray::from_iter(0..24);
     let mut a = a.reshape((2, 6, 2));


### PR DESCRIPTION
Two special cases were identified, first by @jturner314, that break the
logic that picks out the last and uneven chunk in axis_chunks_iter/_mut;
we can't rely on a specific pointer value to recognize this chunk, as
the cases in the new test show.

Instead use the indices and length stored in the iterator.

Also add a new public method `fn stride_of(&self, Axis) -> isize` which was first added to clean up the style of the axis chunks iter code.

Fixes #542