### PR TITLE
NonZero start

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: required
 dist: trusty
 matrix:
   include:
-    - rust: 1.31.0
+    - rust: 1.34.0
       env:
        - FEATURES='test docs'
     - rust: stable

--- a/src/dimension/mod.rs
+++ b/src/dimension/mod.rs
@@ -360,8 +360,7 @@ fn to_abs_slice(axis_len: usize, slice: Slice) -> (usize, usize, isize) {
         end,
         axis_len,
     );
-    ndassert!(step != 0, "Slice stride must not be zero");
-    (start, end, step)
+    (start, end, step.get())
 }
 
 /// Modify dimension, stride and return data pointer offset

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -413,7 +413,7 @@ where
             .enumerate()
             .for_each(|(axis, &slice_or_index)| match slice_or_index {
                 SliceOrIndex::Slice { start, end, step } => {
-                    self.slice_axis_inplace(Axis(axis), Slice { start, end, step })
+                    self.slice_axis_inplace(Axis(axis), Slice::new(start, end, step))
                 }
                 SliceOrIndex::Index(index) => {
                     let i_usize = abs_index(self.len_of(Axis(axis)), index);

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -69,9 +69,6 @@ impl Slice {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Hash, Copy, Clone)]
-struct Index(isize);
-
 /// A slice (range with step) or an index.
 ///
 /// See also the [`s![]`](macro.s!.html) macro for a convenient way to create a

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -54,6 +54,19 @@ impl Slice {
             step: NonZeroIsize::new(step).expect("Slice::new: step must be nonzero"),
         }
     }
+
+    /// Create a new `Slice` with the given step size (multiplied with the
+    /// previous step size).
+    ///
+    /// `step` must be nonzero.
+    /// (This method checks with a debug assertion that `step` is not zero.)
+    #[inline]
+    pub fn step_by(self, step: isize) -> Self {
+        Slice {
+            step: NonZeroIsize::new(self.step.get() * step).expect("step must be nonzero"),
+            ..self
+        }
+    }
 }
 
 #[derive(Debug, PartialEq, Eq, Hash, Copy, Clone)]

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -235,7 +235,7 @@ impl From<Slice> for SliceOrIndex {
         SliceOrIndex::Slice {
             start: s.start,
             end: s.end,
-            step: s.step.get(),
+            step: s.step.into(),
         }
     }
 }

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -257,7 +257,7 @@ fn test_slice_dyninput_vec_dyn() {
     let info = &SliceInfo::<_, IxDyn>::new(vec![
         SliceOrIndex::from(1..),
         SliceOrIndex::from(1),
-        SliceOrIndex::from(..).step_by(2),
+        SliceOrIndex::from(..).step_by(2isize),
     ])
     .unwrap();
     arr.slice(info.as_ref());

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -257,7 +257,7 @@ fn test_slice_dyninput_vec_dyn() {
     let info = &SliceInfo::<_, IxDyn>::new(vec![
         SliceOrIndex::from(1..),
         SliceOrIndex::from(1),
-        SliceOrIndex::from(..).step_by(2isize),
+        SliceOrIndex::from(..).step_by(2),
     ])
     .unwrap();
     arr.slice(info.as_ref());


### PR DESCRIPTION
I started attempting to implement NonZero from https://github.com/rust-ndarray/ndarray/issues/558

But I was tripping over from the get-go - am I going in the right direction here?

As well as the errors I'd expect to see (e.g. from direct struct construction), I'm also seeing errors like these:

```
error[E0277]: the trait bound `isize: std::convert::From<i32>` is not satisfied
   --> src/dimension/mod.rs:886:38
    |
886 |         assert_eq!(slice_min_max(10, Slice::new(-9, None, 3)), Some((1, 7)));
    |                                      ^^^^^^^^^^ the trait `std::convert::From<i32>` is not implemented for `isize`
    |
    = help: the following implementations were found:
              <isize as std::convert::From<bool>>
              <isize as std::convert::From<i16>>
              <isize as std::convert::From<i8>>
              <isize as std::convert::From<std::num::NonZeroIsize>>
              <isize as std::convert::From<u8>>
    = note: required because of the requirements on the impl of `std::convert::Into<isize>` for `i32`
note: required by `slice::Slice::new`
   --> src/slice.rs:51:5
    |
51  | /     pub fn new<S>(start: isize, end: Option<isize>, step: S) -> Slice
52  | |     where S: Into<isize> + Debug + PartialEq
53  | |     {
54  | |         debug_assert_ne!(step, 0, "Slice::new: step must be nonzero");
55  | |         let step = NonZeroIsize::new(step).unwrap();
56  | |         Slice { start, end, step }
57  | |     }
    | |_____^
```

Any guidance would be appreciated!