### PR TITLE
Update matrixmultiply dependency to 0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ itertools = { version = "0.7.0", default-features = false }
 cblas-sys = { version = "0.1.4", optional = true, default-features = false }
 blas-src = { version = "0.2.0", optional = true, default-features = false }
 
-matrixmultiply = { version = "0.1.15" }
+matrixmultiply = { version = "0.2.0" }
 # Use via the `serde-1` crate feature!
 serde = { version = "1.0", optional = true }
 


### PR DESCRIPTION
This brings better vectorization and much higher performance on x86-64
by default.

Requires Rust 1.28

Fixes #541 