### PR TITLE
Add `logspace` constructor

### DIFF
--- a/src/impl_constructors.rs
+++ b/src/impl_constructors.rs
@@ -112,11 +112,9 @@ impl<S, A> ArrayBase<S, Ix1>
     /// use ndarray::{Array, arr1};
     ///
     /// let array = Array::logspace(1e0, 1e3, 4);
-    /// println!("{}", array);
     /// assert!(array.all_close(&arr1(&[1e0, 1e1, 1e2, 1e3]), 1e-5));
     ///
     /// let array = Array::logspace(-1e3, -1e0, 4);
-    /// println!("{}", array);
     /// assert!(array.all_close(&arr1(&[-1e3, -1e2, -1e1, -1e0]), 1e-5));
     /// ```
     pub fn logspace(start: A, end: A, n: usize) -> Self

--- a/src/impl_constructors.rs
+++ b/src/impl_constructors.rs
@@ -10,18 +10,18 @@
 //!
 //!
 
-use num_traits::{Zero, One, Float};
+use num_traits::{Float, One, Zero};
 use std::isize;
 use std::mem;
 
-use crate::imp_prelude::*;
-use crate::StrideShape;
 use crate::dimension;
-use crate::linspace;
 use crate::error::{self, ShapeError};
-use crate::indices;
+use crate::imp_prelude::*;
 use crate::indexes;
+use crate::indices;
 use crate::iterators::{to_vec, to_vec_mapped};
+use crate::StrideShape;
+use crate::{linspace, logspace};
 
 /// # Constructor Methods for Owned Arrays
 ///
@@ -100,6 +100,30 @@ impl<S, A> ArrayBase<S, Ix1>
         where A: Float,
     {
         Self::from_vec(to_vec(linspace::range(start, end, step)))
+    }
+
+    /// Create a one-dimensional array from the inclusive interval `[start,
+    /// end]` with `n` elements logarithmically spaced. `A` must be a floating
+    /// point type.
+    ///
+    /// **Panics** if `n` is greater than `isize::MAX`.
+    ///
+    /// ```rust
+    /// use ndarray::{Array, arr1};
+    ///
+    /// let array = Array::logspace(1e0, 1e3, 4);
+    /// println!("{}", array);
+    /// assert!(array.all_close(&arr1(&[1e0, 1e1, 1e2, 1e3]), 1e-5));
+    ///
+    /// let array = Array::logspace(-1e3, -1e0, 4);
+    /// println!("{}", array);
+    /// assert!(array.all_close(&arr1(&[-1e3, -1e2, -1e1, -1e0]), 1e-5));
+    /// ```
+    pub fn logspace(start: A, end: A, n: usize) -> Self
+    where
+        A: Float,
+    {
+        Self::from_vec(to_vec(logspace::logspace(start, end, n)))
     }
 }
 

--- a/src/impl_constructors.rs
+++ b/src/impl_constructors.rs
@@ -21,7 +21,7 @@ use crate::indexes;
 use crate::indices;
 use crate::iterators::{to_vec, to_vec_mapped};
 use crate::StrideShape;
-use crate::{linspace, logspace};
+use crate::{linspace, geomspace, logspace};
 
 /// # Constructor Methods for Owned Arrays
 ///
@@ -102,26 +102,53 @@ impl<S, A> ArrayBase<S, Ix1>
         Self::from_vec(to_vec(linspace::range(start, end, step)))
     }
 
+    /// Create a one-dimensional array with `n` elements logarithmically spaced,
+    /// with the starting value being `base.powf(start)` and the final one being
+    /// `base.powf(end)`. `A` must be a floating point type.
+    ///
+    /// If `base` is negative, all values will be negative.
+    ///
+    /// **Panics** if the length is greater than `isize::MAX`.
+    ///
+    /// ```rust
+    /// use ndarray::{Array, arr1};
+    ///
+    /// let array = Array::logspace(10.0, 0.0, 3.0, 4);
+    /// assert!(array.all_close(&arr1(&[1e0, 1e1, 1e2, 1e3]), 1e-5));
+    ///
+    /// let array = Array::logspace(-10.0, 3.0, 0.0, 4);
+    /// assert!(array.all_close(&arr1(&[-1e3, -1e2, -1e1, -1e0]), 1e-5));
+    /// ```
+    pub fn logspace(base: A, start: A, end: A, n: usize) -> Self
+    where
+        A: Float,
+    {
+        Self::from_vec(to_vec(logspace::logspace(base, start, end, n)))
+    }
+
     /// Create a one-dimensional array from the inclusive interval `[start,
