### PR TITLE
Improve docs of .raw_dim(), .shape(), and .strides()

### DIFF
--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -102,18 +102,28 @@ where
 
     /// Return the shape of the array as a slice.
     ///
-    /// Note that you probably don't want to use this to create an
-    /// array of the same shape as another array because creating an
-    /// array with e.g. [`Array::zeros()`](ArrayBase::zeros) using a
-    /// shape of type `&[usize]` results in a dynamic-dimensional
-    /// array. For example, if `arr` is of type `Array<A, D>`, then
-    /// `Array::zeros(arr.shape())` returns an instance of type
-    /// `Array<B, IxDyn>`, not `Array<B, D>`.
+    /// Note that you probably don't want to use this to create an array of the
+    /// same shape as another array because creating an array with e.g.
+    /// [`Array::zeros()`](ArrayBase::zeros) using a shape of type `&[usize]`
+    /// results in a dynamic-dimensional array. If you want to create an array
+    /// that has the same shape and dimensionality as another array, use
+    /// [`.raw_dim()`](ArrayBase::raw_dim) instead:
     ///
-    /// If you want to create an array that has the same shape and
-    /// dimensionality as another array, use
-    /// [`.raw_dim()`](ArrayBase::raw_dim) instead, e.g.
-    /// `Array::zeros(arr.raw_dim())`.
+    /// ```rust
+    /// use ndarray::{Array, Array2};
+    ///
+    /// let a = Array2::<i32>::zeros((3, 4));
+    /// let shape = a.shape();
+    /// assert_eq!(shape, &[3, 4]);
+    ///
+    /// // Since `a.shape()` returned `&[usize]`, we get an `ArrayD` instance:
+    /// let b = Array::zeros(shape);
+    /// assert_eq!(a.clone().into_dyn(), b);
+    ///
+    /// // To get the same dimension type, use `.raw_dim()` instead:
+    /// let c = Array::zeros(a.raw_dim());
+    /// assert_eq!(a, c);
+    /// ```
     pub fn shape(&self) -> &[usize] {
         self.dim.slice()
     }

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -83,17 +83,43 @@ where
     }
 
     /// Return the shape of the array as it stored in the array.
+    ///
+    /// This is primarily useful for passing to other `ArrayBase`
+    /// functions, such as when creating another array of the same
+    /// shape and dimensionality.
+    ///
+    /// ```
+    /// use ndarray::Array;
+    ///
+    /// let a = Array::from_elem((2, 3), 5.);
+    ///
+    /// // Create an array of zeros that's the same shape and dimensionality as `a`.
+    /// let b = Array::<f64, _>::zeros(a.raw_dim());
+    /// ```
     pub fn raw_dim(&self) -> D {
         self.dim.clone()
     }
 
     /// Return the shape of the array as a slice.
-    pub fn shape(&self) -> &[Ix] {
+    ///
+    /// Note that you probably don't want to use this to create an
+    /// array of the same shape as another array because creating an
+    /// array with e.g. [`Array::zeros()`](ArrayBase::zeros) using a
+    /// shape of type `&[usize]` results in a dynamic-dimensional
+    /// array. For example, if `arr` is of type `Array<A, D>`, then
+    /// `Array::zeros(arr.shape())` returns an instance of type
+    /// `Array<B, IxDyn>`, not `Array<B, D>`.
+    ///
+    /// If you want to create an array that has the same shape and
+    /// dimensionality as another array, use
+    /// [`.raw_dim()`](ArrayBase::raw_dim) instead, e.g.
+    /// `Array::zeros(arr.raw_dim())`.
+    pub fn shape(&self) -> &[usize] {
         self.dim.slice()
     }
 
-    /// Return the strides of the array as a slice
-    pub fn strides(&self) -> &[Ixs] {
+    /// Return the strides of the array as a slice.
+    pub fn strides(&self) -> &[isize] {
         let s = self.strides.slice();
         // reinterpret unsigned integer as signed
         unsafe {


### PR DESCRIPTION
This should help prevent a common source of confusion, even among relatively experienced `ndarray` users: using `.shape()` where `.raw_dim()` is necessary. This has come up multiple times in the past.

Please let me know if the wording could be improved.