### PR TITLE
Pairwise summation

### DIFF
--- a/src/numeric/impl_numeric.rs
+++ b/src/numeric/impl_numeric.rs
@@ -33,14 +33,14 @@ impl<A, S, D> ArrayBase<S, D>
         where A: Clone + Add<Output=A> + num_traits::Zero,
     {
         if let Some(slc) = self.as_slice_memory_order() {
-            return numeric_util::unrolled_fold(slc, A::zero, A::add);
+            return numeric_util::pairwise_sum(&slc)
         }
         let mut sum = A::zero();
         for row in self.inner_rows() {
             if let Some(slc) = row.as_slice() {
-                sum = sum + numeric_util::unrolled_fold(slc, A::zero, A::add);
+                sum = sum + numeric_util::pairwise_sum(&slc);
             } else {
-                sum = sum + row.iter().fold(A::zero(), |acc, elt| acc + elt.clone());
+                sum = sum + numeric_util::iterator_pairwise_sum(row.iter());
             }
         }
         sum

--- a/src/numeric/impl_numeric.rs
+++ b/src/numeric/impl_numeric.rs
@@ -104,21 +104,21 @@ impl<A, S, D> ArrayBase<S, D>
               D: RemoveAxis,
     {
         let n = self.len_of(axis);
-        let mut res = Array::zeros(self.raw_dim().remove_axis(axis));
         let stride = self.strides()[axis.index()];
+        let mut res = Array::zeros(self.raw_dim().remove_axis(axis));
         if self.ndim() == 2 && stride == 1 {
             // contiguous along the axis we are summing
             let ax = axis.index();
             for (i, elt) in enumerate(&mut res) {
                 *elt = self.index_axis(Axis(1 - ax), i).sum();
             }
+            res
         } else {
-            for i in 0..n {
-                let view = self.index_axis(axis, i);
-                res = res + &view;
-            }
+            numeric_util::array_pairwise_sum(
+                (0..n).map(|i| self.index_axis(axis, i)),
+                || res.clone()
+            )
         }
-        res
     }
 
     /// Return mean along `axis`.

--- a/src/numeric_util.rs
+++ b/src/numeric_util.rs
@@ -15,7 +15,7 @@ where
     A: Clone + Add<Output=A> + Zero,
 {
     if v.len() <= 512 {
-        unimplemented!()
+        return unrolled_fold(v, A::zero, A::add);
     } else {
         unimplemented!()
     }

--- a/src/numeric_util.rs
+++ b/src/numeric_util.rs
@@ -24,6 +24,23 @@ where
     }
 }
 
+pub(crate) fn iterator_pairwise_sum<'a, I, A: 'a>(iter: I) -> A
+    where
+        I: Iterator<Item=&'a A>,
+        A: Clone + Add<Output=A> + Zero,
+{
+    let mut partial_sums = vec![];
+    let mut partial_sum = A::zero();
+    for (i, x) in iter.enumerate() {
+        partial_sum = partial_sum + x.clone();
+        if i % 512 == 511 {
+            partial_sums.push(partial_sum);
+            partial_sum = A::zero();
+        }
+    }
+    pairwise_sum(&partial_sums)
+}
+
 /// Fold over the manually unrolled `xs` with `f`
 pub fn unrolled_fold<A, I, F>(mut xs: &[A], init: I, f: F) -> A
     where A: Clone,

--- a/src/numeric_util.rs
+++ b/src/numeric_util.rs
@@ -14,7 +14,11 @@ pub(crate) fn pairwise_sum<A>(v: &[A]) -> A
 where
     A: Clone + Add<Output=A> + Zero,
 {
-    unimplemented!()
+    if v.len() <= 512 {
+        unimplemented!()
+    } else {
+        unimplemented!()
+    }
 }
 
 /// Fold over the manually unrolled `xs` with `f`

--- a/src/numeric_util.rs
+++ b/src/numeric_util.rs
@@ -59,14 +59,16 @@ pub(crate) fn array_pairwise_sum<I, A, S, D, F>(iter: I, zero: F) -> Array<A, D>
             partial_sum = zero();
         }
     }
-    if partial_sums.len() > 512 {
-        array_pairwise_sum(partial_sums.into_iter(), zero)
+
+    if partial_sums.len() <= 512 {
+        partial_sums
+            .iter()
+            .fold(
+                zero(),
+                |acc, elem| acc + elem
+            )
     } else {
-        let mut res = zero();
-        for x in partial_sums.iter() {
-            res = res + x;
-        }
-        res
+        array_pairwise_sum(partial_sums.into_iter(), zero)
     }
 }
 

