### PR TITLE
Improve performance of .fold()

### DIFF
--- a/src/dimension/axes.rs
+++ b/src/dimension/axes.rs
@@ -75,6 +75,15 @@ impl<'a, D> Iterator for Axes<'a, D>
         }
     }
 
+    fn fold<B, F>(self, init: B, f: F) -> B
+    where
+        F: FnMut(B, AxisDescription) -> B,
+    {
+        (self.start..self.end)
+            .map(move |i| AxisDescription(Axis(i), self.dim[i], self.strides[i] as isize))
+            .fold(init, f)
+    }
+
     fn size_hint(&self) -> (usize, Option<usize>) {
         let len = self.end - self.start;
         (len, Some(len))


### PR DESCRIPTION
This PR does two things that improve the performance of `.fold()` for `ArrayBase`:

1. Specialize the process of finding the inner axis for 2-D arrays.
2. Implement `.fold()` for the `Axes` iterator. This is an improvement for arrays with more than 2 axes.

For the function below with a 320x320 input array, this PR improves the performance by ~50%.

```rust
const RADIUS: usize = 1;
const WINDOW_SIZE: usize = 2 * RADIUS + 1;

fn sum_sq_diff_windows(data: ArrayView2<f64>) -> Array2<f64> {
    let mut out = Array2::zeros((data.rows() - 2 * RADIUS, data.cols() - 2 * RADIUS));
    Zip::from(&mut out)
        .and(data.windows((WINDOW_SIZE, WINDOW_SIZE)))
        .apply(|out, window| {
            let center = window[(RADIUS, RADIUS)];
            *out = window.fold(0., |acc, x| acc + (x - center).powi(2));
        });
    out
}
```