### PR TITLE
Travis runs on all branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,6 @@ env:
   global:
     - HOST=x86_64-unknown-linux-gnu
     - CARGO_INCREMENTAL=0
-branches:
-  only:
-    - master
-    - 0.10.x
 addons:
   apt:
     packages:


### PR DESCRIPTION
Was there a reason to have this filter?

The existing code wouldn't kick off travis runs on my fork's travis (i.e. https://travis-ci.org/max-sixty/ndarray/branches), which I think means I need to create a PR to see a travis run.

The proposed code will kick off a travis run on any branch (on forks which have travis enabled)

But if this was deliberate for some reason then feel free to close