### PR TITLE
rename `into_slice` on ArrayView `to_slice` 

### DIFF
--- a/src/impl_views.rs
+++ b/src/impl_views.rs
@@ -137,7 +137,7 @@ where
 
     /// Return the array’s data as a slice, if it is contiguous and in standard order.
     /// Return `None` otherwise.
-    #[deprecated(note = "`into_slice` has been renamed to `to_slice`")]
+    #[deprecated(note = "`into_slice` has been renamed to `to_slice`", since="0.13.0")]
     pub fn into_slice(&self) -> Option<&'a [A]> {
         if self.is_standard_layout() {
             unsafe { Some(slice::from_raw_parts(self.ptr, self.len())) }

--- a/src/impl_views.rs
+++ b/src/impl_views.rs
@@ -137,7 +137,18 @@ where
 
     /// Return the array’s data as a slice, if it is contiguous and in standard order.
     /// Return `None` otherwise.
+    #[deprecated(note="`into_slice` has been renamed to `to_slice`")]
     pub fn into_slice(&self) -> Option<&'a [A]> {
+        if self.is_standard_layout() {
+            unsafe { Some(slice::from_raw_parts(self.ptr, self.len())) }
+        } else {
+            None
+        }
+    }
+
+    /// Return the array’s data as a slice, if it is contiguous and in standard order.
+    /// Return `None` otherwise.
+    pub fn to_slice(&self) -> Option<&'a [A]> {
         if self.is_standard_layout() {
             unsafe { Some(slice::from_raw_parts(self.ptr, self.len())) }
         } else {

--- a/src/impl_views.rs
+++ b/src/impl_views.rs
@@ -137,7 +137,7 @@ where
 
     /// Return the array’s data as a slice, if it is contiguous and in standard order.
     /// Return `None` otherwise.
-    #[deprecated(note = "`into_slice` has been renamed to `to_slice`", since="0.13.0")]
+    #[deprecated(note = "`into_slice` has been renamed to `to_slice`", since = "0.13.0")]
     pub fn into_slice(&self) -> Option<&'a [A]> {
         if self.is_standard_layout() {
             unsafe { Some(slice::from_raw_parts(self.ptr, self.len())) }

--- a/src/impl_views.rs
+++ b/src/impl_views.rs
@@ -137,7 +137,7 @@ where
 
     /// Return the array’s data as a slice, if it is contiguous and in standard order.
     /// Return `None` otherwise.
-    #[deprecated(note="`into_slice` has been renamed to `to_slice`")]
+    #[deprecated(note = "`into_slice` has been renamed to `to_slice`")]
     pub fn into_slice(&self) -> Option<&'a [A]> {
         if self.is_standard_layout() {
             unsafe { Some(slice::from_raw_parts(self.ptr, self.len())) }

--- a/src/iterators/mod.rs
+++ b/src/iterators/mod.rs
@@ -264,7 +264,7 @@ where
 {
     pub(crate) fn new(self_: ArrayView<'a, A, D>) -> Self {
         Iter {
-            inner: if let Some(slc) = self_.into_slice() {
+            inner: if let Some(slc) = self_.to_slice() {
                 ElementsRepr::Slice(slc.iter())
             } else {
                 ElementsRepr::Counted(self_.into_elements_base())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -988,8 +988,8 @@ pub type Ixs = isize;
 /// `Array<A, D>` | `Vec<A>` | [`.into_raw_vec()`](type.Array.html#method.into_raw_vec)<sup>[1](#into_raw_vec)</sup>
 /// `&ArrayBase<S, D>` | `&[A]` | [`.as_slice()`](#method.as_slice)<sup>[2](#req_contig_std)</sup>, [`.as_slice_memory_order()`](#method.as_slice_memory_order)<sup>[3](#req_contig)</sup>
 /// `&mut ArrayBase<S: DataMut, D>` | `&mut [A]` | [`.as_slice_mut()`](#method.as_slice_mut)<sup>[2](#req_contig_std)</sup>, [`.as_slice_memory_order_mut()`](#method.as_slice_memory_order_mut)<sup>[3](#req_contig)</sup>
-/// `ArrayView<A, D>` | `&[A]` | [`.into_slice()`](type.ArrayView.html#method.into_slice)<sup>[2](#req_contig_std)</sup>
-/// `ArrayViewMut<A, D>` | `&mut [A]` | [`.into_slice()`](type.ArrayViewMut.html#method.into_slice)<sup>[2](#req_contig_std)</sup>
+/// `ArrayView<A, D>` | `&[A]` | [`.to_slice()`](type.ArrayView.html#method.to_slice)<sup>[2](#req_contig_std)</sup>
+/// `ArrayViewMut<A, D>` | `&mut [A]` | [`.to_slice()`](type.ArrayViewMut.html#method.to_slice)<sup>[2](#req_contig_std)</sup>
 /// `Array0<A>` | `A` | [`.into_scalar()`](type.Array.html#method.into_scalar)
 ///
 /// <sup><a name="into_raw_vec">1</a></sup>Returns the data in memory order.


### PR DESCRIPTION
Deprecated the existing method

from https://github.com/rust-ndarray/ndarray/pull/642#discussion_r296072708