### PR TITLE
Basic traits restrictions for Dimension::Pattern

### DIFF
--- a/src/dimension/dimension_trait.rs
+++ b/src/dimension/dimension_trait.rs
@@ -72,7 +72,7 @@ pub trait Dimension:
     /// - For `Ix2`: `(usize, usize)`
     /// - and so on..
     /// - For `IxDyn`: `IxDyn`
-    type Pattern: IntoDimension<Dim = Self>;
+    type Pattern: IntoDimension<Dim = Self> + Clone + Debug + PartialEq + Eq + Default;
     /// Next smaller dimension (if applicable)
     type Smaller: Dimension;
     /// Next larger dimension


### PR DESCRIPTION
The `Pattern` associated type of `Dimension` is used in several top level API e.g. [ArrayBase::dim](https://docs.rs/ndarray/0.12.1/ndarray/struct.ArrayBase.html#method.dim), but its definition lacks restrictions `Eq`, `Debug`, and others. Here is my code:

```rust
fn assert_equal_size<A, S1, S2, D>(test: &ArrayBase<S1, D>, truth: &ArrayBase<S2, D>)
where
    A: LinalgScalar,
    S1: Data<Elem = A>,
    S2: Data<Elem = A>,
    D: Dimension,
    D::Pattern: PartialEq + Debug,   // I'd like to remove this line !!
{
    assert_eq!(test.dim(), truth.dim());
}
```

Summary
------------
- Add `Clone`, `Debug`, `PartialEq`, `Eq`, and `Default` restrictions to `Dimension::Pattern`
- `Copy` is not added because `IxDyn` is not `Copy`