### PR TITLE
Remove usize as dimension pattern

### DIFF
--- a/benches/bench1.rs
+++ b/benches/bench1.rs
@@ -20,7 +20,7 @@ use test::black_box;
 #[bench]
 fn iter_sum_1d_regular(bench: &mut test::Bencher)
 {
-    let a = Array::<i32, _>::zeros(64 * 64);
+    let a = Array::<i32, _>::zeros((64 * 64,));
     let a = black_box(a);
     bench.iter(|| {
         let mut sum = 0;
@@ -35,7 +35,7 @@ fn iter_sum_1d_regular(bench: &mut test::Bencher)
 fn iter_sum_1d_raw(bench: &mut test::Bencher)
 {
     // this is autovectorized to death (= great performance)
-    let a = Array::<i32, _>::zeros(64 * 64);
+    let a = Array::<i32, _>::zeros((64 * 64,));
     let a = black_box(a);
     bench.iter(|| {
         let mut sum = 0;
@@ -404,7 +404,7 @@ fn add_2d_cutouts_by_32(bench: &mut test::Bencher)
 fn add_2d_broadcast_1_to_2(bench: &mut test::Bencher)
 {
     let mut a = Array2::<i32>::zeros((ADD2DSZ, ADD2DSZ));
-    let b = Array1::<i32>::zeros(ADD2DSZ);
+    let b = Array1::<i32>::zeros((ADD2DSZ,));
     let bv = b.view();
     bench.iter(|| {
         a += &bv;
@@ -614,7 +614,7 @@ const ADD1D_SIZE: usize = 64 * 64;
 #[bench]
 fn add_1d_regular(bench: &mut test::Bencher)
 {
-    let mut a = Array::<f32, _>::zeros(ADD1D_SIZE);
+    let mut a = Array::<f32, _>::zeros((ADD1D_SIZE,));
     let b = Array::<f32, _>::zeros(a.dim());
     bench.iter(|| {
         a += &b;
@@ -624,7 +624,7 @@ fn add_1d_regular(bench: &mut test::Bencher)
 #[bench]
 fn add_1d_strided(bench: &mut test::Bencher)
 {
-    let mut a = Array::<f32, _>::zeros(ADD1D_SIZE * 2);
+    let mut a = Array::<f32, _>::zeros((ADD1D_SIZE * 2,));
     let mut av = a.slice_mut(s![..;2]);
     let b = Array::<f32, _>::zeros(av.dim());
     bench.iter(|| {
@@ -880,40 +880,40 @@ fn equality_f32_mixorder(bench: &mut test::Bencher)
 #[bench]
 fn dot_f32_16(bench: &mut test::Bencher)
 {
-    let a = Array::<f32, _>::zeros(16);
-    let b = Array::<f32, _>::zeros(16);
+    let a = Array::<f32, _>::zeros((16,));
+    let b = Array::<f32, _>::zeros((16,));
     bench.iter(|| a.dot(&b));
 }
 
 #[bench]
 fn dot_f32_20(bench: &mut test::Bencher)
 {
-    let a = Array::<f32, _>::zeros(20);
-    let b = Array::<f32, _>::zeros(20);
+    let a = Array::<f32, _>::zeros((20,));
+    let b = Array::<f32, _>::zeros((20,));
     bench.iter(|| a.dot(&b));
 }
 
 #[bench]
 fn dot_f32_32(bench: &mut test::Bencher)
 {
-    let a = Array::<f32, _>::zeros(32);
-    let b = Array::<f32, _>::zeros(32);
+    let a = Array::<f32, _>::zeros((32,));
+    let b = Array::<f32, _>::zeros((32,));
     bench.iter(|| a.dot(&b));
 }
 
 #[bench]
 fn dot_f32_256(bench: &mut test::Bencher)
 {
-    let a = Array::<f32, _>::zeros(256);
-    let b = Array::<f32, _>::zeros(256);
+    let a = Array::<f32, _>::zeros((256,));
+    let b = Array::<f32, _>::zeros((256,));
     bench.iter(|| a.dot(&b));
 }
 
 #[bench]
 fn dot_f32_1024(bench: &mut test::Bencher)
 {
-    let av = Array::<f32, _>::zeros(1024);
-    let bv = Array::<f32, _>::zeros(1024);
+    let av = Array::<f32, _>::zeros((1024,));
+    let bv = Array::<f32, _>::zeros((1024,));
     bench.iter(|| {
         av.dot(&bv)
     });
@@ -923,8 +923,8 @@ fn dot_f32_1024(bench: &mut test::Bencher)
 fn dot_f32_10e6(bench: &mut test::Bencher)
 {
     let n = 1_000_000;
-    let av = Array::<f32, _>::zeros(n);
-    let bv = Array::<f32, _>::zeros(n);
+    let av = Array::<f32, _>::zeros((n,));
+    let bv = Array::<f32, _>::zeros((n,));
     bench.iter(|| {
         av.dot(&bv)
     });

--- a/benches/gemv.rs
+++ b/benches/gemv.rs
@@ -12,8 +12,8 @@ use ndarray::linalg::general_mat_vec_mul;
 fn gemv_64_64c(bench: &mut Bencher) {
     let a = Array::zeros((64, 64));
     let (m, n) = a.dim();
-    let x = Array::zeros(n);
-    let mut y = Array::zeros(m);
+    let x = Array::zeros((n,));
+    let mut y = Array::zeros((m,));
     bench.iter(|| {
         general_mat_vec_mul(1.0, &a, &x, 1.0, &mut y);
     });
@@ -23,8 +23,8 @@ fn gemv_64_64c(bench: &mut Bencher) {
 fn gemv_64_64f(bench: &mut Bencher) {
     let a = Array::zeros((64, 64).f());
     let (m, n) = a.dim();
-    let x = Array::zeros(n);
-    let mut y = Array::zeros(m);
+    let x = Array::zeros((n,));
+    let mut y = Array::zeros((m,));
     bench.iter(|| {
         general_mat_vec_mul(1.0, &a, &x, 1.0, &mut y);
     });
@@ -34,8 +34,8 @@ fn gemv_64_64f(bench: &mut Bencher) {
 fn gemv_64_32(bench: &mut Bencher) {
     let a = Array::zeros((64, 32));
     let (m, n) = a.dim();
-    let x = Array::zeros(n);
-    let mut y = Array::zeros(m);
+    let x = Array::zeros((n,));
+    let mut y = Array::zeros((m,));
     bench.iter(|| {
         general_mat_vec_mul(1.0, &a, &x, 1.0, &mut y);
     });

--- a/benches/iter.rs
+++ b/benches/iter.rs
@@ -235,8 +235,8 @@ const I2DSZ: usize = 64;
 
 #[bench]
 fn indexed_iter_1d_ix1(bench: &mut Bencher) {
-    let mut a = Array::<f64, _>::zeros(I2DSZ * I2DSZ);
-    for (i, elt) in a.indexed_iter_mut() {
+    let mut a = Array::<f64, _>::zeros((I2DSZ * I2DSZ,));
+    for ((i,), elt) in a.indexed_iter_mut() {
         *elt = i as _;
     }
 
@@ -250,8 +250,8 @@ fn indexed_iter_1d_ix1(bench: &mut Bencher) {
 
 #[bench]
 fn indexed_zip_1d_ix1(bench: &mut Bencher) {
-    let mut a = Array::<f64, _>::zeros(I2DSZ * I2DSZ);
-    for (i, elt) in a.indexed_iter_mut() {
+    let mut a = Array::<f64, _>::zeros((I2DSZ * I2DSZ,));
+    for ((i,), elt) in a.indexed_iter_mut() {
         *elt = i as _;
     }
 
@@ -346,7 +346,7 @@ fn indexed_iter_3d_dyn(bench: &mut Bencher) {
 #[bench]
 fn iter_sum_1d_strided_fold(bench: &mut Bencher)
 {
-    let mut a = Array::<u64, _>::ones(10240);
+    let mut a = Array::<u64, _>::ones((10240,));
     a.slice_axis_inplace(Axis(0), Slice::new(0, None, 2));
     bench.iter(|| {
         a.iter().fold(0, |acc, &x| acc + x)
@@ -356,7 +356,7 @@ fn iter_sum_1d_strided_fold(bench: &mut Bencher)
 #[bench]
 fn iter_sum_1d_strided_rfold(bench: &mut Bencher)
 {
-    let mut a = Array::<u64, _>::ones(10240);
+    let mut a = Array::<u64, _>::ones((10240,));
     a.slice_axis_inplace(Axis(0), Slice::new(0, None, 2));
     bench.iter(|| {
         a.iter().rfold(0, |acc, &x| acc + x)

--- a/blas-tests/tests/oper.rs
+++ b/blas-tests/tests/oper.rs
@@ -183,9 +183,9 @@ fn reference_mat_vec_mul<A, S, S2>(lhs: &ArrayBase<S, Ix2>, rhs: &ArrayBase<S2, 
           S: Data<Elem=A>,
           S2: Data<Elem=A>,
 {
-    let ((m, _), k) = (lhs.dim(), rhs.dim());
+    let ((m, _), (k,)) = (lhs.dim(), rhs.dim());
     reference_mat_mul(lhs, &rhs.to_owned().into_shape((k, 1)).unwrap())
-        .into_shape(m).unwrap()
+        .into_shape((m,)).unwrap()
 }
 
 // simple, slow, correct (hopefully) mat mul
@@ -195,9 +195,9 @@ fn reference_vec_mat_mul<A, S, S2>(lhs: &ArrayBase<S, Ix1>, rhs: &ArrayBase<S2, 
           S: Data<Elem=A>,
           S2: Data<Elem=A>,
 {
-    let (m, (_, n)) = (lhs.dim(), rhs.dim());
+    let ((m,), (_, n)) = (lhs.dim(), rhs.dim());
     reference_mat_mul(&lhs.to_owned().into_shape((1, m)).unwrap(), rhs)
-        .into_shape(n).unwrap()
+        .into_shape((n,)).unwrap()
 }
 
 #[test]
@@ -309,7 +309,7 @@ fn mat_mul_broadcast() {
     let x1 = 1.;
     let x = Array::from_vec(vec![x1]);
     let b0 = x.broadcast((n, k)).unwrap();
-    let b1 = Array::from_elem(n, x1);
+    let b1 = Array::from_elem((n,), x1);
     let b1 = b1.broadcast((n, k)).unwrap();
     let b2 = Array::from_elem((n, k), x1);
 

--- a/examples/axis_ops.rs
+++ b/examples/axis_ops.rs
@@ -51,7 +51,7 @@ fn main() {
         *elt = i;
     }
     regularize(&mut b).ok();
-    let mut b = b.into_shape(a.len()).unwrap();
+    let mut b = b.into_shape((a.len(),)).unwrap();
     regularize(&mut b).ok();
     b.invert_axis(Axis(0));
     regularize(&mut b).ok();

--- a/examples/zip_many.rs
+++ b/examples/zip_many.rs
@@ -25,7 +25,7 @@ fn main() {
 
     // sum of each row
     let ax = Axis(0);
-    let mut sums = Array::zeros(a.len_of(ax));
+    let mut sums = Array::zeros((a.len_of(ax),));
     azip!(mut sums, ref a (a.axis_iter(ax)) in { *sums = a.sum() });
 
     // sum of each chunk

--- a/src/arraytraits.rs
+++ b/src/arraytraits.rs
@@ -230,7 +230,7 @@ impl<'a, A, Slice: ?Sized> From<&'a Slice> for ArrayView<'a, A, Ix1>
             );
         }
         unsafe {
-            Self::from_shape_ptr(xs.len(), xs.as_ptr())
+            Self::from_shape_ptr((xs.len(),), xs.as_ptr())
         }
     }
 }
@@ -262,7 +262,7 @@ impl<'a, A, Slice: ?Sized> From<&'a mut Slice> for ArrayViewMut<'a, A, Ix1>
             );
         }
         unsafe {
-            Self::from_shape_ptr(xs.len(), xs.as_mut_ptr())
+            Self::from_shape_ptr((xs.len(),), xs.as_mut_ptr())
         }
     }
 }

--- a/src/dimension/conversion.rs
+++ b/src/dimension/conversion.rs
@@ -11,7 +11,7 @@
 use std::ops::{Index, IndexMut};
 use num_traits::Zero;
 
-use crate::{Ix, Ix1, IxDyn, Dimension, Dim, IxDynImpl};
+use crate::{Ix, IxDyn, Dimension, Dim, IxDynImpl};
 
 /// $m: macro callback
 /// $m is called with $arg and then the indices corresponding to the size argument
@@ -41,12 +41,6 @@ macro_rules! index_item {
 pub trait IntoDimension {
     type Dim: Dimension;
     fn into_dimension(self) -> Self::Dim;
-}
-
-impl IntoDimension for Ix {
-    type Dim = Ix1;
-    #[inline(always)]
-    fn into_dimension(self) -> Ix1 { Ix1(self) }
 }
 
 impl<D> IntoDimension for D where D: Dimension {

--- a/src/dimension/dimension_trait.rs
+++ b/src/dimension/dimension_trait.rs
@@ -62,7 +62,7 @@ pub trait Dimension : Clone + Eq + Debug + Send + Sync + Default +
     type SliceArg: ?Sized + AsRef<[SliceOrIndex]>;
     /// Pattern matching friendly form of the dimension value.
     ///
-    /// - For `Ix1`: `usize`,
+    /// - For `Ix1`: `(usize)`,
     /// - For `Ix2`: `(usize, usize)`
     /// - and so on..
     /// - For `IxDyn`: `IxDyn`
@@ -402,7 +402,7 @@ impl Dimension for Dim<[Ix; 0]> {
 impl Dimension for Dim<[Ix; 1]> {
     const NDIM: Option<usize> = Some(1);
     type SliceArg = [SliceOrIndex; 1];
-    type Pattern = Ix;
+    type Pattern = (Ix,);
     type Smaller = Ix0;
     type Larger = Ix2;
     #[inline]
@@ -413,7 +413,7 @@ impl Dimension for Dim<[Ix; 1]> {
     fn slice_mut(&mut self) -> &mut [Ix] { self.ixm() }
     #[inline]
     fn into_pattern(self) -> Self::Pattern {
-        get!(&self, 0)
+        self.ix().convert()
     }
     #[inline]
     fn zeros(ndim: usize) -> Self {

--- a/src/dimension/ndindex.rs
+++ b/src/dimension/ndindex.rs
@@ -47,6 +47,16 @@ unsafe impl NdIndex<Ix0> for () {
     }
 }
 
+unsafe impl NdIndex<Ix1> for (Ix,) {
+    #[inline]
+    fn index_checked(&self, dim: &Ix1, strides: &Ix1) -> Option<isize> {
+        dim.stride_offset_checked(strides, &Ix1(self.0))
+    }
+    #[inline(always)]
+    fn index_unchecked(&self, strides: &Ix1) -> isize {
+        stride_offset(self.0, get!(strides, 0))
+    }
+}
 unsafe impl NdIndex<Ix2> for (Ix, Ix) {
     #[inline]
     fn index_checked(&self, dim: &Ix2, strides: &Ix2) -> Option<isize> {

--- a/src/doc/ndarray_for_numpy_users/simple_math.rs
+++ b/src/doc/ndarray_for_numpy_users/simple_math.rs
@@ -72,7 +72,7 @@
 //! let odd_sum = a.slice(s![.., 1..;2]).sum();
 //!
 //! // Create a 1-D array of exp(index).
-//! let b = Array::from_shape_fn(4, |i| (i as f64).exp());
+//! let b = Array::from_shape_fn((4,), |(i,)| (i as f64).exp());
 //!
 //! // Add b to a (broadcasting to rows).
 //! let c = a + &b;

--- a/src/impl_constructors.rs
+++ b/src/impl_constructors.rs
@@ -48,7 +48,7 @@ impl<S, A> ArrayBase<S, Ix1>
                 "Length must fit in `isize`.",
             );
         }
-        unsafe { Self::from_shape_vec_unchecked(v.len() as Ix, v) }
+        unsafe { Self::from_shape_vec_unchecked((v.len() as Ix,), v) }
     }
 
     /// Create a one-dimensional array from an iterable.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -416,7 +416,7 @@ pub type Ixs = isize;
 ///
 /// // 2. Use Zip to pair each row in 2D `a` with elements in 1D `b`
 /// use ndarray::Zip;
-/// let mut b = Array::zeros(a.rows());
+/// let mut b = Array::zeros((a.rows(),));
 ///
 /// Zip::from(a.genrows())
 ///     .and(&mut b)

--- a/src/linalg/impl_linalg.rs
+++ b/src/linalg/impl_linalg.rs
@@ -79,7 +79,7 @@ impl<A, S> ArrayBase<S, Ix1>
         let mut sum = A::zero();
         for i in 0..self.len() {
             unsafe {
-                sum = sum.clone() + self.uget(i).clone() * rhs.uget(i).clone();
+                sum = sum.clone() + self.uget((i,)).clone() * rhs.uget((i,)).clone();
             }
         }
         sum
@@ -312,14 +312,14 @@ impl<A, S, S2> Dot<ArrayBase<S2, Ix1>> for ArrayBase<S, Ix2>
     type Output = Array<A, Ix1>;
     fn dot(&self, rhs: &ArrayBase<S2, Ix1>) -> Array<A, Ix1>
     {
-        let ((m, a), n) = (self.dim(), rhs.dim());
+        let ((m, a), (n,)) = (self.dim(), rhs.dim());
         if a != n {
             dot_shape_error(m, a, n, 1);
         }
 
         // Avoid initializing the memory in vec -- set it during iteration
         unsafe {
-            let mut c = Array::uninitialized(m);
+            let mut c = Array::uninitialized((m,));
             general_mat_vec_mul(A::one(), self, rhs, A::zero(), &mut c);
             c
         }
@@ -574,8 +574,8 @@ pub fn general_mat_vec_mul<A, S1, S2, S3>(alpha: A,
           S3: DataMut<Elem=A>,
           A: LinalgScalar,
 {
-    let ((m, k), k2) = (a.dim(), x.dim());
-    let m2 = y.dim();
+    let ((m, k), (k2,)) = (a.dim(), x.dim());
+    let (m2,) = y.dim();
     if k != k2 || m != m2 {
         general_dot_shape_error(m, k, k2, 1, m2, 1);
     } else {

--- a/src/zip/mod.rs
+++ b/src/zip/mod.rs
@@ -437,7 +437,7 @@ impl<'a, A, D: Dimension> NdProducer for ArrayViewMut<'a, A, D> {
 ///
 /// use ndarray::{Array1, Axis};
 ///
-/// let mut totals = Array1::zeros(a.rows());
+/// let mut totals = Array1::zeros((a.rows(),));
 ///
 /// Zip::from(&mut totals)
 ///     .and(a.genrows())

--- a/src/zip/zipmacro.rs
+++ b/src/zip/zipmacro.rs
@@ -103,7 +103,7 @@
 ///     //
 ///     // The row is an array view; use the 'ref' rule on the row, to avoid the
 ///     // default which is to dereference the produced item.
-///     let mut totals = Array1::zeros(a.rows());
+///     let mut totals = Array1::zeros((a.rows(),));
 ///
 ///     azip!(mut totals, ref row (a.genrows()) in {
 ///         *totals = row.sum();

--- a/tests/array-construct.rs
+++ b/tests/array-construct.rs
@@ -64,7 +64,7 @@ fn test_from_fn_c0() {
 
 #[test]
 fn test_from_fn_c1() {
-    let a = Array::from_shape_fn(28, |i| i);
+    let a = Array::from_shape_fn((28,), |i| i);
     for (i, elt) in a.indexed_iter() {
         assert_eq!(i, *elt);
     }
@@ -96,7 +96,7 @@ fn test_from_fn_f0() {
 
 #[test]
 fn test_from_fn_f1() {
-    let a = Array::from_shape_fn(28.f(), |i| i);
+    let a = Array::from_shape_fn((28,).f(), |i| i);
     for (i, elt) in a.indexed_iter() {
         assert_eq!(i, *elt);
     }
@@ -138,7 +138,7 @@ fn deny_wraparound_from_vec() {
     let five = vec![0; 5];
     let five_large = Array::from_shape_vec((3, 7, 29, 36760123, 823996703), five.clone());
     assert!(five_large.is_err());
-    let six = Array::from_shape_vec(6, five.clone());
+    let six = Array::from_shape_vec((6,), five.clone());
     assert!(six.is_err());
 }
 
@@ -161,7 +161,7 @@ fn deny_wraparound_zeros() {
 #[test]
 fn deny_wraparound_reshape() {
     //2^64 + 5 = 18446744073709551621 = 3×7×29×36760123×823996703  (5 distinct prime factors)
-    let five = Array::<f32, _>::zeros(5);
+    let five = Array::<f32, _>::zeros((5,));
     let _five_large = five.into_shape((3, 7, 29, 36760123, 823996703)).unwrap();
 }
 

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -404,7 +404,7 @@ fn test_multislice_intersecting() {
 
 #[test]
 fn test_multislice_eval_args_only_once() {
-    let mut arr = Array1::<u8>::zeros(10);
+    let mut arr = Array1::<u8>::zeros((10,));
     let mut eval_count = 0;
     {
         let mut slice = || {
@@ -540,7 +540,7 @@ fn test_add()
 #[test]
 fn test_multidim()
 {
-    let mut mat = ArcArray::zeros(2*3*4*5*6).reshape((2,3,4,5,6));
+    let mut mat = ArcArray::zeros((2*3*4*5*6,)).reshape((2,3,4,5,6));
     mat[(0,0,0,0,0)] = 22u8;
     {
         for (i, elt) in mat.iter_mut().enumerate() {
@@ -603,7 +603,7 @@ fn test_cow()
     assert_eq!(n[[0, 0]], 1);
     assert_eq!(n[[0, 1]], 0);
     assert_eq!(n.get((0, 1)), Some(&0));
-    let mut rev = mat.reshape(4);
+    let mut rev = mat.reshape((4,));
     rev.slice_collapse(s![..;-1]);
     assert_eq!(rev[0], 4);
     assert_eq!(rev[1], 3);
@@ -643,7 +643,7 @@ fn test_cow_shrink()
     assert_eq!(n[[0, 1]], 0);
     assert_eq!(n.get((0, 1)), Some(&0));
     // small has non-C strides this way
-    let mut small = mat.reshape(6);
+    let mut small = mat.reshape((6,));
     small.slice_collapse(s![4..;-1]);
     assert_eq!(small[0], 6);
     assert_eq!(small[1], 5);
@@ -709,14 +709,14 @@ fn test_select(){
 fn diag()
 {
     let d = arr2(&[[1., 2., 3.0f32]]).into_diag();
-    assert_eq!(d.dim(), 1);
+    assert_eq!(d.dim(), (1,));
     let a = arr2(&[[1., 2., 3.0f32], [0., 0., 0.]]);
     let d = a.view().into_diag();
-    assert_eq!(d.dim(), 2);
+    assert_eq!(d.dim(), (2,));
     let d = arr2::<f32, _>(&[[]]).into_diag();
-    assert_eq!(d.dim(), 0);
+    assert_eq!(d.dim(), (0,));
     let d = ArcArray::<f32, _>::zeros(()).into_diag();
-    assert_eq!(d.dim(), 1);
+    assert_eq!(d.dim(), (1,));
 }
 
 /// Check that the merged shape is correct.
@@ -893,7 +893,7 @@ fn standard_layout()
     assert!(x1.is_standard_layout());
     let x2 = a.index_axis(Axis(1), 0);
     assert!(!x2.is_standard_layout());
-    let x3 = ArrayView1::from_shape(1.strides(2), &[1]).unwrap();
+    let x3 = ArrayView1::from_shape((1,).strides((2,)), &[1]).unwrap();
     assert!(x3.is_standard_layout());
     let x4 = ArrayView2::from_shape((0, 2).strides((0, 1)), &[1, 2]).unwrap();
     assert!(x4.is_standard_layout());
@@ -908,7 +908,7 @@ fn assign()
     assert_eq!(a, b);
 
     /* Test broadcasting */
-    a.assign(&ArcArray::zeros(1));
+    a.assign(&ArcArray::zeros((1,)));
     assert_eq!(a, ArcArray::zeros((2, 2)));
 
     /* Test other type */
@@ -977,7 +977,7 @@ fn zero_axes()
 
     // we can even get a subarray of b
     let bsub = b.index_axis(Axis(0), 2);
-    assert_eq!(bsub.dim(), 0);
+    assert_eq!(bsub.dim(), (0,));
 }
 
 #[test]
@@ -1118,7 +1118,7 @@ macro_rules! assert_matches {
 #[test]
 fn from_vec_dim_stride_empty_1d() {
     let empty: [f32; 0] = [];
-    assert_matches!(Array::from_shape_vec(0.strides(1), empty.to_vec()),
+    assert_matches!(Array::from_shape_vec((0,).strides((1,)), empty.to_vec()),
                     Ok(_));
 }
 
@@ -1470,10 +1470,10 @@ fn insert_axis_f() {
     assert!(::std::panic::catch_unwind(
         || Array0::from_shape_vec(().f(), vec![1]).unwrap().insert_axis(Axis(1))).is_err());
 
-    test_insert_f!(Array1::<u8>::zeros((3).f()), 0, Array2::<u8>::zeros((1, 3)));
-    test_insert_f!(Array1::<u8>::zeros((3).f()), 1, Array2::<u8>::zeros((3, 1)));
+    test_insert_f!(Array1::<u8>::zeros((3,).f()), 0, Array2::<u8>::zeros((1, 3)));
+    test_insert_f!(Array1::<u8>::zeros((3,).f()), 1, Array2::<u8>::zeros((3, 1)));
     assert!(::std::panic::catch_unwind(
-        || Array1::<u8>::zeros((3).f()).insert_axis(Axis(2))).is_err());
+        || Array1::<u8>::zeros((3,).f()).insert_axis(Axis(2))).is_err());
 
     test_insert_f!(Array3::<u8>::zeros((3, 4, 5).f()), 1, Array4::<u8>::zeros((3, 1, 4, 5)));
     assert!(::std::panic::catch_unwind(

--- a/tests/azip.rs
+++ b/tests/azip.rs
@@ -11,7 +11,7 @@ use std::mem::swap;
 
 #[test]
 fn test_azip1() {
-    let mut a = Array::zeros(62);
+    let mut a = Array::zeros((62,));
     let mut x = 0;
     azip!(mut a in { *a = x; x += 1; });
     assert_equal(cloned(&a), 0..a.len());
@@ -49,7 +49,7 @@ fn test_azip2_sum() {
     let c = Array::from_shape_fn((5, 10), |(i, j)| f32::exp((i + j) as f32));
     for i in 0..2 {
         let ax = Axis(i);
-        let mut b = Array::zeros(c.len_of(ax));
+        let mut b = Array::zeros((c.len_of(ax),));
         azip!(mut b, ref c (c.axis_iter(ax)) in { *b = c.sum() });
         assert!(b.all_close(&c.sum_axis(Axis(1 - i)), 1e-6));
     }
@@ -150,7 +150,7 @@ fn test_clone() {
 
 #[test]
 fn test_indices_1() {
-    let mut a1 = Array::default(12);
+    let mut a1 = Array::default((12,));
     for (i, elt) in a1.indexed_iter_mut() {
         *elt = i;
     }

--- a/tests/broadcast.rs
+++ b/tests/broadcast.rs
@@ -14,7 +14,7 @@ fn broadcast_1()
 
     let c_dim = Dim([2, 1]);
     let c = ArcArray::linspace(0., 1., c_dim.size()).reshape(c_dim);
-    assert!(c.broadcast(1).is_none());
+    assert!(c.broadcast((1,)).is_none());
     assert!(c.broadcast(()).is_none());
     assert!(c.broadcast((2, 1)).is_some());
     assert!(c.broadcast((2, 2)).is_some());
@@ -24,8 +24,8 @@ fn broadcast_1()
     /* () can be broadcast to anything */
     let z = ArcArray::<f32,_>::zeros(());
     assert!(z.broadcast(()).is_some());
-    assert!(z.broadcast(1).is_some());
-    assert!(z.broadcast(3).is_some());
+    assert!(z.broadcast((1,)).is_some());
+    assert!(z.broadcast((3,)).is_some());
     assert!(z.broadcast((7,2,9)).is_some());
 }
 
@@ -46,7 +46,7 @@ fn test_add_incompat()
 {
     let a_dim = Dim([2, 4, 2, 2]);
     let mut a = ArcArray::linspace(0.0, 1., a_dim.size()).reshape(a_dim);
-    let incompat = ArcArray::from_elem(3, 1.0f32);
+    let incompat = ArcArray::from_elem((3,), 1.0f32);
     a += &incompat;
 }
 
@@ -58,7 +58,7 @@ fn test_broadcast() {
     let x = Array::from_vec(vec![x1]);
     let b0 = x.broadcast((n, k)).unwrap();
     // b1 broadcast n -> n, k
-    let b1 = Array::from_elem(n, x1);
+    let b1 = Array::from_elem((n,), x1);
     let b1 = b1.broadcast((n, k)).unwrap();
     // b2 is n, k
     let b2 = Array::from_elem((n, k), x1);
@@ -76,8 +76,8 @@ fn test_broadcast_1d() {
     let x1 = 1.;
     // b0 broadcast 1 -> n
     let x = Array::from_vec(vec![x1]);
-    let b0 = x.broadcast(n).unwrap();
-    let b2 = Array::from_elem(n, x1);
+    let b0 = x.broadcast((n,)).unwrap();
+    let b2 = Array::from_elem((n,), x1);
 
     println!("b0=\n{:?}", b0);
     println!("b2=\n{:?}", b2);

--- a/tests/dimension.rs
+++ b/tests/dimension.rs
@@ -165,7 +165,7 @@ fn min_stride_axis() {
 
 #[test]
 fn max_stride_axis() {
-    let a = ArrayF32::zeros(10);
+    let a = ArrayF32::zeros((10,));
     assert_eq!(a.max_stride_axis(), Axis(0));
 
     let a = ArrayF32::zeros((3, 3));
@@ -265,7 +265,7 @@ fn test_generic_operations() {
 
     test_dim(&Dim([2, 3, 4]));
     test_dim(&Dim(vec![2, 3, 4, 1]));
-    test_dim(&Dim(2));
+    test_dim(&Dim((2,)));
 }
 
 #[test]
@@ -277,7 +277,7 @@ fn test_array_view() {
 
     test_dim(&Dim([1, 2, 4]));
     test_dim(&Dim(vec![1, 1, 2, 3]));
-    test_dim(&Dim(7));
+    test_dim(&Dim((7,)));
 }
 
 #[test]

--- a/tests/iterators.rs
+++ b/tests/iterators.rs
@@ -42,7 +42,7 @@ fn iter_size_hint() {
 fn indexed()
 {
     let a = ArcArray::linspace(0., 7., 8);
-    for (i, elt) in a.indexed_iter() {
+    for ((i,), elt) in a.indexed_iter() {
         assert_eq!(i, *elt as Ix);
     }
     let a = a.reshape((2, 4, 1));
@@ -516,7 +516,7 @@ fn test_fold() {
 #[test]
 fn test_rfold() {
     {
-        let mut a = Array1::<i32>::default(256);
+        let mut a = Array1::<i32>::default((256,));
         a += 1;
         let mut iter = a.iter();
         iter.next();
@@ -525,7 +525,7 @@ fn test_rfold() {
 
     // Test strided arrays
     {
-        let mut a = Array1::<i32>::default(256);
+        let mut a = Array1::<i32>::default((256,));
         a.slice_axis_inplace(Axis(0), Slice::new(0, None, 2));
         a += 1;
         let mut iter = a.iter();
@@ -534,7 +534,7 @@ fn test_rfold() {
     }
 
     {
-        let mut a = Array1::<i32>::default(256);
+        let mut a = Array1::<i32>::default((256,));
         a.slice_axis_inplace(Axis(0), Slice::new(0, None, -2));
         a += 1;
         let mut iter = a.iter();

--- a/tests/numeric.rs
+++ b/tests/numeric.rs
@@ -50,12 +50,12 @@ fn sum_mean()
 #[test]
 fn sum_mean_empty() {
     assert_eq!(Array3::<f32>::ones((2, 0, 3)).sum(), 0.);
-    assert_eq!(Array1::<f32>::ones(0).sum_axis(Axis(0)), arr0(0.));
+    assert_eq!(Array1::<f32>::ones((0,)).sum_axis(Axis(0)), arr0(0.));
     assert_eq!(
         Array3::<f32>::ones((2, 0, 3)).sum_axis(Axis(1)),
         Array::zeros((2, 3)),
     );
-    let a = Array1::<f32>::ones(0).mean_axis(Axis(0));
+    let a = Array1::<f32>::ones((0,)).mean_axis(Axis(0));
     assert_eq!(a, None);
     let a = Array3::<f32>::ones((2, 0, 3)).mean_axis(Axis(1));
     assert_eq!(a, None);

--- a/tests/oper.rs
+++ b/tests/oper.rs
@@ -348,9 +348,9 @@ fn reference_mat_vec_mul<A, S, S2>(lhs: &ArrayBase<S, Ix2>, rhs: &ArrayBase<S2, 
           S: Data<Elem=A>,
           S2: Data<Elem=A>,
 {
-    let ((m, _), k) = (lhs.dim(), rhs.dim());
+    let ((m, _), (k,)) = (lhs.dim(), rhs.dim());
     reference_mat_mul(lhs, &rhs.to_owned().into_shape((k, 1)).unwrap())
-        .into_shape(m).unwrap()
+        .into_shape((m,)).unwrap()
 }
 
 // simple, slow, correct (hopefully) mat mul
@@ -360,9 +360,9 @@ fn reference_vec_mat_mul<A, S, S2>(lhs: &ArrayBase<S, Ix1>, rhs: &ArrayBase<S2, 
           S: Data<Elem=A>,
           S2: Data<Elem=A>,
 {
-    let (m, (_, n)) = (lhs.dim(), rhs.dim());
+    let ((m,), (_, n)) = (lhs.dim(), rhs.dim());
     reference_mat_mul(&lhs.to_owned().into_shape((1, m)).unwrap(), rhs)
-        .into_shape(n).unwrap()
+        .into_shape((n,)).unwrap()
 }
 
 #[test]
@@ -474,7 +474,7 @@ fn mat_mul_broadcast() {
     let x1 = 1.;
     let x = Array::from_vec(vec![x1]);
     let b0 = x.broadcast((n, k)).unwrap();
-    let b1 = Array::from_elem(n, x1);
+    let b1 = Array::from_elem((n,), x1);
     let b1 = b1.broadcast((n, k)).unwrap();
     let b2 = Array::from_elem((n, k), x1);
 

--- a/tests/par_azip.rs
+++ b/tests/par_azip.rs
@@ -10,8 +10,8 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 #[test]
 fn test_par_azip1() {
-    let mut a = Array::zeros(62);
-    let b = Array::from_elem(62, 42);
+    let mut a = Array::zeros((62,));
+    let b = Array::from_elem((62,), 42);
     par_azip!(mut a in { *a = 42 });
     assert_eq!(a, b);
 }
@@ -53,7 +53,7 @@ fn test_zip_dim_mismatch_1() {
 
 #[test]
 fn test_indices_1() {
-    let mut a1 = Array::default(12);
+    let mut a1 = Array::default((12,));
     for (i, elt) in a1.indexed_iter_mut() {
         *elt = i;
     }

--- a/tests/windows.rs
+++ b/tests/windows.rs
@@ -41,9 +41,9 @@ fn windows_iterator_oversized() {
 /// Simple test for iterating 1d-arrays via `Windows`.
 #[test]
 fn windows_iterator_1d() {
-    let a = Array::from_iter(10..20).into_shape(10).unwrap();
+    let a = Array::from_iter(10..20).into_shape((10,)).unwrap();
     itertools::assert_equal(
-        a.windows(Dim(4)),
+        a.windows(Dim((4,))),
         vec![
             arr1(&[10, 11, 12, 13]),
             arr1(&[11, 12, 13, 14]),


### PR DESCRIPTION
Removes the feature that an usize may be used as a pattern for a one-dimensional shape.

- Closes https://github.com/rust-ndarray/ndarray/issues/622
- The documentation wasn't extensively reviewed.