-    /// end]` with `n` elements logarithmically spaced. `A` must be a floating
+    /// end]` with `n` elements geometrically spaced. `A` must be a floating
     /// point type.
+    ///
+    /// The interval can be either all positive or all negative; however, it
+    /// cannot contain 0 (including the end points).
     ///
     /// **Panics** if `n` is greater than `isize::MAX`.
     ///
     /// ```rust
     /// use ndarray::{Array, arr1};
     ///
-    /// let array = Array::logspace(1e0, 1e3, 4);
+    /// let array = Array::geomspace(1e0, 1e3, 4);
     /// assert!(array.all_close(&arr1(&[1e0, 1e1, 1e2, 1e3]), 1e-5));
     ///
-    /// let array = Array::logspace(-1e3, -1e0, 4);
+    /// let array = Array::geomspace(-1e3, -1e0, 4);
     /// assert!(array.all_close(&arr1(&[-1e3, -1e2, -1e1, -1e0]), 1e-5));
     /// ```
-    pub fn logspace(start: A, end: A, n: usize) -> Self
+    pub fn geomspace(start: A, end: A, n: usize) -> Self
     where
         A: Float,
     {
-        Self::from_vec(to_vec(logspace::logspace(start, end, n)))
+        Self::from_vec(to_vec(geomspace::geomspace(start, end, n)))
     }
 }
 

--- a/src/iterators/mod.rs
+++ b/src/iterators/mod.rs
@@ -1214,25 +1214,24 @@ send_sync_read_write!(ElementsBaseMut);
 
 /// (Trait used internally) An iterator that we trust
 /// to deliver exactly as many items as it said it would.
-pub unsafe trait TrustedIterator { }
+pub unsafe trait TrustedIterator {}
 
-use std;
-use crate::linspace::Linspace;
-use crate::iter::IndicesIter;
 use crate::indexes::IndicesIterF;
+use crate::iter::IndicesIter;
+use crate::{linspace::Linspace, logspace::Logspace};
+use std;
 
-unsafe impl<F> TrustedIterator for Linspace<F> { }
-unsafe impl<'a, A, D> TrustedIterator for Iter<'a, A, D> { }
-unsafe impl<'a, A, D> TrustedIterator for IterMut<'a, A, D> { }
-unsafe impl<I, F> TrustedIterator for std::iter::Map<I, F>
-    where I: TrustedIterator { }
-unsafe impl<'a, A> TrustedIterator for slice::Iter<'a, A> { }
-unsafe impl<'a, A> TrustedIterator for slice::IterMut<'a, A> { }
-unsafe impl TrustedIterator for ::std::ops::Range<usize> { }
+unsafe impl<F> TrustedIterator for Linspace<F> {}
+unsafe impl<F> TrustedIterator for Logspace<F> {}
+unsafe impl<'a, A, D> TrustedIterator for Iter<'a, A, D> {}
+unsafe impl<'a, A, D> TrustedIterator for IterMut<'a, A, D> {}
+unsafe impl<I, F> TrustedIterator for std::iter::Map<I, F> where I: TrustedIterator {}
+unsafe impl<'a, A> TrustedIterator for slice::Iter<'a, A> {}
+unsafe impl<'a, A> TrustedIterator for slice::IterMut<'a, A> {}
+unsafe impl TrustedIterator for ::std::ops::Range<usize> {}
 // FIXME: These indices iter are dubious -- size needs to be checked up front.
