### PR TITLE
Fix blas mat-vec multiplication on array with only 1 nontrivial dimension

### DIFF
--- a/blas-tests/tests/oper.rs
+++ b/blas-tests/tests/oper.rs
@@ -87,6 +87,14 @@ fn dot_product() {
     assert_eq!(a.dot(&b), dot as i32);
 }
 
+#[test]
+fn mat_vec_product_1d() {
+    let a = arr2(&[[1.], [2.]]);
+    let b = arr1(&[1., 2.]);
+    let ans = arr1(&[5.]);
+    assert_eq!(a.t().dot(&b), ans);
+}
+
 // test that we can dot product with a broadcast array
 #[test]
 fn dot_product_0() {

--- a/src/linalg/impl_linalg.rs
+++ b/src/linalg/impl_linalg.rs
@@ -588,8 +588,12 @@ pub fn general_mat_vec_mul<A, S1, S2, S3>(alpha: A,
                     {
                         let a_trans = CblasNoTrans;
                         let a_stride = match layout {
-                            CBLAS_LAYOUT::CblasRowMajor => a.strides()[0].max(k as isize) as blas_index,
-                            CBLAS_LAYOUT::CblasColMajor => a.strides()[1].max(m as isize) as blas_index,
+                            CBLAS_LAYOUT::CblasRowMajor => {
+                                a.strides()[0].max(k as isize) as blas_index
+                            }
+                            CBLAS_LAYOUT::CblasColMajor => {
+                                a.strides()[1].max(m as isize) as blas_index
+                            }
                         };
 
                         let x_stride = x.strides()[0] as blas_index;

--- a/src/linalg/impl_linalg.rs
+++ b/src/linalg/impl_linalg.rs
@@ -588,8 +588,8 @@ pub fn general_mat_vec_mul<A, S1, S2, S3>(alpha: A,
                     {
                         let a_trans = CblasNoTrans;
                         let a_stride = match layout {
-                            CBLAS_LAYOUT::CblasRowMajor => a.strides()[0] as blas_index,
-                            CBLAS_LAYOUT::CblasColMajor => a.strides()[1] as blas_index,
+                            CBLAS_LAYOUT::CblasRowMajor => a.strides()[0].max(k as isize) as blas_index,
+                            CBLAS_LAYOUT::CblasColMajor => a.strides()[1].max(m as isize) as blas_index,
                         };
 
                         let x_stride = x.strides()[0] as blas_index;


### PR DESCRIPTION
First attempt at fixing #584 