### PR TITLE
Add Code Coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,16 @@ language: rust
 
 sudo: required
 
-rust:
-  - 1.32.0
-  - stable
-  - beta
-  - nightly
-
 matrix:
+  include:
+    - rust: 1.32.0
+      env: FEATURES="blas serde-1 docs"
+    - rust: stable
+      env: FEATURES="blas serde-1 docs"
+    - rust: beta
+      env: FEATURES="blas serde-1 docs"
+    - rust: nightly
+      env: FEATURES="blas serde-1 docs nightly"
   allow_failures:
     - rust: beta
     - rust: nightly
@@ -16,7 +19,6 @@ matrix:
 env:
   global:
     - RUSTFLAGS="-D warnings"
-    - FEATURES="blas serde-1 docs"
 
 cache: cargo
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,34 +1,45 @@
 language: rust
-# use trusty for newer openblas
+
 sudo: required
-dist: trusty
+
+rust:
+  - 1.32.0
+  - stable
+  - beta
+  - nightly
+
 matrix:
-  include:
-    - rust: 1.32.0
-      env:
-       - FEATURES='test docs'
-       - RUSTFLAGS='-D warnings'
-    - rust: stable
-      env:
-       - FEATURES='test docs'
-       - RUSTFLAGS='-D warnings'
+  allow_failures:
     - rust: beta
-      env:
-       - FEATURES='test docs'
-       - CHANNEL='beta'
-       - RUSTFLAGS='-D warnings'
     - rust: nightly
-      env:
-       - FEATURES='test docs'
-       - CHANNEL='nightly'
+
 env:
   global:
-    - HOST=x86_64-unknown-linux-gnu
-    - CARGO_INCREMENTAL=0
+    - RUSTFLAGS="-D warnings"
+    - FEATURES="blas serde-1 docs"
+
+cache: cargo
+
 addons:
   apt:
+    update: true
     packages:
       - libopenblas-dev
       - gfortran
+      - libcurl4-openssl-dev
+      - libelf-dev
+      - libdw-dev
+      - cmake
+      - gcc
+      - binutils-dev
+      - libiberty-dev
+      - libgsl0-dev
+
+before_script:
+  - ./ci/before_script.sh
+
 script:
-  - ./scripts/all-tests.sh "$FEATURES" "$CHANNEL"
+  - ./ci/script.sh
+
+after_success:
+  - ./ci/after_success.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,17 @@ addons:
     packages:
       - libopenblas-dev
       - gfortran
-      - kcov
+      # kcov dependencies
+      - cmake
+      - g++
+      - pkg-config
+      - jq
+      - libcurl4-openssl-dev
+      - libelf-dev
+      - libdw-dev
+      - binutils-dev
+      - libiberty-dev
+
 
 before_script:
   - ./ci/before_script.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,14 +28,7 @@ addons:
     packages:
       - libopenblas-dev
       - gfortran
-      - libcurl4-openssl-dev
-      - libelf-dev
-      - libdw-dev
-      - cmake
-      - gcc
-      - binutils-dev
-      - libiberty-dev
-      - libgsl0-dev
+      - kcov
 
 before_script:
   - ./ci/before_script.sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,29 +28,25 @@ bench = false
 test = true
 
 [dependencies]
+itertools = { version = "0.8.0", default-features = false }
+matrixmultiply = "0.2.0"
+num-complex = "0.2"
 num-integer = "0.1.39"
 num-traits = "0.2"
-num-complex = "0.2"
-itertools = { version = "0.8.0", default-features = false }
 
+## Optional dependencies
+approx = { version = "0.3.2", optional = true }
+blas-src = { version = "0.2.0", optional = true, default-features = false }
+cblas-sys = { version = "0.1.4", optional = true, default-features = false }
+serde = { version = "1.0", optional = true }
 rayon = { version = "1.0.3", optional = true }
 
-approx = { version = "0.3.2", optional = true }
-
-# Use via the `blas` crate feature!
-cblas-sys = { version = "0.1.4", optional = true, default-features = false }
-blas-src = { version = "0.2.0", optional = true, default-features = false }
-
-matrixmultiply = { version = "0.2.0" }
-# Use via the `serde-1` crate feature!
-serde = { version = "1.0", optional = true }
-
 [dev-dependencies]
+approx = "0.3.2"
 defmac = "0.2"
+itertools = { version = "0.8.0", default-features = false, features = ["use_std"] }
 quickcheck = { version = "0.8", default-features = false }
 rawpointer = "0.1"
