### PR TITLE
Change syntax of azip! to be similar to for loops

### DIFF
--- a/benches/bench1.rs
+++ b/benches/bench1.rs
@@ -270,7 +270,7 @@ fn add_2d_zip_alloc(bench: &mut test::Bencher) {
     let b = Array::<i32, _>::zeros((ADD2DSZ, ADD2DSZ));
     bench.iter(|| unsafe {
         let mut c = Array::uninitialized(a.dim());
-        azip!(a, b, mut c in { *c = a + b });
+        azip!((&a in &a, &b in &b, c in &mut c) *c = a + b);
         c
     });
 }

--- a/benches/chunks.rs
+++ b/benches/chunks.rs
@@ -12,7 +12,7 @@ fn chunk2x2_iter_sum(bench: &mut Bencher) {
     let chunksz = (2, 2);
     let mut sum = Array::zeros(a.exact_chunks(chunksz).raw_dim());
     bench.iter(|| {
-        azip!(ref a (a.exact_chunks(chunksz)), mut sum in {
+        azip!((a in a.exact_chunks(chunksz), sum in &mut sum) {
             *sum = a.iter().sum::<f32>();
         });
     });
@@ -24,7 +24,7 @@ fn chunk2x2_sum(bench: &mut Bencher) {
     let chunksz = (2, 2);
     let mut sum = Array::zeros(a.exact_chunks(chunksz).raw_dim());
     bench.iter(|| {
-        azip!(ref a (a.exact_chunks(chunksz)), mut sum in {
+        azip!((a in a.exact_chunks(chunksz), sum in &mut sum) {
             *sum = a.sum();
         });
     });

--- a/benches/iter.rs
+++ b/benches/iter.rs
@@ -155,7 +155,7 @@ fn sum_3_azip(bench: &mut Bencher) {
     let c = vec![1; ZIPSZ];
     bench.iter(|| {
         let mut s = 0;
-        azip!(a, b, c in {
+        azip!((&a in &a, &b in &b, &c in &c) {
             s += a + b + c;
         });
         s
@@ -182,7 +182,7 @@ fn vector_sum_3_azip(bench: &mut Bencher) {
     let b = vec![1.; ZIPSZ];
     let mut c = vec![1.; ZIPSZ];
     bench.iter(|| {
-        azip!(a, b, mut c in {
+        azip!((&a in &a, &b in &b, c in &mut c) {
             *c += a + b;
         });
     });

--- a/benches/par_rayon.rs
+++ b/benches/par_rayon.rs
@@ -117,7 +117,7 @@ fn add(bench: &mut Bencher) {
     let c = Array2::<f64>::zeros((ADDN, ADDN));
     let d = Array2::<f64>::zeros((ADDN, ADDN));
     bench.iter(|| {
-        azip!(mut a, b, c, d in {
+        azip!((a in &mut a, &b in &b, &c in &c, &d in &d) {
             *a += b.exp() + c.exp() + d.exp();
         });
     });

--- a/examples/zip_many.rs
+++ b/examples/zip_many.rs
@@ -20,23 +20,23 @@ fn main() {
 
     {
         let a = a.view_mut().reversed_axes();
-        azip!(mut a (a), b (b.t()) in { *a = b });
+        azip!((a in a, &b in b.t()) *a = b);
     }
     assert_eq!(a, b);
 
-    azip!(mut a, b, c in { *a = b + c; });
+    azip!((a in &mut a, &b in &b, &c in c) *a = b + c);
     assert_eq!(a, &b + &c);
 
     // sum of each row
     let ax = Axis(0);
     let mut sums = Array::zeros(a.len_of(ax));
-    azip!(mut sums, ref a (a.axis_iter(ax)) in { *sums = a.sum() });
+    azip!((s in &mut sums, a in a.axis_iter(ax)) *s = a.sum());
 
     // sum of each chunk
     let chunk_sz = (2, 2);
     let nchunks = (n / chunk_sz.0, n / chunk_sz.1);
     let mut sums = Array::zeros(nchunks);
-    azip!(mut sums, ref a (a.exact_chunks(chunk_sz)) in { *sums = a.sum() });
+    azip!((s in &mut sums, a in a.exact_chunks(chunk_sz)) *s = a.sum());
 
     // Let's imagine we split to parallelize
     {

--- a/src/doc/ndarray_for_numpy_users/coord_transform.rs
+++ b/src/doc/ndarray_for_numpy_users/coord_transform.rs
@@ -105,7 +105,7 @@
 //!     let bunge = Array2::<f64>::ones((3, nelems));
 //!
 //!     let mut rmat = Array::zeros((3, 3, nelems).f());
-//!     azip!(mut rmat (rmat.axis_iter_mut(Axis(2))), ref bunge (bunge.axis_iter(Axis(1))) in {
+//!     azip!((mut rmat in rmat.axis_iter_mut(Axis(2)), bunge in bunge.axis_iter(Axis(1))) {
 //!         let s1 = bunge[0].sin();
 //!         let c1 = bunge[0].cos();
 //!         let s2 = bunge[1].sin();
@@ -129,8 +129,8 @@
 //!     let eye2d = Array2::<f64>::eye(3);
 //!
 //!     let mut rotated = Array3::<f64>::zeros((3, 3, nelems).f());
-//!     azip!(mut rotated (rotated.axis_iter_mut(Axis(2)), rmat (rmat.axis_iter(Axis(2)))) in {
-//!         rotated.assign({ &rmat.dot(&eye2d) });
+//!     azip!((mut rotated in rotated.axis_iter_mut(Axis(2)), rmat in rmat.axis_iter(Axis(2))) {
+//!         rotated.assign(&rmat.dot(&eye2d));
 //!     });
 //! }
 //! ```

--- a/src/numeric/impl_numeric.rs
+++ b/src/numeric/impl_numeric.rs
@@ -247,7 +247,7 @@ where
         let mut sum_sq = Array::<A, _>::zeros(self.dim.remove_axis(axis));
         for (i, subview) in self.axis_iter(axis).enumerate() {
             let count = A::from_usize(i + 1).expect("Converting index to `A` must not fail.");
-            azip!(mut mean, mut sum_sq, x (subview) in {
+            azip!((mean in &mut mean, sum_sq in &mut sum_sq, &x in &subview) {
                 let delta = x - *mean;
                 *mean = *mean + delta / count;
                 *sum_sq = (x - *mean).mul_add(delta, *sum_sq);

--- a/tests/azip.rs
+++ b/tests/azip.rs
@@ -18,7 +18,7 @@ use std::mem::swap;
 fn test_azip1() {
     let mut a = Array::zeros(62);
     let mut x = 0;
-    azip!(mut a in { *a = x; x += 1; });
+    azip!((a in &mut a) { *a = x; x += 1; });
     assert_equal(cloned(&a), 0..a.len());
 }
 
@@ -26,7 +26,7 @@ fn test_azip1() {
 fn test_azip2() {
     let mut a = Array::zeros((5, 7));
     let b = Array::from_shape_fn(a.dim(), |(i, j)| 1. / (i + 2 * j) as f32);
-    azip!(mut a, b in { *a = b; });
+    azip!((a in &mut a, &b in &b) *a = b);
     assert_eq!(a, b);
 }
 
@@ -35,7 +35,7 @@ fn test_azip2_1() {
     let mut a = Array::zeros((5, 7));
     let b = Array::from_shape_fn((5, 10), |(i, j)| 1. / (i + 2 * j) as f32);
     let b = b.slice(s![..;-1, 3..]);
-    azip!(mut a, b in { *a = b; });
+    azip!((a in &mut a, &b in &b) *a = b);
     assert_eq!(a, b);
 }
 
@@ -44,7 +44,7 @@ fn test_azip2_3() {
     let mut b = Array::from_shape_fn((5, 10), |(i, j)| 1. / (i + 2 * j) as f32);
     let mut c = Array::from_shape_fn((5, 10), |(i, j)| f32::exp((i + j) as f32));
     let a = b.clone();
-    azip!(mut b, mut c in { swap(b, c) });
+    azip!((b in &mut b, c in &mut c) swap(b, c));
     assert_eq!(a, c);
     assert!(a != b);
 }
@@ -58,7 +58,7 @@ fn test_azip2_sum() {
     for i in 0..2 {
         let ax = Axis(i);
         let mut b = Array::zeros(c.len_of(ax));
-        azip!(mut b, ref c (c.axis_iter(ax)) in { *b = c.sum() });
+        azip!((b in &mut b, c in c.axis_iter(ax)) *b = c.sum());
         assert_abs_diff_eq!(b, c.sum_axis(Axis(1 - i)), epsilon = 1e-6);
     }
 }
@@ -75,7 +75,7 @@ fn test_azip3_slices() {
         *elt = i as f32;
     }
 
-    azip!(mut a (&mut a[..]), b (&b[..]), mut c (&mut c[..]) in {
+    azip!((a in &mut a[..], b in &b[..], c in &mut c[..]) {
         *a += b / 10.;
         *c = a.sin();
     });
@@ -115,7 +115,7 @@ fn test_zip_dim_mismatch_1() {
     let mut d = a.raw_dim();
     d[0] += 1;
     let b = Array::from_shape_fn(d, |(i, j)| 1. / (i + 2 * j) as f32);
-    azip!(mut a, b in { *a = b; });
+    azip!((a in &mut a, &b in &b) *a = b);
 }
 
 // Test that Zip handles memory layout correctly for
@@ -136,7 +136,7 @@ fn test_contiguous_but_not_c_or_f() {
     let correct_012 = a[[0, 1, 2]] + b[[0, 1, 2]];
 
     let mut ans = Array::zeros(a.dim().f());
-    azip!(mut ans, a, b in { *ans = a + b });
+    azip!((ans in &mut ans, &a in &a, &b in &b) *ans = a + b);
     println!("{:?}", a);
     println!("{:?}", b);
     println!("{:?}", ans);
@@ -200,7 +200,7 @@ fn test_indices_2() {
     }
 
     let mut count = 0;
-    azip!(index i, a1 in {
+    azip!((index i, &a1 in &a1) {
         count += 1;
         assert_eq!(a1, i);
     });


### PR DESCRIPTION
The `azip!` macro is a common source of confusion for both new and experienced users. I think this is largely due to its unique and somewhat non-intuitive dereferencing behavior. (For example, it's inconsistent that the pattern corresponding to `b` is `&b`, but the pattern corresponding to `mut a` is `mut a`. You can see why this is the case (you generally want to dereference in the immutable case but not the mutable case), but it's confusing.)

As I see it, the `azip!` macro is useful for two reasons:

1. It's more concise than `Zip::from` followed by `.and` and `.apply`.
2. It keeps the patterns and producer-generating expressions next to each other so that it's easy to see which parameter name corresponds to which producer.

This PR proposes a new syntax for `azip!`, based on standard `for` loops, that still has both of these qualities:

```rust
azip!((pat1 in expr1, pat2 in expr2, ...) body_expr)
```

So, for example, you would write

```rust
fn zip_ref_ref<Sa, Sb, D: Dimension>(a: &mut ArrayBase<Sa, D>, b: &ArrayBase<Sb, D>)
where Sa: DataMut<Elem = f64>,
      Sb: Data<Elem = f64>
{
    azip!((a in a, &b in b) *a = 2.0*b);
}
```

instead of

```rust
fn zip_ref_ref<Sa, Sb, D: Dimension>(a: &mut ArrayBase<Sa, D>, b: &ArrayBase<Sb, D>)
where Sa: DataMut<Elem = f64>,
      Sb: Data<Elem = f64>
{
    azip!(mut a (a), b (b) in { *a = 2.0*b });
}
```

(This example comes from #625.)

The goal of this new syntax is to match the behavior of `for` loops, which Rust users should be familiar with. The `pat` and `expr` in each `pat in expr` correspond directly to the `pat` and `expr` in `for pat in expr`: `pat` is the pattern of the item, and `expr` is the expression creating the producer/iterator.

The special `index` pattern is handled similarly to how it is now, for example

```rust
azip!((index (i, j), &b in &b, &c in &c) {
    a[[i, j]] = b - c;
});
```

The example above does show one disadvantage of this approach compared to the current version of `azip`: it's necessary to write `&b in &b`, while in the current version of `azip!`, this would simply be `b`. If desired, we could interpret `&b` as equivalent to `&b in &b`. Unfortunately, that wouldn't help with mutable references (because you don't want to dereference the item in the pattern). IMO, the additional clarity and consistency is worth the additional verbosity in that occurs some cases with this PR.

Please let me know what you think!

TODO: Change `par_azip` too.

Closes #625.