### PR TITLE
Add accumulate_axis_inplace method and implement NdProducer for RawArrayView/Mut

### DIFF
--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -2268,9 +2268,9 @@ where
         if self.len_of(axis) <= 1 {
             return;
         }
-        let mut prev = self.raw_view();
+        let mut curr = self.raw_view_mut(); // mut borrow of the array here
+        let mut prev = curr.raw_view(); // derive further raw views from the same borrow
         prev.slice_axis_inplace(axis, Slice::from(..-1));
-        let mut curr = self.raw_view_mut();
         curr.slice_axis_inplace(axis, Slice::from(1..));
         // This implementation relies on `Zip` iterating along `axis` in order.
         Zip::from(prev).and(curr).apply(|prev, curr| unsafe {

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -1098,7 +1098,7 @@ fn owned_array_with_stride() {
 
 #[test]
 fn owned_array_discontiguous() {
-    use ::std::iter::repeat;
+    use std::iter::repeat;
     let v: Vec<_> = (0..12).flat_map(|x| repeat(x).take(2)).collect();
     let dim = (3, 2, 2);
     let strides = (8, 4, 2);
@@ -1111,9 +1111,9 @@ fn owned_array_discontiguous() {
 
 #[test]
 fn owned_array_discontiguous_drop() {
-    use ::std::cell::RefCell;
-    use ::std::collections::BTreeSet;
-    use ::std::rc::Rc;
+    use std::cell::RefCell;
+    use std::collections::BTreeSet;
+    use std::rc::Rc;
 
     struct InsertOnDrop<T: Ord>(Rc<RefCell<BTreeSet<T>>>, Option<T>);
     impl<T: Ord> Drop for InsertOnDrop<T> {
@@ -1963,6 +1963,7 @@ fn test_accumulate_axis_inplace_noop() {
     assert_eq!(a, Array2::zeros((3, 1)));
 }
 
+#[rustfmt::skip] // Allow block array formatting
 #[test]
 fn test_accumulate_axis_inplace_nonstandard_layout() {
     let a = arr2(&[[1, 2, 3],

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -1953,6 +1953,47 @@ fn test_map_axis() {
 }
 
 #[test]
+fn test_accumulate_axis_inplace_noop() {
+    let mut a = Array2::<u8>::zeros((0, 3));
+    a.accumulate_axis_inplace(Axis(0), |&prev, curr| *curr += prev);
+    assert_eq!(a, Array2::zeros((0, 3)));
+
+    let mut a = Array2::<u8>::zeros((3, 1));
+    a.accumulate_axis_inplace(Axis(1), |&prev, curr| *curr += prev);
+    assert_eq!(a, Array2::zeros((3, 1)));
+}
+
+#[test]
+fn test_accumulate_axis_inplace_nonstandard_layout() {
+    let a = arr2(&[[1, 2, 3],
+                   [4, 5, 6],
+                   [7, 8, 9],
+                   [10,11,12]]);
+
+    let mut a_t = a.clone().reversed_axes();
+    a_t.accumulate_axis_inplace(Axis(0), |&prev, curr| *curr += prev);
+    assert_eq!(a_t, aview2(&[[1, 4, 7, 10],
+                             [3, 9, 15, 21],
+                             [6, 15, 24, 33]]));
+
+    let mut a0 = a.clone();
+    a0.invert_axis(Axis(0));
+    a0.accumulate_axis_inplace(Axis(0), |&prev, curr| *curr += prev);
+    assert_eq!(a0, aview2(&[[10, 11, 12],
+                            [17, 19, 21],
+                            [21, 24, 27],
+                            [22, 26, 30]]));
+
+    let mut a1 = a.clone();
+    a1.invert_axis(Axis(1));
+    a1.accumulate_axis_inplace(Axis(1), |&prev, curr| *curr += prev);
+    assert_eq!(a1, aview2(&[[3, 5, 6],
+                            [6, 11, 15],
+                            [9, 17, 24],
+                            [12, 23, 33]]));
+}
+
+#[test]
 fn test_to_vec() {
     let mut a = arr2(&[[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]]);
 


### PR DESCRIPTION
This `accumulate_axis_inplace` method is a non-cloning version of the `accumulate_axis_method` proposed in #513.