-approx = "0.3.2"
-itertools = { version = "0.8.0", default-features = false, features = ["use_std"] }
 
 [features]
 # Enable blas usage
@@ -60,9 +56,8 @@ blas = ["cblas-sys", "blas-src"]
 # Serde 1.0
 serde-1 = ["serde"]
 
-# These features are used for testing
-test-blas-openblas-sys = ["blas"]
-test = ["test-blas-openblas-sys"]
+# Enable nightly-only features
+nightly = []
 
 # This feature is used for docs
 docs = ["approx", "serde-1", "rayon"]

--- a/benches/bench1.rs
+++ b/benches/bench1.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "nightly")]
 #![feature(test)]
 #![allow(unused_imports)]
 #![allow(

--- a/benches/chunks.rs
+++ b/benches/chunks.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "nightly")]
 #![feature(test)]
 
 extern crate test;

--- a/benches/construct.rs
+++ b/benches/construct.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "nightly")]
 #![feature(test)]
 #![allow(
     clippy::many_single_char_names,

--- a/benches/gemv.rs
+++ b/benches/gemv.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "nightly")]
 #![feature(test)]
 #![allow(
     clippy::many_single_char_names,

--- a/benches/higher-order.rs
+++ b/benches/higher-order.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "nightly")]
 #![feature(test)]
 #![allow(
     clippy::many_single_char_names,

--- a/benches/iter.rs
+++ b/benches/iter.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "nightly")]
 #![feature(test)]
 #![allow(
     clippy::many_single_char_names,

--- a/benches/numeric.rs
+++ b/benches/numeric.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "nightly")]
 #![feature(test)]
 
 extern crate test;

--- a/benches/par_rayon.rs
+++ b/benches/par_rayon.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "nightly")]
 #![cfg(feature = "rayon")]
 #![feature(test)]
 

--- a/build.rs
+++ b/build.rs
@@ -1,10 +1,8 @@
-///
-/// This build script emits the openblas linking directive if requested
-///
+//! This build script emits the openblas linking directive if requested
 
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
-    if cfg!(feature = "test-blas-openblas-sys") {
+    if cfg!(feature = "blas") {
         println!("cargo:rustc-link-lib={}=openblas", "dylib");
     }
 }

--- a/ci/after_success.sh
+++ b/ci/after_success.sh
@@ -7,22 +7,14 @@ set -o nounset
 # Exit on any error
 set -o errexit
 
