### PR TITLE
Improve do_slice

### DIFF
--- a/src/dimension/mod.rs
+++ b/src/dimension/mod.rs
@@ -380,15 +380,18 @@ pub fn do_slice(dim: &mut usize, stride: &mut usize, slice: Slice) -> isize {
         offset += stride_offset(m - 1, *stride);
     }
 
-    let s_prim = s * step;
+    // Update dimension.
+    let abs_step = step.abs() as usize;
+    *dim = if abs_step == 1 {
+        m
+    } else {
+        let d = m / abs_step;
+        let r = m % abs_step;
+        d + if r > 0 { 1 } else { 0 }
+    };
 
-    let d = m / step.abs() as usize;
-    let r = m % step.abs() as usize;
-    let m_prim = d + if r > 0 { 1 } else { 0 };
-
-    // Update dimension and stride coordinate
-    *dim = m_prim;
-    *stride = s_prim as usize;
+    // Update stride.
+    *stride = (s * step) as usize;
 
     offset
 }

--- a/src/dimension/mod.rs
+++ b/src/dimension/mod.rs
@@ -390,8 +390,9 @@ pub fn do_slice(dim: &mut usize, stride: &mut usize, slice: Slice) -> isize {
         d + if r > 0 { 1 } else { 0 }
     };
 
-    // Update stride.
-    *stride = (s * step) as usize;
+    // Update stride. The additional check is necessary to avoid possible
+    // overflow in the multiplication.
+    *stride = if *dim <= 1 { 0 } else { (s * step) as usize };
 
     offset
 }


### PR DESCRIPTION
This PR does two things:

1. Avoid performing division when `step.abs() == 1`. This improves performance. (See #571.)
2. Prevent overflow when calculating the new stride. This is a bug fix, and I think it's necessary for soundness.