--- a/src/numeric_util.rs
+++ b/src/numeric_util.rs
@@ -14,10 +14,13 @@ pub(crate) fn pairwise_sum<A>(v: &[A]) -> A
 where
     A: Clone + Add<Output=A> + Zero,
 {
-    if v.len() <= 512 {
+    let n = v.len();
+    if n <= 512 {
         return unrolled_fold(v, A::zero, A::add);
     } else {
-        unimplemented!()
+        let mid_index = n / 2;
+        let (v1, v2) = v.split_at(mid_index);
+        pairwise_sum(v1) + pairwise_sum(v2)
     }
 }
 

--- a/src/numeric_util.rs
+++ b/src/numeric_util.rs
@@ -11,8 +11,25 @@ use num_traits::{self, Zero};
 use super::{ArrayBase, Array, Data, Dimension};
 use crate::LinalgScalar;
 
+/// Size threshold to switch to naive summation in all implementations of pairwise summation.
 const NAIVE_SUM_THRESHOLD: usize = 512;
 
+/// An implementation of pairwise summation for a vector slice.
+///
+/// Pairwise summation compute the sum of a set of *n* numbers by splitting
+/// it recursively in two halves, summing their elements and then adding the respective
+/// sums.
+/// It switches to the naive sum algorithm once the size of the set to be summed
+/// is below a certain pre-defined threshold ([`threshold`]).
+///
+/// Pairwise summation is useful to reduce the accumulated round-off error
+/// when summing floating point numbers.
+/// Pairwise summation provides an asymptotic error bound of *O(eps log n)*, where
+/// *eps* is machine precision, compared to *O(eps n)* of the naive summation algorithm.
+/// For more details, see [`paper`].
+///
+/// [`paper`]: https://epubs.siam.org/doi/10.1137/0914050
+/// [`threshold`]: constant.NAIVE_SUM_THRESHOLD.html
 pub(crate) fn pairwise_sum<A>(v: &[A]) -> A
 where
     A: Clone + Add<Output=A> + Zero,
@@ -27,6 +44,11 @@ where
     }
 }
 
+/// An implementation of pairwise summation for an iterator.
+///
+/// See [`pairwise_sum`] for details on the algorithm.
+///
+/// [`pairwise_sum`]: fn.pairwise_sum.html
 pub(crate) fn iterator_pairwise_sum<'a, I, A: 'a>(iter: I) -> A
 where
     I: Iterator<Item=&'a A>,
@@ -44,6 +66,11 @@ where
     pairwise_sum(&partial_sums)
 }
 
+/// An implementation of pairwise summation for an iterator over *n*-dimensional arrays.
+///
+/// See [`pairwise_sum`] for details on the algorithm.
+///
+/// [`pairwise_sum`]: fn.pairwise_sum.html
 pub(crate) fn array_pairwise_sum<I, A, S, D, F>(iter: I, zero: F) -> Array<A, D>
 where
     I: Iterator<Item=ArrayBase<S, D>>,

--- a/src/numeric_util.rs
+++ b/src/numeric_util.rs
@@ -24,11 +24,12 @@ const NAIVE_SUM_THRESHOLD: usize = 512;
 ///
 /// Pairwise summation is useful to reduce the accumulated round-off error
 /// when summing floating point numbers.
-/// Pairwise summation provides an asymptotic error bound of *O(eps log n)*, where
-/// *eps* is machine precision, compared to *O(eps n)* of the naive summation algorithm.
-/// For more details, see [`paper`].
+/// Pairwise summation provides an asymptotic error bound of *O(ε* log *n)*, where
+/// *ε* is machine precision, compared to *O(εn)* of the naive summation algorithm.
+/// For more details, see [`paper`] or [`Wikipedia`].
 ///
 /// [`paper`]: https://epubs.siam.org/doi/10.1137/0914050
+/// [`Wikipedia`]: https://en.wikipedia.org/wiki/Pairwise_summation
 /// [`threshold`]: constant.NAIVE_SUM_THRESHOLD.html
 pub(crate) fn pairwise_sum<A>(v: &[A]) -> A
 where

--- a/src/numeric_util.rs
+++ b/src/numeric_util.rs
@@ -6,8 +6,16 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 use std::cmp;
-
+use std::ops::Add;
+use num_traits::{self, Zero};
 use crate::LinalgScalar;
+
+pub(crate) fn pairwise_sum<A>(v: &[A]) -> A
+where
+    A: Clone + Add<Output=A> + Zero,
+{
+    unimplemented!()
+}
 
 /// Fold over the manually unrolled `xs` with `f`
 pub fn unrolled_fold<A, I, F>(mut xs: &[A], init: I, f: F) -> A


### PR DESCRIPTION
##  Motivation 
The naive summation algorithm can cause significant loss in precision when summing several floating point numbers - [pairwise summation](https://en.wikipedia.org/wiki/Pairwise_summation) mitigates the issue without adding significant computational overhead. 

Ideally, this should only be used when dealing with floats, but unfortunately we can't specialize on the argument type. Mitigating precision loss in floating point sums, on the other hand, is of paramount importance for a lot of algorithms relying on it as a building block - given that the overhead is minimal, I'd argue that the precision benefit is sufficient to adopt it as standard summation method.

## Public API
Nothing changes.

## Technicalities
I haven't modified the overall structure in `sum` and `sum_axis`: I have just provided some helper functions that isolate the pairwise summation algorithm.

The function that sums slices leverages the available `unrolled_fold` to vectorise the sum once the vector length is below the size threhold.

The function that sums iterators falls back on the slices summation function as soon as the first pass is over, to recover vectorisation given that the array of partial sums is contiguous in memory (only relevant for array with more than 512^2 elements).

The function that sums an iterator of arrays is self-recursive.