-KCOV_BIN="./target/kcov-master/build/src/kcov"
-
 run_kcov() {
     # Run kcov on all the test suites
-    cargo coverage --all --tests --benches --no-default-features
-    mv target/kcov target/kcov-no-default-features
-    cargo coverage --all --tests --benches --features "$FEATURES"
-    mv target/kcov target/kcov-features
+    cargo kcov --all --no-default-features --output kcov-no-default-features
+    cargo kcov --all --features "$FEATURES" --output kcov-features
 
-    $KCOV_BIN --merge target/kcov \
-              target/kcov-no-default-features \
-              target/kcov-features
-
-    rm -rf \
-       target/kcov-no-default-features \
-       target/kcov-features
+    kcov --merge kcov \
+         kcov-no-default-features \
+         kcov-features
 }
 
 coverage_codecov() {
@@ -32,7 +24,7 @@ coverage_codecov() {
 
     run_kcov
 
-    bash <(curl -s https://codecov.io/bash) -s target/kcov
+    bash <(curl -s https://codecov.io/bash) -s kcov
     echo "Uploaded code coverage to codecov.io"
 }
 

--- a/ci/after_success.sh
+++ b/ci/after_success.sh
@@ -7,28 +7,22 @@ set -o nounset
 # Exit on any error
 set -o errexit
 
-# We only need to run the coverage suite once
-COVERAGE_RUN=false
 KCOV_BIN="./target/kcov-master/build/src/kcov"
 
 run_kcov() {
     # Run kcov on all the test suites
-    if [[ $COVERAGE_RUN != "true" ]]; then
-        cargo coverage --all --tests --benches --no-default-features
-        mv target/kcov target/kcov-no-default-features
-        cargo coverage --all --tests --benches --features "$FEATURES"
-        mv target/kcov target/kcov-features
+    cargo coverage --all --tests --benches --no-default-features
+    mv target/kcov target/kcov-no-default-features
+    cargo coverage --all --tests --benches --features "$FEATURES"
+    mv target/kcov target/kcov-features
 
-        $KCOV_BIN --coveralls-id $TRAVIS_JOB_ID --merge target/kcov \
-                  target/kcov-no-default-features \
-                  target/kcov-features
+    $KCOV_BIN --merge target/kcov \
+              target/kcov-no-default-features \
+              target/kcov-features
 
-        rm -rf \
-           target/kcov-no-default-features \
-           target/kcov-features
-
-        COVERAGE_RUN=true
-    fi
+    rm -rf \
+       target/kcov-no-default-features \
+       target/kcov-features
 }
 
 coverage_codecov() {
@@ -42,18 +36,7 @@ coverage_codecov() {
     echo "Uploaded code coverage to codecov.io"
 }
 
-coverage_coveralls() {
-    if [[ "$TRAVIS_RUST_VERSION" != "stable" ]]; then
-        return
-    fi
-
-    run_kcov
-
-    # Data is automatically uploaded by kcov
-}
-
 main() {
-    coverage_coveralls
     coverage_codecov
 }
 

--- a/ci/after_success.sh
+++ b/ci/after_success.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# Echo all commands before executing them
+set -o xtrace
+# Forbid any unset variables
+set -o nounset
+# Exit on any error
+set -o errexit
+
+# We only need to run the coverage suite once
+COVERAGE_RUN=false
+KCOV_BIN="./target/kcov-master/build/src/kcov"
+
+run_kcov() {
+    # Run kcov on all the test suites
+    if [[ $COVERAGE_RUN != "true" ]]; then
+        cargo coverage --all --tests --benches --no-default-features
+        mv target/kcov target/kcov-no-default-features
+        cargo coverage --all --tests --benches --features "$FEATURES"
+        mv target/kcov target/kcov-features
+
+        $KCOV_BIN --coveralls-id $TRAVIS_JOB_ID --merge target/kcov \
+                  target/kcov-no-default-features \
+                  target/kcov-features
+
+        rm -rf \
+           target/kcov-no-default-features \
+           target/kcov-features
+
+        COVERAGE_RUN=true
+    fi
+}
+
+coverage_codecov() {
+    if [[ "$TRAVIS_RUST_VERSION" != "stable" ]]; then
+        return
+    fi
+
+    run_kcov
+
+    bash <(curl -s https://codecov.io/bash) -s target/kcov
+    echo "Uploaded code coverage to codecov.io"
+}
+
+coverage_coveralls() {
+    if [[ "$TRAVIS_RUST_VERSION" != "stable" ]]; then
+        return
+    fi
+
+    run_kcov
+
+    # Data is automatically uploaded by kcov
+}
+
+main() {
+    coverage_coveralls
+    coverage_codecov
+}
+
+main

--- a/ci/after_success.sh
+++ b/ci/after_success.sh
@@ -7,12 +7,16 @@ set -o nounset
 # Exit on any error
 set -o errexit
 
+
 run_kcov() {
+    sh <(cargo kcov --print-install-kcov-sh)
+    KCOV_BIN="./$(ls | grep kcov)/build/src/kcov"
+
     # Run kcov on all the test suites
     cargo kcov --all --no-default-features --output kcov-no-default-features
     cargo kcov --all --features "$FEATURES" --output kcov-features
 
-    kcov --merge kcov \
+    $KCOV_BIN --merge kcov \
          kcov-no-default-features \
          kcov-features
 }

--- a/ci/before_script.sh
+++ b/ci/before_script.sh
@@ -14,6 +14,9 @@ rustup_tools() {
 
 # Install cargo tools
 cargo_tools() {
+    if [[ "$TRAVIS_RUST_VERSION" != "stable" ]]; then
+        return
+    fi
     cargo install cargo-update || echo "cargo-update already installed"
     cargo install cargo-travis || echo "cargo-travis already installed"
     # Update cached binaries

--- a/ci/before_script.sh
+++ b/ci/before_script.sh
@@ -18,7 +18,7 @@ cargo_tools() {
         return
     fi
     cargo install cargo-update || echo "cargo-update already installed"
-    cargo install cargo-travis || echo "cargo-travis already installed"
+    cargo install cargo-kcov || echo "cargo-kcov already installed"
     # Update cached binaries
     cargo install-update -a
 }

--- a/ci/before_script.sh
+++ b/ci/before_script.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Echo all commands before executing them
+set -o xtrace
+# Forbid any unset variables
+set -o nounset
+# Exit on any error
+set -o errexit
+
+# Install clippy and rustfmt
+rustup_tools() {
+    rustup component add clippy rustfmt
+}
+
+# Install cargo tools
+cargo_tools() {
+    cargo install cargo-update || echo "cargo-update already installed"
+    cargo install cargo-travis || echo "cargo-travis already installed"
+    # Update cached binaries
+    cargo install-update -a
+}
+
+main() {
+    rustup_tools
+    cargo_tools
+}
+
+main

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Echo all commands before executing them
+set -o xtrace
+# Forbid any unset variables
+set -o nounset
+# Exit on any error
+set -o errexit
+
+# Ensure there are no outstanding lints.
+check_lints() {
+    ## In the future, it would be good if `|| true` can be removed so that
+    ## clippy warnings abort the build.
+    cargo clippy --all --features "$FEATURES" || true
+}
+
+# Ensure the code is correctly formatted.
+check_format() {
+    cargo fmt --all -- --check
+}
+
+# Run the test suite.
+check_tests() {
+    cargo test --all --examples --tests --benches --no-default-features
+    cargo test --all --examples --tests --benches --features "$FEATURES"
+}
+
+main() {
+    check_lints
+    check_format
+    check_tests
+}
+
+main

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -21,8 +21,8 @@ check_format() {
 
 # Run the test suite.
 check_tests() {
-    cargo test --all --examples --tests --benches --no-default-features
-    cargo test --all --examples --tests --benches --features "$FEATURES"
+    cargo test --all --no-default-features
+    cargo test --all --features "$FEATURES"
 }
 
 main() {

--- a/ndarray-rand/benches/bench.rs
+++ b/ndarray-rand/benches/bench.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "nightly")]
 #![feature(test)]
 
 extern crate test;

--- a/numeric-tests/Cargo.toml
+++ b/numeric-tests/Cargo.toml
@@ -18,9 +18,4 @@ features = ["small_rng"]
 test = false
 
 [features]
-test_blas = ["ndarray/blas", "ndarray/test-blas-openblas-sys"]
-
-[profile.dev]
-opt-level = 2
-[profile.test]
-opt-level = 2
+test_blas = ["ndarray/blas"]

--- a/parallel/Cargo.toml
+++ b/parallel/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["data-structure", "multidimensional", "parallel", "concurrent"]
 categories = ["data-structures", "science", "concurrency"]
 
 [dependencies]
-rayon = { version = "1.0" }
+rayon = "1.0"
 ndarray = { version = "0.12.0", path = "../" }
 
 [dev-dependencies]

--- a/parallel/Cargo.toml
+++ b/parallel/Cargo.toml
@@ -14,9 +14,10 @@ categories = ["data-structures", "science", "concurrency"]
 
 [dependencies]
 rayon = "1.0"
-ndarray = { version = "0.12.0", path = "../" }
+ndarray = { version = "0.12.0", path = "../", features = ["rayon"]}
 
 [dev-dependencies]
+approx = "0.3.2"
 num_cpus = "1.2"
 itertools = { version = "0.8.0", default-features = false }
 

--- a/parallel/benches/rayon.rs
+++ b/parallel/benches/rayon.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "nightly")]
 #![feature(test)]
 
 extern crate num_cpus;

--- a/parallel/src/into_impls.rs
+++ b/parallel/src/into_impls.rs
@@ -1,4 +1,4 @@
-use ndarray::{Array, ArrayView, ArrayViewMut, Dimension, RcArray};
+use ndarray::{ArcArray, Array, ArrayView, ArrayViewMut, Dimension};
 
 use NdarrayIntoParallelIterator;
 use Parallel;
@@ -16,7 +16,7 @@ where
 }
 
 // This is allowed: goes through `.view()`
-impl<'a, A, D> NdarrayIntoParallelIterator for &'a RcArray<A, D>
+impl<'a, A, D> NdarrayIntoParallelIterator for &'a ArcArray<A, D>
 where
     D: Dimension,
     A: Sync,
@@ -41,7 +41,7 @@ where
 }
 
 // This is allowed: goes through `.view_mut()`, which is unique access
-impl<'a, A, D> NdarrayIntoParallelIterator for &'a mut RcArray<A, D>
+impl<'a, A, D> NdarrayIntoParallelIterator for &'a mut ArcArray<A, D>
 where
     D: Dimension,
     A: Sync + Send + Clone,

--- a/parallel/tests/azip.rs
+++ b/parallel/tests/azip.rs
@@ -1,7 +1,9 @@
+extern crate approx;
 extern crate itertools;
 extern crate ndarray;
 extern crate ndarray_parallel;
 
+use approx::assert_abs_diff_eq;
 use itertools::enumerate;
 use ndarray::prelude::*;
 use ndarray_parallel::par_azip;
@@ -37,7 +39,7 @@ fn test_par_azip3() {
         *c = a.sin();
     });
     let res = Array::linspace(0., 3.1, 32).mapv_into(f32::sin);
-    assert!(res.all_close(&ArrayView::from(&c), 1e-4));
+    assert_abs_diff_eq!(res, ArrayView::from(&c), epsilon = 1e-4);
 }
 
 #[should_panic]

--- a/parallel/tests/rayon.rs
+++ b/parallel/tests/rayon.rs
@@ -1,7 +1,9 @@
+extern crate approx;
 extern crate ndarray;
 extern crate ndarray_parallel;
 extern crate rayon;
 
+use approx::assert_abs_diff_eq;
 use ndarray::prelude::*;
 use ndarray_parallel::prelude::*;
 
@@ -30,7 +32,7 @@ fn test_axis_iter_mut() {
         .into_par_iter()
         .for_each(|mut v| v.mapv_inplace(|x| x.exp()));
     println!("{:?}", a.slice(s![..10, ..5]));
-    assert!(a.all_close(&b, 0.001));
+    assert_abs_diff_eq!(a, b, epsilon = 1e-3);
 }
 
 #[test]

--- a/parallel/tests/zip.rs
+++ b/parallel/tests/zip.rs
@@ -2,8 +2,6 @@ extern crate ndarray;
 extern crate ndarray_parallel;
 
 use ndarray::prelude::*;
-use ndarray_parallel::prelude::*;
-
 use ndarray::Zip;
 
 const M: usize = 1024 * 10;

--- a/serialization-tests/Cargo.toml
+++ b/serialization-tests/Cargo.toml
@@ -9,19 +9,12 @@ test = false
 
 [dependencies]
 ndarray = { path = "../", features = ["serde-1"] }
+ron = { version = "0.1.1", optional = true }
 
 [features]
 default = ["ron"]
 
-[dev-dependencies.serde]
-version = "1.0"
-
-[dev-dependencies.serde_json]
-version = "1.0"
-
-[dev-dependencies.rmp-serde]
-version = "0.13.1"
-
-[dependencies.ron]
-version = "0.1.1"
-optional = true
+[dev-dependencies]
+serde = "1.0"
+serde_json = "1.0"
+rmp-serde = "0.13.1"

--- a/serialization-tests/tests/serialize.rs
+++ b/serialization-tests/tests/serialize.rs
@@ -1,10 +1,7 @@
 extern crate ndarray;
-
-extern crate serde;
-
-extern crate serde_json;
-
 extern crate rmp_serde;
+extern crate serde;
+extern crate serde_json;
 
 #[cfg(feature = "ron")]
 extern crate ron;


### PR DESCRIPTION
This pull request's primary goal is to add code coverage, which can be seen at [codecov](https://codecov.io/gh/JP-Ellis/ndarray) and [coveralls](https://coveralls.io/github/JP-Ellis/ndarray) (note that former only displays stats from the `master` branch on the front page, but you can see stats from commits at https://codecov.io/gh/JP-Ellis/ndarray/commits).

In addition, this pull requests also adds `cargo clippy` and `cargo fmt`.  Failure to pass these does *not* cause the build to break, but serves as a warning.

I also took the slight liberty to change some of the features relating to testing.  Nightly features are kept behind the `nightly` flag (which has no other dependencies), and `cargo test` automatically enables the `cfg(test)` flag making the `tst` feature somewhat redundant.  Tests which are specific to certain features (such as `blas`) can be enabled by invoking `cargo` with the `--feature blas` flag.

Lastly, the first build does take a long time due to the `cargo travis` installation; however, I have enabled caching with travis so that subsequent runs can complete substantially faster.

EDIT:  Forgot to mention that I've added the flags `-D warnings` and `-D missing_docs` which causes the build to fail if there are any warnings or missing documentation on public facing elements.  Fortunately, there were very few such warnings which I've fixed (albeit temporarily in the case of the documentation).