### PR TITLE
IntoNdProducer for &mut &mut ArrayBase

### DIFF
--- a/src/zip/mod.rs
+++ b/src/zip/mod.rs
@@ -220,11 +220,40 @@ impl<'a, A: 'a, S, D> IntoNdProducer for &'a ArrayBase<S, D>
     }
 }
 
+/// An array reference is an n-dimensional producer of element references
+/// (like ArrayView).
+impl<'a, 'b, A: 'a + 'b, S, D> IntoNdProducer for &'b &'a ArrayBase<S, D>
+    where D: Dimension,
+          S: Data<Elem=A>,
+{
+    type Item = &'a A;
+    type Dim = D;
+    type Output = ArrayView<'a, A, D>;
+    fn into_producer(self) -> Self::Output {
+        self.view()
+    }
+}
+
 /// A mutable array reference is an n-dimensional producer of mutable element
 /// references (like ArrayViewMut).
 impl<'a, A: 'a, S, D> IntoNdProducer for &'a mut ArrayBase<S, D>
     where D: Dimension,
           S: DataMut<Elem=A>,
+{
+    type Item = &'a mut A;
+    type Dim = D;
+    type Output = ArrayViewMut<'a, A, D>;
+    fn into_producer(self) -> Self::Output {
+        self.view_mut()
+    }
+}
+
+/// A mutable array reference is an n-dimensional producer of mutable element
+/// references (like ArrayViewMut).
+impl<'a, 'b, A: 'a + 'b, S, D> IntoNdProducer for &'a mut &'b mut ArrayBase<S, D>
+    where D: Dimension,
+          S: DataMut<Elem=A>,
+          'b: 'a
 {
     type Item = &'a mut A;
     type Dim = D;

--- a/tests/zip.rs
+++ b/tests/zip.rs
@@ -1,0 +1,9 @@
+use ndarray::{azip, ArrayBase, Data, DataMut, Dimension};
+
+#[allow(unused)]
+fn zip_ref_ref<Sa, Sb, D: Dimension>(mut a: &mut ArrayBase<Sa, D>, b: &ArrayBase<Sb, D>)
+where Sa: DataMut<Elem = f64>,
+      Sb: Data<Elem = f64>
+{
+    azip!(mut a, b in { *a = 2.0*b });
+}


### PR DESCRIPTION
Objective
----------
make the following code works

```rust
fn zip_ref_ref<Sa, Sb, D: Dimension>(mut a: &mut ArrayBase<Sa, D>, b: &ArrayBase<Sb, D>)
where Sa: DataMut<Elem = f64>,
      Sb: Data<Elem = f64>
{
    azip!(mut a, b in { *a = 2.0*b });
}
```

Problem
-----------
Current master reports an error:

```
error[E0277]: the trait bound `&mut &mut ndarray::ArrayBase<Sa, D>: ndarray::zip::NdProducer` is not satisfied
 --> tests/zip.rs:8:5
  |
8 |     azip!(mut a, b in { *a = 2.0*b });
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `ndarray::zip::NdProducer` is not implemented for `&mut &mut ndarray::ArrayBase<Sa, D>`
  |
  = help: the following implementations were found:
            <ndarray::ArrayBase<ndarray::ViewRepr<&'a A>, D> as ndarray::zip::NdProducer>
            <ndarray::ArrayBase<ndarray::ViewRepr<&'a mut A>, D> as ndarray::zip::NdProducer>
  = note: required by `<ndarray::zip::Zip<(P,), D>>::from`
  = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
```

This occurs because `IntoNdProducer` is implemented for `&mut ArrayBase` but not for `&mut &mut ArrayBase`, and thus the following works

```rust
fn zip_ref_ref<Sa, Sb, D: Dimension>(mut a: &mut ArrayBase<Sa, D>, b: &ArrayBase<Sb, D>)
where Sa: DataMut<Elem = f64>,
      Sb: Data<Elem = f64>
{
    azip!(mut a (&mut *a), b (&*b) in { *a = 2.0*b });  // deref by hand !
}
```

But it is not intuitive.

Solution
------------
Implement `IntoNdProducer` for `&&ArrayBase` and `&mut &mut ArrayBase`.

- We do not have to implement it for `&&&ArrayBase` because we usually do not use `&&ArrayBase` as a function argument.
- I cannot find a way using `AsRef<ArrayBase>` or other way. `IntoNdProducer` is already defined for various types, and generic implementation break them.