### PR TITLE
Fix clippy warnings.

### DIFF
--- a/src/arrayformat.rs
+++ b/src/arrayformat.rs
@@ -55,7 +55,7 @@ fn format_array<A, S, D, F>(view: &ArrayBase<S, D>, f: &mut fmt::Formatter,
                     write!(f, "]")?;
                 }
                 write!(f, ",")?;
-                write!(f, "\n")?;
+                writeln!(f)?;
                 for _ in 0..ndim - n {
                     write!(f, " ")?;
                 }

--- a/src/data_traits.rs
+++ b/src/data_traits.rs
@@ -236,7 +236,7 @@ unsafe impl<A> Data for OwnedArcRepr<A> {
         Self::ensure_unique(&mut self_);
         let data = OwnedRepr(Arc::try_unwrap(self_.data.0).ok().unwrap());
         ArrayBase {
-            data: data,
+            data,
             ptr: self_.ptr,
             dim: self_.dim,
             strides: self_.strides,

--- a/src/dimension/axes.rs
+++ b/src/dimension/axes.rs
@@ -1,4 +1,3 @@
-
 use crate::{Dimension, Axis, Ix, Ixs};
 
 /// Create a new Axes iterator
@@ -7,7 +6,7 @@ pub fn axes_of<'a, D>(d: &'a D, strides: &'a D) -> Axes<'a, D>
 {
     Axes {
         dim: d,
-        strides: strides,
+        strides,
         start: 0,
         end: d.ndim(),
     }
@@ -56,6 +55,9 @@ impl AxisDescription {
     /// Return stride
     #[inline(always)]
     pub fn stride(self) -> Ixs { self.2 }
+    /// Returns True if axis is of length 0
+    #[inline(always)]
+    pub fn is_empty(self) -> bool { self.len() == 0 }
 }
 
 copy_and_clone!(['a, D] Axes<'a, D>);
@@ -128,4 +130,3 @@ impl IncOps for usize {
         *self
     }
 }
-

--- a/src/dimension/axis.rs
+++ b/src/dimension/axis.rs
@@ -21,7 +21,7 @@ pub struct Axis(pub usize);
 impl Axis {
     /// Return the index of the axis.
     #[inline(always)]
-    pub fn index(&self) -> usize { self.0 }
+    pub fn index(self) -> usize { self.0 }
 }
 
 copy_and_clone!{Axis}
@@ -39,4 +39,3 @@ macro_rules! derive_cmp {
 
 derive_cmp!{PartialEq for Axis, eq -> bool}
 derive_cmp!{PartialOrd for Axis, partial_cmp -> Option<Ordering>}
-

--- a/src/dimension/dim.rs
+++ b/src/dimension/dim.rs
@@ -45,7 +45,7 @@ impl<I> Dim<I> {
     /// Private constructor and accessors for Dim
     pub(crate) fn new(index: I) -> Dim<I> {
         Dim {
-            index: index,
+            index,
         }
     }
     #[inline(always)]
@@ -181,4 +181,3 @@ impl_op!(Sub, sub, SubAssign, sub_assign, sub);
 impl_single_op!(Sub, sub, SubAssign, sub_assign, sub);
 impl_op!(Mul, mul, MulAssign, mul_assign, mul);
 impl_scalar_op!(Mul, mul, MulAssign, mul_assign, mul);
-

--- a/src/dimension/dimension_trait.rs
+++ b/src/dimension/dimension_trait.rs
@@ -356,7 +356,7 @@ macro_rules! impl_insert_axis_array(
             debug_assert!(axis.index() <= $n);
             let mut out = [1; $n + 1];
             out[0..axis.index()].copy_from_slice(&self.slice()[0..axis.index()]);
-            out[axis.index()+1..$n+1].copy_from_slice(&self.slice()[axis.index()..$n]);
+            out[axis.index()+1..=$n].copy_from_slice(&self.slice()[axis.index()..$n]);
             Dim(out)
         }
     );

--- a/src/dimension/dynindeximpl.rs
+++ b/src/dimension/dynindeximpl.rs
@@ -1,4 +1,3 @@
-
 use std::ops::{
     Index,
     IndexMut,
@@ -59,9 +58,8 @@ impl<T: Copy + Zero> IxDynRepr<T> {
     pub fn copy_from(x: &[T]) -> Self {
         if x.len() <= CAP {
             let mut arr = [T::zero(); CAP];
-            for i in 0..x.len() {
-                arr[i] = x[i];
-            }
+            // copy x elements to arr
+            arr[..x.len()].clone_from_slice(&x[..]);
             IxDynRepr::Inline(x.len() as _, arr)
         } else {
             Self::from(x)
@@ -134,7 +132,7 @@ impl IxDynImpl {
             if len < CAP {
                 let mut out = [1; CAP];
                 out[0..i].copy_from_slice(&self[0..i]);
-                out[i+1..len+1].copy_from_slice(&self[i..len]);
+                out[i+1..=len].copy_from_slice(&self[i..len]);
                 IxDynRepr::Inline((len + 1) as u32, out)
             } else {
                 let mut out = Vec::with_capacity(len + 1);
@@ -218,7 +216,7 @@ impl<'a> IntoIterator for &'a IxDynImpl {
     type IntoIter = <&'a [Ix] as IntoIterator>::IntoIter;
     #[inline]
     fn into_iter(self) -> Self::IntoIter {
-        self[..].into_iter()
+        self[..].iter()
     }
 }
 
@@ -233,7 +231,7 @@ impl IxDyn {
     /// Create a new dimension value with `n` axes, all zeros
     #[inline]
     pub fn zeros(n: usize) -> IxDyn {
-        const ZEROS: &'static [usize] = &[0; 4];
+        const ZEROS: &[usize] = &[0; 4];
         if n <= ZEROS.len() {
             Dim(&ZEROS[..n])
         } else {

--- a/src/dimension/mod.rs
+++ b/src/dimension/mod.rs
@@ -262,13 +262,11 @@ pub trait DimensionExt {
     /// Get the dimension at `axis`.
     ///
     /// *Panics* if `axis` is out of bounds.
-    #[inline]
     fn axis(&self, axis: Axis) -> Ix;
 
     /// Set the dimension at `axis`.
     ///
     /// *Panics* if `axis` is out of bounds.
-    #[inline]
     fn set_axis(&mut self, axis: Axis, value: Ix);
 }
 
@@ -520,12 +518,11 @@ fn slice_min_max(axis_len: usize, slice: Slice) -> Option<(usize, usize)> {
     let (start, end, step) = to_abs_slice(axis_len, slice);
     if start == end {
         None
+    }
+    else if step > 0 {
+        Some((start, end - 1 - (end - start - 1) % (step as usize)))
     } else {
-        if step > 0 {
-            Some((start, end - 1 - (end - start - 1) % (step as usize)))
-        } else {
-            Some((start + (end - start - 1) % (-step as usize), end - 1))
-        }
+        Some((start + (end - start - 1) % (-step as usize), end - 1))
     }
 }
 

--- a/src/impl_1d.rs
+++ b/src/impl_1d.rs
@@ -27,4 +27,3 @@ impl<A, S> ArrayBase<S, Ix1>
         }
     }
 }
-

--- a/src/impl_clone.rs
+++ b/src/impl_clone.rs
@@ -13,8 +13,8 @@ impl<S: RawDataClone, D: Clone> Clone for ArrayBase<S, D> {
         unsafe {
             let (data, ptr) = self.data.clone_with_ptr(self.ptr);
             ArrayBase {
-                data: data,
-                ptr: ptr,
+                data,
+                ptr,
                 dim: self.dim.clone(),
                 strides: self.strides.clone(),
             }

--- a/src/impl_constructors.rs
+++ b/src/impl_constructors.rs
@@ -246,7 +246,7 @@ impl<S, A, D> ArrayBase<S, D>
             unsafe { Self::from_shape_vec_unchecked(shape, v) }
         } else {
             let dim = shape.dim.clone();
-            let v = to_vec_mapped(indexes::indices_iter_f(dim).into_iter(), f);
+            let v = to_vec_mapped(indexes::indices_iter_f(dim), f);
             unsafe { Self::from_shape_vec_unchecked(shape, v) }
         }
     }
@@ -342,8 +342,8 @@ impl<S, A, D> ArrayBase<S, D>
         ArrayBase {
             ptr: v.as_mut_ptr(),
             data: DataOwned::new(v),
-            strides: strides,
-            dim: dim
+            strides,
+            dim
         }
     }
 

--- a/src/impl_raw_views.rs
+++ b/src/impl_raw_views.rs
@@ -15,7 +15,7 @@ where
         RawArrayView {
             data: RawViewRepr::new(),
             ptr: ptr as *mut A,
-            dim: dim,
+            dim,
             strides: strides,
         }
     }
@@ -118,9 +118,9 @@ where
     pub(crate) unsafe fn new_(ptr: *mut A, dim: D, strides: D) -> Self {
         RawArrayViewMut {
             data: RawViewRepr::new(),
-            ptr: ptr,
-            dim: dim,
-            strides: strides,
+            ptr,
+            dim,
+            strides,
         }
     }
 

--- a/src/impl_views.rs
+++ b/src/impl_views.rs
@@ -486,8 +486,8 @@ impl<'a, A, D> ArrayView<'a, A, D>
         ArrayView {
             data: ViewRepr::new(),
             ptr: ptr as *mut A,
-            dim: dim,
-            strides: strides,
+            dim,
+            strides,
         }
     }
 
@@ -533,9 +533,9 @@ impl<'a, A, D> ArrayViewMut<'a, A, D>
         }
         ArrayViewMut {
             data: ViewRepr::new(),
-            ptr: ptr,
-            dim: dim,
-            strides: strides,
+            ptr,
+            dim,
+            strides,
         }
     }
 
@@ -586,4 +586,3 @@ impl<'a, A, D> ArrayViewMut<'a, A, D>
         AxisIterMut::new(self, Axis(0))
     }
 }
-

--- a/src/indexes.rs
+++ b/src/indexes.rs
@@ -32,7 +32,7 @@ pub fn indices<E>(shape: E) -> Indices<E::Dim>
     let dim = shape.into_dimension();
     Indices {
         start: E::Dim::zeros(dim.ndim()),
-        dim: dim,
+        dim,
     }
 }
 
@@ -90,7 +90,7 @@ impl<D> IntoIterator for Indices<D>
         let sz = self.dim.size();
         let index = if sz != 0 { Some(self.start) } else { None };
         IndicesIter {
-            index: index,
+            index,
             dim: self.dim,
         }
     }
@@ -135,7 +135,7 @@ impl<D: Dimension + Copy> NdProducer for Indices<D> {
 
     #[doc(hidden)]
     fn raw_dim(&self) -> Self::Dim {
-        self.dim.clone()
+        self.dim
     }
 
     #[doc(hidden)]
@@ -168,7 +168,7 @@ impl<D: Dimension + Copy> NdProducer for Indices<D> {
     unsafe fn uget_ptr(&self, i: &Self::Dim) -> Self::Ptr {
         let mut index = *i;
         index += &self.start;
-        IndexPtr { index: index }
+        IndexPtr { index }
     }
 
     #[doc(hidden)]
@@ -214,7 +214,7 @@ pub fn indices_iter_f<E>(shape: E) -> IndicesIterF<E::Dim>
     IndicesIterF {
         has_remaining: dim.size_checked() != Some(0),
         index: zero,
-        dim: dim,
+        dim,
     }
 }
 

--- a/src/iterators/chunks.rs
+++ b/src/iterators/chunks.rs
@@ -1,4 +1,3 @@
-
 use crate::imp_prelude::*;
 use crate::IntoDimension;
 use crate::{NdProducer, Layout};
@@ -59,8 +58,8 @@ impl<'a, A, D: Dimension> ExactChunks<'a, A, D> {
 
         ExactChunks {
             base: a,
-            chunk: chunk,
-            inner_strides: inner_strides,
+            chunk,
+            inner_strides,
         }
     }
 }
@@ -142,8 +141,8 @@ impl<'a, A, D: Dimension> ExactChunksMut<'a, A, D> {
 
         ExactChunksMut {
             base: a,
-            chunk: chunk,
-            inner_strides: inner_strides,
+            chunk,
+            inner_strides,
         }
     }
 }

