### PR TITLE
Allow ops on arrays with elems of different types

### DIFF
--- a/src/arraytraits.rs
+++ b/src/arraytraits.rs
@@ -81,11 +81,12 @@ impl<S, D, I> IndexMut<I> for ArrayBase<S, D>
 
 /// Return `true` if the array shapes and all elements of `self` and
 /// `rhs` are equal. Return `false` otherwise.
-impl<S, S2, D> PartialEq<ArrayBase<S2, D>> for ArrayBase<S, D>
-    where D: Dimension,
-          S: Data,
-          S2: Data<Elem = S::Elem>,
-          S::Elem: PartialEq
+impl<A, B, S, S2, D> PartialEq<ArrayBase<S2, D>> for ArrayBase<S, D>
+where
+    A: PartialEq<B>,
+    S: Data<Elem = A>,
+    S2: Data<Elem = B>,
+    D: Dimension,
 {
     fn eq(&self, rhs: &ArrayBase<S2, D>) -> bool {
         if self.shape() != rhs.shape() {

--- a/src/impl_ops.rs
+++ b/src/impl_ops.rs
@@ -60,12 +60,14 @@ macro_rules! impl_binary_op(
 /// If their shapes disagree, `rhs` is broadcast to the shape of `self`.
 ///
 /// **Panics** if broadcasting isn’t possible.
-impl<A, S, S2, D, E> $trt<ArrayBase<S2, E>> for ArrayBase<S, D>
-    where A: Clone + $trt<A, Output=A>,
-          S: DataOwned<Elem=A> + DataMut,
-          S2: Data<Elem=A>,
-          D: Dimension,
-          E: Dimension,
+impl<A, B, S, S2, D, E> $trt<ArrayBase<S2, E>> for ArrayBase<S, D>
+where
+    A: Clone + $trt<B, Output=A>,
+    B: Clone,
+    S: DataOwned<Elem=A> + DataMut,
+    S2: Data<Elem=B>,
+    D: Dimension,
+    E: Dimension,
 {
     type Output = ArrayBase<S, D>;
     fn $mth(self, rhs: ArrayBase<S2, E>) -> ArrayBase<S, D>
@@ -82,12 +84,14 @@ impl<A, S, S2, D, E> $trt<ArrayBase<S2, E>> for ArrayBase<S, D>
 /// If their shapes disagree, `rhs` is broadcast to the shape of `self`.
 ///
 /// **Panics** if broadcasting isn’t possible.
-impl<'a, A, S, S2, D, E> $trt<&'a ArrayBase<S2, E>> for ArrayBase<S, D>
-    where A: Clone + $trt<A, Output=A>,
-          S: DataOwned<Elem=A> + DataMut,
-          S2: Data<Elem=A>,
-          D: Dimension,
-          E: Dimension,
+impl<'a, A, B, S, S2, D, E> $trt<&'a ArrayBase<S2, E>> for ArrayBase<S, D>
+where
+    A: Clone + $trt<B, Output=A>,
+    B: Clone,
+    S: DataOwned<Elem=A> + DataMut,
+    S2: Data<Elem=B>,
+    D: Dimension,
+    E: Dimension,
 {
     type Output = ArrayBase<S, D>;
     fn $mth(mut self, rhs: &ArrayBase<S2, E>) -> ArrayBase<S, D>
@@ -107,12 +111,14 @@ impl<'a, A, S, S2, D, E> $trt<&'a ArrayBase<S2, E>> for ArrayBase<S, D>
 /// If their shapes disagree, `rhs` is broadcast to the shape of `self`.
 ///
 /// **Panics** if broadcasting isn’t possible.
-impl<'a, A, S, S2, D, E> $trt<&'a ArrayBase<S2, E>> for &'a ArrayBase<S, D>
-    where A: Clone + $trt<A, Output=A>,
-          S: Data<Elem=A>,
-          S2: Data<Elem=A>,
-          D: Dimension,
-          E: Dimension,
+impl<'a, A, B, S, S2, D, E> $trt<&'a ArrayBase<S2, E>> for &'a ArrayBase<S, D>
+where
+    A: Clone + $trt<B, Output=A>,
+    B: Clone,
+    S: Data<Elem=A>,
+    S2: Data<Elem=B>,
+    D: Dimension,
+    E: Dimension,
 {
     type Output = Array<A, D>;
     fn $mth(self, rhs: &'a ArrayBase<S2, E>) -> Array<A, D> {

--- a/src/numeric_util.rs
+++ b/src/numeric_util.rs
@@ -96,8 +96,9 @@ pub fn unrolled_dot<A>(xs: &[A], ys: &[A]) -> A
 /// Compute pairwise equality
 ///
 /// `xs` and `ys` must be the same length
-pub fn unrolled_eq<A>(xs: &[A], ys: &[A]) -> bool
-    where A: PartialEq
+pub fn unrolled_eq<A, B>(xs: &[A], ys: &[B]) -> bool
+where
+    A: PartialEq<B>,
 {
     debug_assert_eq!(xs.len(), ys.len());
     // eightfold unrolled for performance (this is not done by llvm automatically)

--- a/tests/iterators.rs
+++ b/tests/iterators.rs
@@ -131,7 +131,7 @@ fn inner_iter() {
 
 #[test]
 fn inner_iter_corner_cases() {
-    let a0 = ArcArray::zeros(());
+    let a0 = ArcArray::<i32, _>::zeros(());
     assert_equal(a0.genrows(), vec![aview1(&[0])]);
 
     let a2 = ArcArray::<i32, _>::zeros((0, 3));


### PR DESCRIPTION
This generalizes the right operand element type. The implementations of operations for `&'a ArrayBase<S, D>` are still unnecessarily restrictive in the `Output` element type, but the implementations are now more general than they were before this commit.

As far as I can tell, this change is backwards compatible except for possibly causing ambiguities in type inference that weren't present before.