-unsafe impl<D> TrustedIterator for IndicesIter<D> where D: Dimension { }
-unsafe impl<D> TrustedIterator for IndicesIterF<D> where D: Dimension { }
-
+unsafe impl<D> TrustedIterator for IndicesIter<D> where D: Dimension {}
+unsafe impl<D> TrustedIterator for IndicesIterF<D> where D: Dimension {}
 
 /// Like Iterator::collect, but only for trusted length iterators
 pub fn to_vec<I>(iter: I) -> Vec<I::Item>

--- a/src/iterators/mod.rs
+++ b/src/iterators/mod.rs
@@ -1218,9 +1218,10 @@ pub unsafe trait TrustedIterator {}
 
 use crate::indexes::IndicesIterF;
 use crate::iter::IndicesIter;
-use crate::{linspace::Linspace, logspace::Logspace};
+use crate::{geomspace::Geomspace, linspace::Linspace, logspace::Logspace};
 use std;
 
+unsafe impl<F> TrustedIterator for Geomspace<F> {}
 unsafe impl<F> TrustedIterator for Linspace<F> {}
 unsafe impl<F> TrustedIterator for Logspace<F> {}
 unsafe impl<'a, A, D> TrustedIterator for Iter<'a, A, D> {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,9 +167,8 @@ mod free_functions;
 pub use crate::free_functions::*;
 pub use crate::iterators::iter;
 
-#[macro_use]
-mod slice;
 mod error;
+mod geomspace;
 mod indexes;
 mod iterators;
 mod layout;
@@ -178,6 +177,8 @@ mod linspace;
 mod logspace;
 mod numeric_util;
 mod shape_builder;
+#[macro_use]
+mod slice;
 mod stacking;
 #[macro_use]
 mod zip;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,14 +167,16 @@ mod free_functions;
 pub use crate::free_functions::*;
 pub use crate::iterators::iter;
 
-#[macro_use] mod slice;
-mod layout;
+#[macro_use]
+mod slice;
+mod error;
 mod indexes;
 mod iterators;
+mod layout;
 mod linalg_traits;
 mod linspace;
+mod logspace;
 mod numeric_util;
-mod error;
 mod shape_builder;
 mod stacking;
 #[macro_use]

--- a/src/logspace.rs
+++ b/src/logspace.rs
@@ -114,8 +114,14 @@ mod tests {
         let array: Array1<_> = logspace(1e0, 1e3, 4).collect();
         assert!(array.all_close(&arr1(&[1e0, 1e1, 1e2, 1e3]), 1e-5));
 
+        let array: Array1<_> = logspace(1e3, 1e0, 4).collect();
+        assert!(array.all_close(&arr1(&[1e3, 1e2, 1e1, 1e0]), 1e-5));
+
         let array: Array1<_> = logspace(-1e3, -1e0, 4).collect();
         assert!(array.all_close(&arr1(&[-1e3, -1e2, -1e1, -1e0]), 1e-5));
+
+        let array: Array1<_> = logspace(-1e0, -1e3, 4).collect();
+        assert!(array.all_close(&arr1(&[-1e0, -1e1, -1e2, -1e3]), 1e-5));
     }
 
     #[test]

--- a/src/logspace.rs
+++ b/src/logspace.rs
@@ -1,0 +1,105 @@
+// Copyright 2014-2016 bluss and ndarray developers.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+use num_traits::Float;
+
+/// An iterator of a sequence of logarithmically evenly spaced floats.
+///
+/// Iterator element type is `F`.
+pub struct Logspace<F> {
+    current: F,
+    last: F,
+    step: F,
+    index: usize,
+    len: usize,
+}
+
+impl<F> Iterator for Logspace<F>
+where
+    F: Float,
+{
+    type Item = F;
+
+    #[inline]
+    fn next(&mut self) -> Option<F> {
+        if self.index >= self.len {
+            None
+        } else {
+            self.index += 1;
+
+            let v = self.current;
+            self.current = self.current * self.step;
+            Some(v)
+        }
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let n = self.len - self.index;
+        (n, Some(n))
+    }
+}
+
+impl<F> DoubleEndedIterator for Logspace<F>
+where
+    F: Float,
+{
+    #[inline]
+    fn next_back(&mut self) -> Option<F> {
+        if self.index >= self.len {
+            None
+        } else {
+            self.len -= 1;
+
+            let v = self.last;
+            self.last = self.last / self.step;
+            Some(v)
+        }
+    }
+}
+
+impl<F> ExactSizeIterator for Logspace<F> where Logspace<F>: Iterator {}
+
+/// Return an iterator of logarithmically evenly spaced floats.
+///
+/// The `Logspace` has `n` elements, where the first element is `a` and the last
+/// element is `b`.
+///
+/// The sign of `a` and `b` must be the same so that the interval does not
+/// include 0.
+///
+/// Iterator element type is `F`, where `F` must be either `f32` or `f64`.
+#[inline]
+pub fn logspace<F>(a: F, b: F, n: usize) -> Logspace<F>
+where
+    F: Float,
+{
+    assert!(
+        a != F::zero() && b != F::zero(),
+        "Start and/or end of logspace cannot be zero.",
+    );
+    assert!(
+        a.is_sign_negative() == b.is_sign_negative(),
+        "Logarithmic interval cannot cross 0."
+    );
+
+    let log_a = a.abs().ln();
+    let log_b = b.abs().ln();
+    let step = if n > 1 {
+        let nf = F::from(n).unwrap();
+        ((log_b - log_a) / (nf - F::one())).exp()
+    } else {
+        F::one()
+    };
+    Logspace {
+        current: a,
+        last: b,
+        step: step,
+        index: 0,
+        len: n,
+    }
+}

--- a/src/logspace.rs
+++ b/src/logspace.rs
@@ -103,3 +103,66 @@ where
         len: n,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::logspace;
+    use crate::{arr1, Array1};
+
+    #[test]
+    fn valid() {
+        let array: Array1<_> = logspace(1e0, 1e3, 4).collect();
+        assert!(array.all_close(&arr1(&[1e0, 1e1, 1e2, 1e3]), 1e-5));
+
+        let array: Array1<_> = logspace(-1e3, -1e0, 4).collect();
+        assert!(array.all_close(&arr1(&[-1e3, -1e2, -1e1, -1e0]), 1e-5));
+    }
+
+    #[test]
+    fn iter_forward() {
+        let mut iter = logspace(1.0f64, 1e3, 4);
+
+        assert!(iter.size_hint() == (4, Some(4)));
+
+        assert!((iter.next().unwrap() - 1e0).abs() < 1e-5);
+        assert!((iter.next().unwrap() - 1e1).abs() < 1e-5);
+        assert!((iter.next().unwrap() - 1e2).abs() < 1e-5);
+        assert!((iter.next().unwrap() - 1e3).abs() < 1e-5);
+        assert!(iter.next().is_none());
+
+        assert!(iter.size_hint() == (0, Some(0)));
+    }
+
+    #[test]
+    fn iter_backward() {
+        let mut iter = logspace(1.0f64, 1e3, 4);
+
+        assert!(iter.size_hint() == (4, Some(4)));
+
+        assert!((iter.next_back().unwrap() - 1e3).abs() < 1e-5);
+        assert!((iter.next_back().unwrap() - 1e2).abs() < 1e-5);
+        assert!((iter.next_back().unwrap() - 1e1).abs() < 1e-5);
+        assert!((iter.next_back().unwrap() - 1e0).abs() < 1e-5);
+        assert!(iter.next_back().is_none());
+
+        assert!(iter.size_hint() == (0, Some(0)));
+    }
+
+    #[test]
+    #[should_panic]
+    fn zero_lower() {
+        logspace(0.0, 1.0, 4);
+    }
+
+    #[test]
+    #[should_panic]
+    fn zero_upper() {
+        logspace(1.0, 0.0, 4);
+    }
+
+    #[test]
+    #[should_panic]
+    fn zero_included() {
+        logspace(-1.0, 1.0, 4);
+    }
+}


### PR DESCRIPTION
This pull requests adds the `logspace` constructor for Array1 that works in the same way as `linspace` but creates logarithmically spaced floats.

This implementation supports both positive and negative intervals, though
(obviously) not intervals which cross `0.0`.