--- a/src/iterators/windows.rs
+++ b/src/iterators/windows.rs
@@ -1,4 +1,3 @@
-
 use crate::imp_prelude::*;
 use super::ElementsBase;
 use crate::IntoDimension;
@@ -37,7 +36,7 @@ impl<'a, A, D: Dimension> Windows<'a, A, D> {
         unsafe {
             Windows {
                 base: ArrayView::from_shape_ptr(size.clone().strides(a.strides), a.ptr),
-                window: window,
+                window,
                 strides: window_strides,
             }
         }

--- a/src/layout/layoutfmt.rs
+++ b/src/layout/layoutfmt.rs
@@ -1,4 +1,3 @@
-
 // Copyright 2017 bluss and ndarray developers.
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
@@ -11,7 +10,7 @@ use itertools::Itertools;
 use super::Layout;
 use super::LayoutPriv;
 
-const LAYOUT_NAMES: &'static [&'static str] = &["C", "F"];
+const LAYOUT_NAMES: &[&str] = &["C", "F"];
 
 use std::fmt;
 
@@ -33,4 +32,3 @@ impl fmt::Debug for Layout {
         write!(f, " ({:#x})", self.0)
     }
 }
-

--- a/src/linalg/impl_linalg.rs
+++ b/src/linalg/impl_linalg.rs
@@ -79,7 +79,7 @@ impl<A, S> ArrayBase<S, Ix1>
         let mut sum = A::zero();
         for i in 0..self.len() {
             unsafe {
-                sum = sum.clone() + self.uget(i).clone() * rhs.uget(i).clone();
+                sum = sum + *self.uget(i) * *rhs.uget(i);
             }
         }
         sum
