### PR TITLE
Add link to #rust-sci in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,15 +12,19 @@ __ https://docs.rs/ndarray/
 |build_status|_ |crates|_ |matrix-chat|_ |irc|_
 
 .. |build_status| image:: https://github.com/rust-ndarray/ndarray/workflows/Continuous%20integration/badge.svg?branch=master
+   :alt: CI build status
 .. _build_status: https://github.com/rust-ndarray/ndarray/actions
 
 .. |crates| image:: http://meritbadge.herokuapp.com/ndarray
+   :alt: ndarray at crates.io
 .. _crates: https://crates.io/crates/ndarray
 
 .. |matrix-chat| image:: https://img.shields.io/badge/Matrix-%23rust--sci%3Amatrix.org-lightgrey
+   :alt: Matrix chat at #rust-sci:matrix.org
 .. _matrix-chat: https://matrix.to/#/#rust-sci:matrix.org
 
 .. |irc| image:: https://img.shields.io/badge/IRC-%23rust--sci%20on%20OFTC-lightgrey
+   :alt: IRC at #rust-sci on OFTC
 .. _irc: https://webchat.oftc.net/?channels=rust-sci
 
 Highlights

--- a/README.rst
+++ b/README.rst
@@ -9,13 +9,19 @@ or take a look at the `quickstart tutorial <./README-quick-start.md>`_.
 
 __ https://docs.rs/ndarray/
 
-|build_status|_ |crates|_
+|build_status|_ |crates|_ |matrix-chat|_ |irc|_
 
 .. |build_status| image:: https://github.com/rust-ndarray/ndarray/workflows/Continuous%20integration/badge.svg?branch=master
 .. _build_status: https://github.com/rust-ndarray/ndarray/actions
 
 .. |crates| image:: http://meritbadge.herokuapp.com/ndarray
 .. _crates: https://crates.io/crates/ndarray
+
+.. |matrix-chat| image:: https://img.shields.io/badge/Matrix-%23rust--sci%3Amatrix.org-lightgrey
+.. _matrix-chat: https://matrix.to/#/#rust-sci:matrix.org
+
+.. |irc| image:: https://img.shields.io/badge/IRC-%23rust--sci%20on%20OFTC-lightgrey
+.. _irc: https://webchat.oftc.net/?channels=rust-sci
 
 Highlights
 ----------


### PR DESCRIPTION
It's helpful to have a place for users to chat. The link is to #rust-sci in the Mibbit client (the same client used for the "Mozilla IRC" link on https://www.rust-lang.org/community). Mibbit is nice because it provides a way for people to join the chat using their browser without even having to register.