### PR TITLE
Update ndarray to Rust 2018 edition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: required
 dist: trusty
 matrix:
   include:
-    - rust: 1.30.0
+    - rust: 1.31.0
       env:
        - FEATURES='test docs'
     - rust: stable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 
 name = "ndarray"
 version = "0.12.1"
+edition = "2018"
 authors = [
   "bluss",
   "Jim Turner"

--- a/src/aliases.rs
+++ b/src/aliases.rs
@@ -2,7 +2,7 @@
 //!
 
 #[allow(deprecated)]
-use ::{
+use crate::{
     Ix,
     Array,
     ArrayView,
@@ -10,7 +10,7 @@ use ::{
     RcArray,
     IxDynImpl,
 };
-use ::dimension::Dim;
+use crate::dimension::Dim;
 
 /// Create a zero-dimensional index
 #[allow(non_snake_case)]

--- a/src/arrayformat.rs
+++ b/src/arrayformat.rs
@@ -12,7 +12,7 @@ use super::{
     Dimension,
     NdProducer,
 };
-use dimension::IntoDimension;
+use crate::dimension::IntoDimension;
 
 fn format_array<A, S, D, F>(view: &ArrayBase<S, D>, f: &mut fmt::Formatter,
                             mut format: F)
@@ -33,7 +33,7 @@ fn format_array<A, S, D, F>(view: &ArrayBase<S, D>, f: &mut fmt::Formatter,
         Some(ix) => ix,
     };
     for _ in 0..ndim {
-        try!(write!(f, "["));
+        write!(f, "[")?;
     }
     let mut first = true;
     // Simply use the indexed iterator, and take the index wraparounds
@@ -52,15 +52,15 @@ fn format_array<A, S, D, F>(view: &ArrayBase<S, D>, f: &mut fmt::Formatter,
                 // # of ['s needed
                 let n = ndim - i - 1;
                 for _ in 0..n {
-                    try!(write!(f, "]"));
+                    write!(f, "]")?;
                 }
-                try!(write!(f, ","));
-                try!(write!(f, "\n"));
+                write!(f, ",")?;
+                write!(f, "\n")?;
                 for _ in 0..ndim - n {
-                    try!(write!(f, " "));
+                    write!(f, " ")?;
                 }
                 for _ in 0..n {
-                    try!(write!(f, "["));
+                    write!(f, "[")?;
                 }
                 first = true;
                 update_index = true;
@@ -68,17 +68,17 @@ fn format_array<A, S, D, F>(view: &ArrayBase<S, D>, f: &mut fmt::Formatter,
             }
         }
         if !first {
-            try!(write!(f, ", "));
+            write!(f, ", ")?;
         }
         first = false;
-        try!(format(elt, f));
+        format(elt, f)?;
 
         if update_index {
             last_index = index;
         }
     }
     for _ in 0..ndim {
-        try!(write!(f, "]"));
+        write!(f, "]")?;
     }
     Ok(())
 }

--- a/src/arraytraits.rs
+++ b/src/arraytraits.rs
@@ -15,17 +15,17 @@ use std::ops::{
     IndexMut,
 };
 
-use imp_prelude::*;
-use iter::{
+use crate::imp_prelude::*;
+use crate::iter::{
     Iter,
     IterMut,
 };
-use {
+use crate::{
     NdIndex,
 };
 
-use numeric_util;
-use {Zip, FoldWhile};
+use crate::numeric_util;
+use crate::{Zip, FoldWhile};
 
 #[cold]
 #[inline(never)]

--- a/src/data_traits.rs
+++ b/src/data_traits.rs
@@ -11,7 +11,7 @@
 use std::mem::{self, size_of};
 use std::sync::Arc;
 
-use {
+use crate::{
     ArrayBase,
     Dimension,
     RawViewRepr,
@@ -52,7 +52,7 @@ pub unsafe trait RawDataMut : RawData {
     /// If `Self` provides safe mutable access to array elements, then it
     /// **must** panic or ensure that the data is unique.
     #[doc(hidden)]
-    fn try_ensure_unique<D>(&mut ArrayBase<Self, D>)
+    fn try_ensure_unique<D>(_: &mut ArrayBase<Self, D>)
     where Self: Sized,
           D: Dimension;
 

--- a/src/dimension/axes.rs
+++ b/src/dimension/axes.rs
@@ -1,5 +1,5 @@
 
-use {Dimension, Axis, Ix, Ixs};
+use crate::{Dimension, Axis, Ix, Ixs};
 
 /// Create a new Axes iterator
 pub fn axes_of<'a, D>(d: &'a D, strides: &'a D) -> Axes<'a, D>

--- a/src/dimension/conversion.rs
+++ b/src/dimension/conversion.rs
@@ -9,9 +9,9 @@
 //! Tuple to array conversion, IntoDimension, and related things
 
 use std::ops::{Index, IndexMut};
-use libnum::Zero;
+use num_traits::Zero;
 
-use {Ix, Ix1, IxDyn, Dimension, Dim, IxDynImpl};
+use crate::{Ix, Ix1, IxDyn, Dimension, Dim, IxDynImpl};
 
 /// $m: macro callback
 /// $m is called with $arg and then the indices corresponding to the size argument

--- a/src/dimension/dim.rs
+++ b/src/dimension/dim.rs
@@ -12,7 +12,7 @@ use itertools::zip;
 
 use super::IntoDimension;
 use super::Dimension;
-use Ix;
+use crate::Ix;
 
 /// Dimension description.
 ///

--- a/src/dimension/dimension_trait.rs
+++ b/src/dimension/dimension_trait.rs
@@ -13,11 +13,11 @@ use std::ops::{Add, Sub, Mul, AddAssign, SubAssign, MulAssign};
 
 use itertools::{enumerate, izip, zip};
 
-use {Ix, Ixs, Ix0, Ix1, Ix2, Ix3, Ix4, Ix5, Ix6, IxDyn, Dim, SliceOrIndex, IxDynImpl};
-use IntoDimension;
-use RemoveAxis;
-use {ArrayView1, ArrayViewMut1};
-use Axis;
+use crate::{Ix, Ixs, Ix0, Ix1, Ix2, Ix3, Ix4, Ix5, Ix6, IxDyn, Dim, SliceOrIndex, IxDynImpl};
+use crate::IntoDimension;
+use crate::RemoveAxis;
+use crate::{ArrayView1, ArrayViewMut1};
+use crate::Axis;
 use super::{
     stride_offset,
     stride_offset_checked,

--- a/src/dimension/dynindeximpl.rs
+++ b/src/dimension/dynindeximpl.rs
@@ -5,7 +5,7 @@ use std::ops::{
     Deref,
     DerefMut,
 };
-use imp_prelude::*;
+use crate::imp_prelude::*;
 
 const CAP: usize = 4;
 
@@ -53,7 +53,7 @@ impl Default for IxDynRepr<Ix> {
 }
 
 
-use ::libnum::Zero;
+use num_traits::Zero;
 
 impl<T: Copy + Zero> IxDynRepr<T> {
     pub fn copy_from(x: &[T]) -> Self {

--- a/src/dimension/mod.rs
+++ b/src/dimension/mod.rs
@@ -6,8 +6,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use {Ix, Ixs, Slice, SliceOrIndex};
-use error::{from_kind, ErrorKind, ShapeError};
+use crate::{Ix, Ixs, Slice, SliceOrIndex};
+use crate::error::{from_kind, ErrorKind, ShapeError};
 use itertools::izip;
 use num_integer::div_floor;
 
@@ -621,11 +621,11 @@ mod test {
         max_abs_offset_check_overflow, slice_min_max, slices_intersect,
         solve_linear_diophantine_eq, IntoDimension
     };
-    use error::{from_kind, ErrorKind};
+    use crate::{Dim, Dimension, Ix0, Ix1, Ix2, Ix3, IxDyn};
+    use crate::error::{from_kind, ErrorKind};
+    use crate::slice::Slice;
     use num_integer::gcd;
     use quickcheck::{quickcheck, TestResult};
-    use slice::{Slice, SliceOrIndex};
-    use {Dim, Dimension, Ix0, Ix1, Ix2, Ix3, IxDyn};
 
     #[test]
     fn slice_indexing_uncommon_strides() {

--- a/src/dimension/ndindex.rs
+++ b/src/dimension/ndindex.rs
@@ -3,10 +3,7 @@ use std::fmt::Debug;
 
 use itertools::zip;
 
-use {Ix, Ix0, Ix1, Ix2, Ix3, Ix4, Ix5, Ix6, IxDyn, Dim, Dimension, IntoDimension};
-use {
-    IxDynImpl,
-};
+use crate::{Ix, Ix0, Ix1, Ix2, Ix3, Ix4, Ix5, Ix6, IxDyn, IxDynImpl, Dim, Dimension, IntoDimension};
 use super::{stride_offset, stride_offset_checked};
 
 /// Tuple or fixed size arrays that can be used to index an array.

--- a/src/dimension/remove_axis.rs
+++ b/src/dimension/remove_axis.rs
@@ -7,7 +7,7 @@
 // except according to those terms.
 
 
-use {Ix, Ix0, Ix1, Dimension, Dim, Axis};
+use crate::{Ix, Ix0, Ix1, Dimension, Dim, Axis};
 
 /// Array shape with a next smaller dimension.
 ///

--- a/src/free_functions.rs
+++ b/src/free_functions.rs
@@ -9,8 +9,8 @@
 use std::slice;
 use std::mem::{size_of, forget};
 
-use dimension;
-use imp_prelude::*;
+use crate::dimension;
+use crate::imp_prelude::*;
 
 /// Create an [**`Array`**](type.Array.html) with one, two or
 /// three dimensions.

--- a/src/impl_1d.rs
+++ b/src/impl_1d.rs
@@ -8,7 +8,7 @@
 
 
 //! Methods for one-dimensional arrays.
-use imp_prelude::*;
+use crate::imp_prelude::*;
 
 /// # Methods For 1-D Arrays
 impl<A, S> ArrayBase<S, Ix1>
@@ -23,7 +23,7 @@ impl<A, S> ArrayBase<S, Ix1>
         if let Some(slc) = self.as_slice() {
             slc.to_vec()
         } else {
-            ::iterators::to_vec(self.iter().map(|x| x.clone()))
+            crate::iterators::to_vec(self.iter().map(|x| x.clone()))
         }
     }
 }

--- a/src/impl_2d.rs
+++ b/src/impl_2d.rs
@@ -8,7 +8,7 @@
 
 
 //! Methods for two-dimensional arrays.
-use imp_prelude::*;
+use crate::imp_prelude::*;
 
 /// # Methods For 2-D Arrays
 impl<A, S> ArrayBase<S, Ix2>

--- a/src/impl_clone.rs
+++ b/src/impl_clone.rs
@@ -5,8 +5,8 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-use imp_prelude::*;
-use RawDataClone;
+use crate::imp_prelude::*;
+use crate::RawDataClone;
 
 impl<S: RawDataClone, D: Clone> Clone for ArrayBase<S, D> {
     fn clone(&self) -> ArrayBase<S, D> {

--- a/src/impl_constructors.rs
+++ b/src/impl_constructors.rs
@@ -10,18 +10,18 @@
 //!
 //!
 
-use libnum::{Zero, One, Float};
+use num_traits::{Zero, One, Float};
 use std::isize;
 use std::mem;
 
-use imp_prelude::*;
-use StrideShape;
-use dimension;
-use linspace;
-use error::{self, ShapeError};
-use indices;
-use indexes;
-use iterators::{to_vec, to_vec_mapped};
+use crate::imp_prelude::*;
+use crate::StrideShape;
+use crate::dimension;
+use crate::linspace;
+use crate::error::{self, ShapeError};
+use crate::indices;
+use crate::indexes;
+use crate::iterators::{to_vec, to_vec_mapped};
 
 /// # Constructor Methods for Owned Arrays
 ///

--- a/src/impl_dyn.rs
+++ b/src/impl_dyn.rs
@@ -7,7 +7,7 @@
 // except according to those terms.
 
 //! Methods for dynamic-dimensional arrays.
-use imp_prelude::*;
+use crate::imp_prelude::*;
 
 /// # Methods for Dynamic-Dimensional Arrays
 impl<A, S> ArrayBase<S, IxDyn>

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -12,22 +12,22 @@ use std::slice;
 
 use itertools::{izip, zip};
 
-use imp_prelude::*;
+use crate::imp_prelude::*;
 
-use arraytraits;
-use dimension;
-use error::{self, ShapeError, ErrorKind};
-use dimension::IntoDimension;
-use dimension::{abs_index, axes_of, Axes, do_slice, merge_axes, size_of_shape_checked, stride_offset};
-use zip::Zip;
+use crate::arraytraits;
+use crate::dimension;
+use crate::error::{self, ShapeError, ErrorKind};
+use crate::dimension::IntoDimension;
+use crate::dimension::{abs_index, axes_of, Axes, do_slice, merge_axes, size_of_shape_checked, stride_offset};
+use crate::zip::Zip;
 
-use {
+use crate::{
     NdIndex,
     Slice,
     SliceInfo,
     SliceOrIndex
 };
-use iter::{
+use crate::iter::{
     AxisChunksIter,
     AxisChunksIterMut,
     Iter,
@@ -42,7 +42,7 @@ use iter::{
     ExactChunksMut,
     Windows
 };
-use stacking::stack;
+use crate::stacking::stack;
 
 /// # Methods For All Array Types
 impl<A, S, D> ArrayBase<S, D>
@@ -1890,13 +1890,13 @@ where
               S: Data,
     {
         if let Some(slc) = self.as_slice_memory_order() {
-            let v = ::iterators::to_vec_mapped(slc.iter(), f);
+            let v = crate::iterators::to_vec_mapped(slc.iter(), f);
             unsafe {
                 ArrayBase::from_shape_vec_unchecked(
                     self.dim.clone().strides(self.strides.clone()), v)
             }
         } else {
-            let v = ::iterators::to_vec_mapped(self.iter(), f);
+            let v = crate::iterators::to_vec_mapped(self.iter(), f);
             unsafe {
                 ArrayBase::from_shape_vec_unchecked(self.dim.clone(), v)
             }
@@ -1918,13 +1918,13 @@ where
         if self.is_contiguous() {
             let strides = self.strides.clone();
             let slc = self.as_slice_memory_order_mut().unwrap();
-            let v = ::iterators::to_vec_mapped(slc.iter_mut(), f);
+            let v = crate::iterators::to_vec_mapped(slc.iter_mut(), f);
             unsafe {
                 ArrayBase::from_shape_vec_unchecked(
                     dim.strides(strides), v)
             }
         } else {
-            let v = ::iterators::to_vec_mapped(self.iter_mut(), f);
+            let v = crate::iterators::to_vec_mapped(self.iter_mut(), f);
             unsafe {
                 ArrayBase::from_shape_vec_unchecked(dim, v)
             }

--- a/src/impl_ops.rs
+++ b/src/impl_ops.rs
@@ -214,7 +214,7 @@ impl<'a, S, D> $trt<&'a ArrayBase<S, D>> for $scalar
 
 mod arithmetic_ops {
     use super::*;
-    use imp_prelude::*;
+    use crate::imp_prelude::*;
 
     use std::ops::*;
     use num_complex::Complex;
@@ -340,7 +340,7 @@ mod arithmetic_ops {
 
 mod assign_ops {
     use super::*;
-    use imp_prelude::*;
+    use crate::imp_prelude::*;
 
     macro_rules! impl_assign_op {
         ($trt:ident, $method:ident, $doc:expr) => {

--- a/src/impl_owned_array.rs
+++ b/src/impl_owned_array.rs
@@ -1,4 +1,4 @@
-use imp_prelude::*;
+use crate::imp_prelude::*;
 
 /// Methods specific to `Array0`.
 ///

--- a/src/impl_raw_views.rs
+++ b/src/impl_raw_views.rs
@@ -1,6 +1,6 @@
-use dimension::{self, stride_offset};
-use imp_prelude::*;
-use {is_aligned, StrideShape};
+use crate::dimension::{self, stride_offset};
+use crate::imp_prelude::*;
+use crate::{is_aligned, StrideShape};
 
 impl<A, D> RawArrayView<A, D>
 where

--- a/src/impl_views.rs
+++ b/src/impl_views.rs
@@ -8,13 +8,13 @@
 
 use std::slice;
 
-use imp_prelude::*;
-use dimension;
-use error::ShapeError;
-use arraytraits::array_out_of_bounds;
-use {is_aligned, NdIndex, StrideShape};
+use crate::imp_prelude::*;
+use crate::dimension;
+use crate::error::ShapeError;
+use crate::arraytraits::array_out_of_bounds;
+use crate::{is_aligned, NdIndex, StrideShape};
 
-use {
+use crate::{
     ElementsBase,
     ElementsBaseMut,
     Iter,
@@ -22,7 +22,7 @@ use {
     Baseiter,
 };
 
-use iter::{self, AxisIter, AxisIterMut};
+use crate::iter::{self, AxisIter, AxisIterMut};
 
 /// Methods for read-only array views.
 impl<'a, A, D> ArrayView<'a, A, D>

--- a/src/indexes.rs
+++ b/src/indexes.rs
@@ -5,13 +5,13 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-use {ArrayBase, Data};
+use crate::{ArrayBase, Data};
 use super::Dimension;
-use dimension::IntoDimension;
-use Axis;
-use Layout;
-use NdProducer;
-use zip::{Offset, Splittable};
+use crate::dimension::IntoDimension;
+use crate::Axis;
+use crate::Layout;
+use crate::NdProducer;
+use crate::zip::{Offset, Splittable};
 
 /// An iterator over the indexes of an array shape.
 ///

--- a/src/iterators/chunks.rs
+++ b/src/iterators/chunks.rs
@@ -1,9 +1,9 @@
 
-use imp_prelude::*;
-use IntoDimension;
-use {NdProducer, Layout};
-use ::ElementsBase;
-use ::ElementsBaseMut;
+use crate::imp_prelude::*;
+use crate::IntoDimension;
+use crate::{NdProducer, Layout};
+use crate::ElementsBase;
+use crate::ElementsBaseMut;
 
 impl_ndproducer! {
     ['a, A, D: Dimension]

--- a/src/iterators/iter.rs
+++ b/src/iterators/iter.rs
@@ -8,14 +8,14 @@
 //! See also [`NdProducer`](../trait.NdProducer.html).
 
 
-pub use dimension::{
+pub use crate::dimension::{
     Axes,
 };
-pub use indexes::{
+pub use crate::indexes::{
     Indices,
     IndicesIter,
 };
-pub use iterators::{
+pub use crate::iterators::{
     Iter,
     IterMut,
     IndexedIter,

--- a/src/iterators/lanes.rs
+++ b/src/iterators/lanes.rs
@@ -1,7 +1,7 @@
 use std::marker::PhantomData;
 
-use imp_prelude::*;
-use {NdProducer, Layout};
+use crate::imp_prelude::*;
+use crate::{NdProducer, Layout};
 use super::LanesIter;
 use super::LanesIterMut;
 

--- a/src/iterators/mod.rs
+++ b/src/iterators/mod.rs
@@ -16,7 +16,7 @@ pub mod iter;
 use std::marker::PhantomData;
 use std::ptr;
 
-use Ix1;
+use crate::Ix1;
 
 use super::{Dimension, Ix, Ixs};
 use super::{
@@ -942,8 +942,8 @@ impl<'a, A, D: Dimension> NdProducer for AxisIter<'a, A, D>
     type Stride = isize;
 
     #[doc(hidden)]
-    fn layout(&self) -> ::Layout {
-        ::Layout::one_dimensional()
+    fn layout(&self) -> crate::Layout {
+        crate::Layout::one_dimensional()
     }
     #[doc(hidden)]
     fn raw_dim(&self) -> Self::Dim {
@@ -989,8 +989,8 @@ impl<'a, A, D: Dimension> NdProducer for AxisIterMut<'a, A, D>
     type Stride = isize;
 
     #[doc(hidden)]
-    fn layout(&self) -> ::Layout {
-        ::Layout::one_dimensional()
+    fn layout(&self) -> crate::Layout {
+        crate::Layout::one_dimensional()
     }
     #[doc(hidden)]
     fn raw_dim(&self) -> Self::Dim {
@@ -1217,9 +1217,9 @@ send_sync_read_write!(ElementsBaseMut);
 pub unsafe trait TrustedIterator { }
 
 use std;
-use linspace::Linspace;
-use iter::IndicesIter;
-use indexes::IndicesIterF;
+use crate::linspace::Linspace;
+use crate::iter::IndicesIter;
+use crate::indexes::IndicesIterF;
 
 unsafe impl<F> TrustedIterator for Linspace<F> { }
 unsafe impl<'a, A, D> TrustedIterator for Iter<'a, A, D> { }

--- a/src/iterators/windows.rs
+++ b/src/iterators/windows.rs
@@ -1,9 +1,9 @@
 
-use imp_prelude::*;
+use crate::imp_prelude::*;
 use super::ElementsBase;
-use IntoDimension;
-use Layout;
-use NdProducer;
+use crate::IntoDimension;
+use crate::Layout;
+use crate::NdProducer;
 
 /// Window producer and iterable
 ///

--- a/src/layout/layoutfmt.rs
+++ b/src/layout/layoutfmt.rs
@@ -17,7 +17,7 @@ use std::fmt;
 
 impl fmt::Debug for Layout {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        try!(if self.0 == 0 {
+        if self.0 == 0 {
             write!(f, "Custom")
         } else {
             write!(f, "{}",
@@ -29,7 +29,7 @@ impl fmt::Debug for Layout {
                     f(&format_args!("0x{:x}", i))
                 }
             }))
-        });
+        }?;
         write!(f, " ({:#x})", self.0)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@
 //!     needs matching memory layout to be efficient (with some exceptions).
 //!   + Efficient floating point matrix multiplication even for very large
 //!     matrices; can optionally use BLAS to improve it further.
-//! - **Requires Rust 1.30**
+//! - **Requires Rust 1.31**
 //!
 //! ## Crate Feature Flags
 //!
@@ -98,7 +98,7 @@ extern crate blas_src;
 extern crate matrixmultiply;
 
 extern crate itertools;
-extern crate num_traits as libnum;
+extern crate num_traits;
 extern crate num_complex;
 extern crate num_integer;
 
@@ -111,7 +111,7 @@ pub mod doc;
 use std::marker::PhantomData;
 use std::sync::Arc;
 
-pub use dimension::{
+pub use crate::dimension::{
     Dimension,
     IntoDimension,
     RemoveAxis,
@@ -119,26 +119,26 @@ pub use dimension::{
     AxisDescription,
     slices_intersect,
 };
-pub use dimension::dim::*;
+pub use crate::dimension::dim::*;
 
-pub use dimension::NdIndex;
-pub use dimension::IxDynImpl;
-pub use indexes::{indices, indices_of};
-pub use error::{ShapeError, ErrorKind};
-pub use slice::{
+pub use crate::dimension::NdIndex;
+pub use crate::dimension::IxDynImpl;
+pub use crate::indexes::{indices, indices_of};
+pub use crate::error::{ShapeError, ErrorKind};
+pub use crate::slice::{
     deref_raw_view_mut_into_view_with_life, deref_raw_view_mut_into_view_mut_with_life,
     life_of_view_mut, Slice, SliceInfo, SliceNextDim, SliceOrIndex
 };
 
-use iterators::Baseiter;
-use iterators::{ElementsBase, ElementsBaseMut, Iter, IterMut, Lanes, LanesMut};
+use crate::iterators::Baseiter;
+use crate::iterators::{ElementsBase, ElementsBaseMut, Iter, IterMut, Lanes, LanesMut};
 
-pub use arraytraits::AsArray;
-pub use linalg_traits::{LinalgScalar, NdFloat};
-pub use stacking::stack;
+pub use crate::arraytraits::AsArray;
+pub use crate::linalg_traits::{LinalgScalar, NdFloat};
+pub use crate::stacking::stack;
 
-pub use shape_builder::{ ShapeBuilder};
-pub use impl_views::IndexLonger;
+pub use crate::shape_builder::{ ShapeBuilder};
+pub use crate::impl_views::IndexLonger;
 
 #[macro_use] mod macro_utils;
 #[macro_use] mod private;
@@ -149,10 +149,10 @@ mod array_serde;
 mod arrayformat;
 mod data_traits;
 
-pub use aliases::*;
+pub use crate::aliases::*;
 
 #[allow(deprecated)]
-pub use data_traits::{
+pub use crate::data_traits::{
     RawData,
     RawDataMut,
     RawDataClone,
@@ -164,8 +164,8 @@ pub use data_traits::{
 };
 
 mod free_functions;
-pub use free_functions::*;
-pub use iterators::iter;
+pub use crate::free_functions::*;
+pub use crate::iterators::iter;
 
 #[macro_use] mod slice;
 mod layout;
@@ -182,20 +182,20 @@ mod zip;
 
 mod dimension;
 
-pub use zip::{
+pub use crate::zip::{
     Zip,
     NdProducer,
     IntoNdProducer,
     FoldWhile,
 };
 
-pub use layout::Layout;
+pub use crate::layout::Layout;
 
 /// Implementation's prelude. Common types used everywhere.
 mod imp_prelude {
-    pub use prelude::*;
-    pub use ArcArray;
-    pub use {
+    pub use crate::prelude::*;
+    pub use crate::ArcArray;
+    pub use crate::{
         RemoveAxis,
         RawData,
         RawDataMut,
@@ -207,7 +207,7 @@ mod imp_prelude {
         ViewRepr,
         Ix, Ixs,
     };
-    pub use dimension::DimensionExt;
+    pub use crate::dimension::DimensionExt;
 }
 
 pub mod prelude;
@@ -1371,7 +1371,7 @@ mod numeric;
 pub mod linalg;
 
 mod impl_ops;
-pub use impl_ops::ScalarOperand;
+pub use crate::impl_ops::ScalarOperand;
 
 // Array view methods
 mod impl_views;

--- a/src/linalg/impl_linalg.rs
+++ b/src/linalg/impl_linalg.rs
@@ -6,10 +6,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use imp_prelude::*;
-use numeric_util;
+use crate::imp_prelude::*;
+use crate::numeric_util;
 
-use {
+use crate::{
     LinalgScalar,
     Zip,
 };

--- a/src/linalg_traits.rs
+++ b/src/linalg_traits.rs
@@ -5,7 +5,7 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-use libnum::{Zero, One, Float};
+use num_traits::{Zero, One, Float};
 use std::fmt;
 use std::ops::{Add, Sub, Mul, Div};
 use std::ops::{
@@ -15,7 +15,7 @@ use std::ops::{
     DivAssign,
     RemAssign,
 };
-use ScalarOperand;
+use crate::ScalarOperand;
 
 /// Elements that support linear algebra operations.
 ///

--- a/src/linspace.rs
+++ b/src/linspace.rs
@@ -5,7 +5,7 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-use libnum::Float;
+use num_traits::Float;
 
 /// An iterator of a sequence of evenly spaced floats.
 ///

--- a/src/numeric/impl_numeric.rs
+++ b/src/numeric/impl_numeric.rs
@@ -7,13 +7,13 @@
 // except according to those terms.
 
 use std::ops::{Add, Div, Mul};
-use libnum::{self, Zero, Float, FromPrimitive};
+use num_traits::{self, Zero, Float, FromPrimitive};
 use itertools::free::enumerate;
 
-use imp_prelude::*;
-use numeric_util;
+use crate::imp_prelude::*;
+use crate::numeric_util;
 
-use {FoldWhile, Zip};
+use crate::{FoldWhile, Zip};
 
 /// # Numerical Methods for Arrays
 impl<A, S, D> ArrayBase<S, D>
@@ -30,7 +30,7 @@ impl<A, S, D> ArrayBase<S, D>
     /// assert_eq!(a.sum(), 10.);
     /// ```
     pub fn sum(&self) -> A
-        where A: Clone + Add<Output=A> + libnum::Zero,
+        where A: Clone + Add<Output=A> + num_traits::Zero,
     {
         if let Some(slc) = self.as_slice_memory_order() {
             return numeric_util::unrolled_fold(slc, A::zero, A::add);
@@ -52,7 +52,7 @@ impl<A, S, D> ArrayBase<S, D>
     /// next version.*
     // #[deprecated(note="renamed to `sum`", since="0.13")]
     pub fn scalar_sum(&self) -> A
-        where A: Clone + Add<Output=A> + libnum::Zero,
+        where A: Clone + Add<Output=A> + num_traits::Zero,
     {
         self.sum()
     }
@@ -67,7 +67,7 @@ impl<A, S, D> ArrayBase<S, D>
     /// assert_eq!(a.product(), 24.);
     /// ```
     pub fn product(&self) -> A
-        where A: Clone + Mul<Output=A> + libnum::One,
+        where A: Clone + Mul<Output=A> + num_traits::One,
     {
         if let Some(slc) = self.as_slice_memory_order() {
             return numeric_util::unrolled_fold(slc, A::one, A::mul);

--- a/src/numeric_util.rs
+++ b/src/numeric_util.rs
@@ -7,7 +7,7 @@
 // except according to those terms.
 use std::cmp;
 
-use LinalgScalar;
+use crate::LinalgScalar;
 
 /// Fold over the manually unrolled `xs` with `f`
 pub fn unrolled_fold<A, I, F>(mut xs: &[A], init: I, f: F) -> A

--- a/src/parallel/impl_par_methods.rs
+++ b/src/parallel/impl_par_methods.rs
@@ -1,5 +1,5 @@
 
-use {
+use crate::{
     Dimension,
     NdProducer,
     Zip,
@@ -7,7 +7,7 @@ use {
     DataMut,
 };
 
-use parallel::prelude::*;
+use crate::parallel::prelude::*;
 
 
 /// # Parallel methods

--- a/src/parallel/into_impls.rs
+++ b/src/parallel/into_impls.rs
@@ -1,4 +1,4 @@
-use {Array, ArcArray, Dimension, ArrayView, ArrayViewMut};
+use crate::{Array, ArcArray, Dimension, ArrayView, ArrayViewMut};
 
 use super::prelude::IntoParallelIterator;
 use super::Parallel;

--- a/src/parallel/mod.rs
+++ b/src/parallel/mod.rs
@@ -114,7 +114,7 @@ pub mod prelude {
 }
 
 pub use self::par::Parallel;
-pub use par_azip;
+pub use crate::par_azip;
 
 mod par;
 mod impl_par_methods;

--- a/src/parallel/par.rs
+++ b/src/parallel/par.rs
@@ -10,10 +10,10 @@ use rayon::iter::plumbing::UnindexedProducer;
 use rayon::iter::plumbing::bridge_unindexed;
 use rayon::iter::plumbing::Folder;
 
-use iter::AxisIter;
-use iter::AxisIterMut;
-use {Dimension};
-use {ArrayView, ArrayViewMut};
+use crate::iter::AxisIter;
+use crate::iter::AxisIterMut;
+use crate::{Dimension};
+use crate::{ArrayView, ArrayViewMut};
 
 /// Parallel iterator wrapper.
 #[derive(Copy, Clone, Debug)]
@@ -192,7 +192,7 @@ par_iter_view_wrapper!(ArrayView, [Sync]);
 par_iter_view_wrapper!(ArrayViewMut, [Sync + Send]);
 
 
-use {Zip, NdProducer, FoldWhile};
+use crate::{Zip, NdProducer, FoldWhile};
 
 macro_rules! zip_impl {
     ($([$($p:ident)*],)+) => {

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -20,7 +20,7 @@
 
 #[doc(no_inline)]
 #[allow(deprecated)]
-pub use {
+pub use crate::{
     ArrayBase,
     Array,
     ArcArray,
@@ -32,42 +32,42 @@ pub use {
 };
 
 #[doc(no_inline)]
-pub use {
+pub use crate::{
     Axis,
     Dim,
     Dimension,
 };
 
 #[doc(no_inline)]
-pub use {Array0, Array1, Array2, Array3, Array4, Array5, Array6, ArrayD};
+pub use crate::{Array0, Array1, Array2, Array3, Array4, Array5, Array6, ArrayD};
 
 #[doc(no_inline)]
-pub use {ArrayView0, ArrayView1, ArrayView2, ArrayView3, ArrayView4, ArrayView5,
+pub use crate::{ArrayView0, ArrayView1, ArrayView2, ArrayView3, ArrayView4, ArrayView5,
 ArrayView6, ArrayViewD};
 
 #[doc(no_inline)]
-pub use {ArrayViewMut0, ArrayViewMut1, ArrayViewMut2, ArrayViewMut3,
+pub use crate::{ArrayViewMut0, ArrayViewMut1, ArrayViewMut2, ArrayViewMut3,
 ArrayViewMut4, ArrayViewMut5, ArrayViewMut6, ArrayViewMutD};
 
 #[doc(no_inline)]
-pub use {Ix0, Ix1, Ix2, Ix3, Ix4, Ix5, Ix6, IxDyn};
+pub use crate::{Ix0, Ix1, Ix2, Ix3, Ix4, Ix5, Ix6, IxDyn};
 
 #[doc(no_inline)]
-pub use {
+pub use crate::{
     arr0, arr1, arr2,
     aview0, aview1, aview2,
     aview_mut1,
 };
 
-pub use {array, azip, s};
+pub use crate::{array, azip, s};
 
 #[doc(no_inline)]
-pub use {
+pub use crate::{
     ShapeBuilder,
 };
 
 #[doc(no_inline)]
-pub use {
+pub use crate::{
     NdFloat,
     AsArray,
 };

--- a/src/private.rs
+++ b/src/private.rs
@@ -12,15 +12,15 @@ macro_rules! private_decl {
     () => {
         /// This trait is private to implement; this method exists to make it
         /// impossible to implement outside the crate.
-        fn __private__(&self) -> ::private::PrivateMarker;
+        fn __private__(&self) -> crate::private::PrivateMarker;
     }
 }
 
 macro_rules! private_impl {
     () => {
         #[doc(hidden)]
-        fn __private__(&self) -> ::private::PrivateMarker {
-            ::private::PrivateMarker
+        fn __private__(&self) -> crate::private::PrivateMarker {
+            crate::private::PrivateMarker
         }
     }
 }

--- a/src/shape_builder.rs
+++ b/src/shape_builder.rs
@@ -1,7 +1,7 @@
 
-use Dimension;
-use {Shape, StrideShape};
-use dimension::IntoDimension;
+use crate::Dimension;
+use crate::{Shape, StrideShape};
+use crate::dimension::IntoDimension;
 
 /// A trait for `Shape` and `D where D: Dimension` that allows
 /// customizing the memory layout (strides) of an array shape.

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -5,7 +5,7 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-use error::{ShapeError, ErrorKind};
+use crate::error::{ShapeError, ErrorKind};
 use std::ops::{Deref, Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive};
 use std::fmt;
 use std::marker::PhantomData;
@@ -417,7 +417,7 @@ where
 
 #[doc(hidden)]
 pub trait SliceNextDim<D1, D2> {
-    fn next_dim(&self, PhantomData<D1>) -> PhantomData<D2>;
+    fn next_dim(&self, _: PhantomData<D1>) -> PhantomData<D2>;
 }
 
 macro_rules! impl_slicenextdim_equal {

--- a/src/stacking.rs
+++ b/src/stacking.rs
@@ -6,8 +6,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use imp_prelude::*;
-use error::{ShapeError, ErrorKind, from_kind};
+use crate::imp_prelude::*;
+use crate::error::{ShapeError, ErrorKind, from_kind};
 
 /// Stack arrays along the given axis.
 ///
@@ -56,7 +56,7 @@ pub fn stack<'a, A, D>(axis: Axis, arrays: &[ArrayView<'a, A, D>])
     unsafe {
         v.set_len(size);
     }
-    let mut res = try!(Array::from_shape_vec(res_dim, v));
+    let mut res = Array::from_shape_vec(res_dim, v)?;
 
     {
         let mut assign_view = res.view_mut();

--- a/src/zip/mod.rs
+++ b/src/zip/mod.rs
@@ -9,14 +9,14 @@
 #[macro_use]
 mod zipmacro;
 
-use imp_prelude::*;
-use IntoDimension;
-use NdIndex;
-use Layout;
+use crate::imp_prelude::*;
+use crate::IntoDimension;
+use crate::NdIndex;
+use crate::Layout;
 
-use layout::{CORDER, FORDER};
-use layout::LayoutPriv;
-use indexes::{Indices, indices};
+use crate::layout::{CORDER, FORDER};
+use crate::layout::LayoutPriv;
+use crate::indexes::{Indices, indices};
 
 /// Return if the expression is a break value.
 macro_rules! fold_while {
@@ -79,7 +79,7 @@ impl<'a, A, D, E> Broadcast<E> for ArrayView<'a, A, D>
 }
 
 pub trait Splittable : Sized {
-    fn split_at(self, Axis, Ix) -> (Self, Self);
+    fn split_at(self, axis: Axis, index: Ix) -> (Self, Self);
 }
 
 impl<D> Splittable for D
@@ -166,7 +166,7 @@ pub trait NdProducer {
     #[doc(hidden)]
     fn as_ptr(&self) -> Self::Ptr;
     #[doc(hidden)]
-    unsafe fn as_ref(&self, Self::Ptr) -> Self::Item;
+    unsafe fn as_ref(&self, ptr: Self::Ptr) -> Self::Item;
     #[doc(hidden)]
     unsafe fn uget_ptr(&self, i: &Self::Dim) -> Self::Ptr;
     #[doc(hidden)]
@@ -199,7 +199,7 @@ trait ZippableTuple : Sized {
     type Dim: Dimension;
     type Stride: Copy;
     fn as_ptr(&self) -> Self::Ptr;
-    unsafe fn as_ref(&self, Self::Ptr) -> Self::Item;
+    unsafe fn as_ref(&self, ptr: Self::Ptr) -> Self::Item;
     unsafe fn uget_ptr(&self, i: &Self::Dim) -> Self::Ptr;
     fn stride_of(&self, index: usize) -> Self::Stride;
     fn contiguous_stride(&self) -> Self::Stride;

--- a/tests/par_azip.rs
+++ b/tests/par_azip.rs
@@ -1,6 +1,5 @@
 #![cfg(feature="rayon")]
 
-#[macro_use]
 extern crate ndarray;
 extern crate itertools;
 

--- a/tests/par_rayon.rs
+++ b/tests/par_rayon.rs
@@ -2,7 +2,6 @@
 
 extern crate rayon;
 
-#[macro_use]
 extern crate ndarray;
 extern crate itertools;
 


### PR DESCRIPTION
Most of the changes are adding a `crate` prefix to `use` statements and changing `try!` to `?`. I also renamed `libnum` to `num_traits` because `cargo fix` was wanting to add a `crate` prefix, e.g. `use crate::libnum::Whatever`, and I didn't see any reason for the `num-traits` crate to be renamed to `libnum` anyway.

This PR changes only the `ndarray` crate; it doesn't change the `ndarray-rand` crate.

Edit: Also note that I've just run `cargo fix --edition` and made some manual improvements. I haven't run `cargo fix --edition-idioms`, because according to the docs, `--edition-idioms` isn't ready yet.