@@ -495,7 +495,7 @@ fn mat_mul_general<A>(alpha: A,
         }
     } else {
         // It's a no-op if `c` has zero length.
-        if c.len() == 0 {
+        if c.is_empty() {
             return;
         }
 

--- a/src/linspace.rs
+++ b/src/linspace.rs
@@ -80,7 +80,7 @@ pub fn linspace<F>(a: F, b: F, n: usize) -> Linspace<F>
     };
     Linspace {
         start: a,
-        step: step,
+        step,
         index: 0,
         len: n,
     }
@@ -101,7 +101,7 @@ pub fn range<F>(a: F, b: F, step: F) -> Linspace<F>
     let steps = F::ceil(len / step);
     Linspace {
         start: a,
-        step: step,
+        step,
         len: steps.to_usize().unwrap(),
         index: 0,
     }

--- a/src/macro_utils.rs
+++ b/src/macro_utils.rs
@@ -1,4 +1,3 @@
-
 /// Derive Copy and Clone using the parameters (and bounds) as specified in []
 macro_rules! copy_and_clone {
     ([$($parm:tt)*] $type_:ty) => {
@@ -60,7 +59,7 @@ macro_rules! expand_if {
 #[cfg(debug_assertions)]
 macro_rules! debug_bounds_check {
     ($self_:ident, $index:expr) => {
-        if let None = $index.index_checked(&$self_.dim, &$self_.strides) {
+        if $index.index_checked(&$self_.dim, &$self_.strides).is_none() {
             panic!("ndarray: index {:?} is out of bounds for array of shape {:?}",
                    $index, $self_.shape());
         }
@@ -71,4 +70,3 @@ macro_rules! debug_bounds_check {
 macro_rules! debug_bounds_check {
     ($self_:ident, $index:expr) => { };
 }
-

--- a/src/numeric/impl_numeric.rs
+++ b/src/numeric/impl_numeric.rs
@@ -145,7 +145,7 @@ impl<A, S, D> ArrayBase<S, D>
     {
         let n = A::from_usize(self.len_of(axis)).expect("Converting axis length to `A` must not fail.");
         let sum = self.sum_axis(axis);
-        sum / &aview0(&n)
+        sum / aview0(&n)
     }
 
     /// Return variance along `axis`.
@@ -288,4 +288,3 @@ impl<A, S, D> ArrayBase<S, D>
             }).is_done()
     }
 }
-

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -110,16 +110,16 @@ copy_and_clone!{SliceOrIndex}
 impl SliceOrIndex {
     /// Returns `true` if `self` is a `Slice` value.
     pub fn is_slice(&self) -> bool {
-        match self {
-            &SliceOrIndex::Slice { .. } => true,
+        match *self {
+            SliceOrIndex::Slice { .. } => true,
             _ => false,
         }
     }
 
     /// Returns `true` if `self` is an `Index` value.
     pub fn is_index(&self) -> bool {
-        match self {
-            &SliceOrIndex::Index(_) => true,
+        match *self {
+            SliceOrIndex::Index(_) => true,
             _ => false,
         }
     }
@@ -317,8 +317,8 @@ where
     #[doc(hidden)]
     pub unsafe fn new_unchecked(indices: T, out_dim: PhantomData<D>) -> SliceInfo<T, D> {
         SliceInfo {
-            out_dim: out_dim,
-            indices: indices,
+            out_dim,
+            indices,
         }
     }
 }
@@ -339,7 +339,7 @@ where
         }
         Ok(SliceInfo {
             out_dim: PhantomData,
-            indices: indices,
+            indices,
         })
     }
 }

--- a/src/stacking.rs
+++ b/src/stacking.rs
@@ -34,7 +34,7 @@ pub fn stack<'a, A, D>(axis: Axis, arrays: &[ArrayView<'a, A, D>])
     where A: Copy,
           D: RemoveAxis
 {
-    if arrays.len() == 0 {
+    if arrays.is_empty() {
         return Err(from_kind(ErrorKind::Unsupported));
     }
     let mut res_dim = arrays[0].raw_dim();


### PR DESCRIPTION
The following warnings are omitted
1. Redundant field names
2. Constants by default have a `'static'` life time
3. Redundant pattern matching
4. match statements by dereferencing
5. Using clone on copy type
6. Inclusive ranges
7. Manual copying loops
8. Dedicated clone methods