### PR TITLE
Use approx for approximate comparisons in tests

### DIFF
--- a/blas-tests/Cargo.toml
+++ b/blas-tests/Cargo.toml
@@ -8,9 +8,9 @@ publish = false
 test = false
 
 [dev-dependencies]
-ndarray = { path = "../", features = ["blas"] }
+approx = "0.3.2"
+ndarray = { path = "../", features = ["approx", "blas"] }
 blas-src = { version = "0.2.0", default-features = false, features = ["openblas"] }
 openblas-src = { version = "0.6.0", default-features = false, features = ["cblas", "system"] }
 defmac = "0.2"
 num-traits = "0.2"
-

--- a/numeric-tests/Cargo.toml
+++ b/numeric-tests/Cargo.toml
@@ -5,7 +5,8 @@ authors = ["bluss"]
 publish = false
 
 [dependencies]
-ndarray = { path = ".." }
+approx = "0.3.2"
+ndarray = { path = "..", features = ["approx"] }
 ndarray-rand = { path = "../ndarray-rand/" }
 rand = "0.6.0"
 


### PR DESCRIPTION
This allows us to get rid of the custom comparison functions.