### PR TITLE
Use FromIterator trait rather than custom method

### DIFF
--- a/benches/higher-order.rs
+++ b/benches/higher-order.rs
@@ -1,6 +1,7 @@
 #![feature(test)]
 
 extern crate test;
+use std::iter::FromIterator;
 use test::black_box;
 use test::Bencher;
 

--- a/blas-tests/tests/oper.rs
+++ b/blas-tests/tests/oper.rs
@@ -3,12 +3,12 @@ extern crate defmac;
 extern crate ndarray;
 extern crate num_traits;
 
-use std::iter::FromIterator;
 use ndarray::linalg::general_mat_mul;
 use ndarray::linalg::general_mat_vec_mul;
 use ndarray::prelude::*;
 use ndarray::{Data, LinalgScalar};
 use ndarray::{Ix, Ixs, SliceInfo, SliceOrIndex};
+use std::iter::FromIterator;
 
 use approx::{assert_abs_diff_eq, assert_relative_eq};
 use defmac::defmac;

--- a/blas-tests/tests/oper.rs
+++ b/blas-tests/tests/oper.rs
@@ -3,6 +3,7 @@ extern crate defmac;
 extern crate ndarray;
 extern crate num_traits;
 
+use std::iter::FromIterator;
 use ndarray::linalg::general_mat_mul;
 use ndarray::linalg::general_mat_vec_mul;
 use ndarray::prelude::*;

--- a/blas-tests/tests/oper.rs
+++ b/blas-tests/tests/oper.rs
@@ -289,7 +289,7 @@ fn mat_mul_broadcast() {
     let (m, n, k) = (16, 16, 16);
     let a = range_mat(m, n);
     let x1 = 1.;
-    let x = Array::from_vec(vec![x1]);
+    let x = Array::from(vec![x1]);
     let b0 = x.broadcast((n, k)).unwrap();
     let b1 = Array::from_elem(n, x1);
     let b1 = b1.broadcast((n, k)).unwrap();

--- a/examples/life.rs
+++ b/examples/life.rs
@@ -1,9 +1,9 @@
 extern crate ndarray;
 
 use ndarray::prelude::*;
+use std::iter::FromIterator;
 
 const INPUT: &'static [u8] = include_bytes!("life.txt");
-use std::iter::FromIterator;
 
 const N: usize = 100;
 

--- a/examples/life.rs
+++ b/examples/life.rs
@@ -3,10 +3,9 @@ extern crate ndarray;
 use ndarray::prelude::*;
 
 const INPUT: &'static [u8] = include_bytes!("life.txt");
-//const INPUT: &'static [u8] = include_bytes!("lifelite.txt");
+use std::iter::FromIterator;
 
 const N: usize = 100;
-//const N: usize = 8;
 
 type Board = Array2<u8>;
 

--- a/src/arraytraits.rs
+++ b/src/arraytraits.rs
@@ -148,13 +148,20 @@ impl<A, S> FromIterator<A> for ArrayBase<S, Ix1>
 where
     S: DataOwned<Elem = A>,
 {
+    /// Create a one-dimensional array from a vector (no copying needed).
+    ///
+    /// **Panics** if the length is greater than `isize::MAX`.
+    ///
+    /// ```rust
+    /// use ndarray::Array;
+    ///
+    /// let array = Array::from(vec![1., 2., 3., 4.]);
+    /// ```
     fn from_iter<I>(iterable: I) -> ArrayBase<S, Ix1>
     where
         I: IntoIterator<Item = A>,
     {
-        // TODO: can I put this on one line?
-        let v: Vec<A> = iterable.into_iter().collect();
-        Self::from(v)
+        Self::from(iterable.into_iter().collect::<Vec<A>>())
     }
 }
 

--- a/src/arraytraits.rs
+++ b/src/arraytraits.rs
@@ -10,6 +10,7 @@ use std::hash;
 use std::iter::FromIterator;
 use std::iter::IntoIterator;
 use std::mem;
+use std::isize;
 use std::ops::{Index, IndexMut};
 
 use crate::imp_prelude::*;
@@ -181,6 +182,29 @@ where
     }
 }
 
+impl<A,S> From<Vec<A>> for ArrayBase<S, Ix1>
+where
+    S: DataOwned<Elem = A>,
+{
+    /// Create a one-dimensional array from a vector (no copying needed).
+    ///
+    /// **Panics** if the length is greater than `isize::MAX`.
+    ///
+    /// ```rust
+    /// use ndarray::Array;
+    ///
+    /// let array = Array::from_vec(vec![1., 2., 3., 4.]);
+    /// ```
+    fn from(v: Vec<A>) -> Self {
+        if mem::size_of::<A>() == 0 {
+            assert!(
+                v.len() <= isize::MAX as usize,
+                "Length must fit in `isize`.",
+            );
+        }
+        unsafe { Self::from_shape_vec_unchecked(v.len() as Ix, v) }
+    }
+}
 impl<'a, S, D> hash::Hash for ArrayBase<S, D>
 where
     D: Dimension,

--- a/src/arraytraits.rs
+++ b/src/arraytraits.rs
@@ -127,7 +127,7 @@ where
     where
         I: IntoIterator<Item = A>,
     {
-        ArrayBase::from_iter(iterable)
+        Self::from_vec(iterable.into_iter().collect())
     }
 }
 

--- a/src/arraytraits.rs
+++ b/src/arraytraits.rs
@@ -120,6 +120,30 @@ where
 {
 }
 
+impl<A, S> From<Vec<A>> for ArrayBase<S, Ix1>
+where
+    S: DataOwned<Elem = A>,
+{
+    /// Create a one-dimensional array from a vector (no copying needed).
+    ///
+    /// **Panics** if the length is greater than `isize::MAX`.
+    ///
+    /// ```rust
+    /// use ndarray::Array;
+    ///
+    /// let array = Array::from(vec![1., 2., 3., 4.]);
+    /// ```
+    fn from(v: Vec<A>) -> Self {
+        if mem::size_of::<A>() == 0 {
+            assert!(
+                v.len() <= isize::MAX as usize,
+                "Length must fit in `isize`.",
+            );
+        }
+        unsafe { Self::from_shape_vec_unchecked(v.len() as Ix, v) }
+    }
+}
+
 impl<A, S> FromIterator<A> for ArrayBase<S, Ix1>
 where
     S: DataOwned<Elem = A>,
@@ -128,7 +152,9 @@ where
     where
         I: IntoIterator<Item = A>,
     {
-        Self::from_vec(iterable.into_iter().collect())
+        // TODO: can I put this on one line?
+        let v: Vec<A> = iterable.into_iter().collect();
+        Self::from(v)
     }
 }
 
@@ -182,29 +208,6 @@ where
     }
 }
 
-impl<A, S> From<Vec<A>> for ArrayBase<S, Ix1>
-where
-    S: DataOwned<Elem = A>,
-{
-    /// Create a one-dimensional array from a vector (no copying needed).
-    ///
-    /// **Panics** if the length is greater than `isize::MAX`.
-    ///
-    /// ```rust
-    /// use ndarray::Array;
-    ///
-    /// let array = Array::from(vec![1., 2., 3., 4.]);
-    /// ```
-    fn from(v: Vec<A>) -> Self {
-        if mem::size_of::<A>() == 0 {
-            assert!(
-                v.len() <= isize::MAX as usize,
-                "Length must fit in `isize`.",
-            );
-        }
-        unsafe { Self::from_shape_vec_unchecked(v.len() as Ix, v) }
-    }
-}
 impl<'a, S, D> hash::Hash for ArrayBase<S, D>
 where
     D: Dimension,

--- a/src/arraytraits.rs
+++ b/src/arraytraits.rs
@@ -7,10 +7,10 @@
 // except according to those terms.
 
 use std::hash;
+use std::isize;
 use std::iter::FromIterator;
 use std::iter::IntoIterator;
 use std::mem;
-use std::isize;
 use std::ops::{Index, IndexMut};
 
 use crate::imp_prelude::*;
@@ -182,7 +182,7 @@ where
     }
 }
 
-impl<A,S> From<Vec<A>> for ArrayBase<S, Ix1>
+impl<A, S> From<Vec<A>> for ArrayBase<S, Ix1>
 where
     S: DataOwned<Elem = A>,
 {
@@ -193,7 +193,7 @@ where
     /// ```rust
     /// use ndarray::Array;
     ///
-    /// let array = Array::from_vec(vec![1., 2., 3., 4.]);
+    /// let array = Array::from(vec![1., 2., 3., 4.]);
     /// ```
     fn from(v: Vec<A>) -> Self {
         if mem::size_of::<A>() == 0 {

--- a/src/arraytraits.rs
+++ b/src/arraytraits.rs
@@ -148,14 +148,17 @@ impl<A, S> FromIterator<A> for ArrayBase<S, Ix1>
 where
     S: DataOwned<Elem = A>,
 {
-    /// Create a one-dimensional array from a vector (no copying needed).
+    /// Create a one-dimensional array from an iterable.
     ///
     /// **Panics** if the length is greater than `isize::MAX`.
     ///
     /// ```rust
-    /// use ndarray::Array;
+    /// use ndarray::{Array, arr1};
+    /// use std::iter::FromIterator;
     ///
-    /// let array = Array::from(vec![1., 2., 3., 4.]);
+    /// // Either use `from_iter` directly or use `Iterator::collect`.
+    /// let array = Array::from_iter((0..5).map(|x| x * x));
+    /// assert!(array == arr1(&[0, 1, 4, 9, 16]))
     /// ```
     fn from_iter<I>(iterable: I) -> ArrayBase<S, Ix1>
     where

--- a/src/free_functions.rs
+++ b/src/free_functions.rs
@@ -59,7 +59,7 @@ pub fn arr0<A>(x: A) -> Array0<A> {
 
 /// Create a one-dimensional array with elements from `xs`.
 pub fn arr1<A: Clone>(xs: &[A]) -> Array1<A> {
-    ArrayBase::from_vec(xs.to_vec())
+    ArrayBase::from(xs.to_vec())
 }
 
 /// Create a one-dimensional array with elements from `xs`.

--- a/src/free_functions.rs
+++ b/src/free_functions.rs
@@ -226,12 +226,6 @@ where
     Array2::from(xs.to_vec())
 }
 
-impl<A> From<Vec<A>> for Array1<A> {
-    fn from(xs: Vec<A>) -> Self {
-        Array1::from_vec(xs)
-    }
-}
-
 impl<A, V> From<Vec<V>> for Array2<A>
 where
     V: FixedInitializer<Elem = A>,

--- a/src/free_functions.rs
+++ b/src/free_functions.rs
@@ -48,7 +48,7 @@ macro_rules! array {
         $crate::Array2::from(vec![$([$($x,)*],)*])
     }};
     ($($x:expr),* $(,)*) => {{
-        $crate::Array::from_vec(vec![$($x,)*])
+        $crate::Array::from(vec![$($x,)*])
     }};
 }
 

--- a/src/impl_constructors.rs
+++ b/src/impl_constructors.rs
@@ -53,6 +53,27 @@ where
         unsafe { Self::from_shape_vec_unchecked(v.len() as Ix, v) }
     }
 
+    // FIXME: Having this uncommented means that `from_iter` references this
+    // rather than the `from_iter` in std. Is there a way of removing this without
+    // breaking backward-compat?
+    // /// Create a one-dimensional array from an iterable.
+    // ///
+    // /// **Panics** if the length is greater than `isize::MAX`.
+    // ///
+    // /// ```rust
+    // /// use ndarray::{Array, arr1};
+    // ///
+    // /// let array = Array::from_iter((0..5).map(|x| x * x));
+    // /// assert!(array == arr1(&[0, 1, 4, 9, 16]))
+    // /// ```
+    // #[deprecated(note = "use std::iter::FromIterator;", since = "0.13.0")]
+    // pub fn from_iter<I>(iterable: I) -> Self
+    // where
+    //     I: IntoIterator<Item = A>,
+    // {
+    //     Self::from_vec(iterable.into_iter().collect())
+    // }
+
     /// Create a one-dimensional array with `n` evenly spaced elements from
     /// `start` to `end` (inclusive). `A` must be a floating point type.
     ///

--- a/src/impl_constructors.rs
+++ b/src/impl_constructors.rs
@@ -47,27 +47,6 @@ where
         Self::from(v)
     }
 
-    // FIXME: Having this uncommented means that `from_iter` references this
-    // rather than the `from_iter` in std. Is there a way of removing this without
-    // breaking backward-compat?
-    // /// Create a one-dimensional array from an iterable.
-    // ///
-    // /// **Panics** if the length is greater than `isize::MAX`.
-    // ///
-    // /// ```rust
-    // /// use ndarray::{Array, arr1};
-    // ///
-    // /// let array = Array::from_iter((0..5).map(|x| x * x));
-    // /// assert!(array == arr1(&[0, 1, 4, 9, 16]))
-    // /// ```
-    // #[deprecated(note = "use std::iter::FromIterator;", since = "0.13.0")]
-    // pub fn from_iter<I>(iterable: I) -> Self
-    // where
-    //     I: IntoIterator<Item = A>,
-    // {
-    //     Self::from_vec(iterable.into_iter().collect())
-    // }
-
     /// Create a one-dimensional array with `n` evenly spaced elements from
     /// `start` to `end` (inclusive). `A` must be a floating point type.
     ///

--- a/src/impl_constructors.rs
+++ b/src/impl_constructors.rs
@@ -11,8 +11,6 @@
 //!
 
 use num_traits::{Float, One, Zero};
-use std::isize;
-use std::mem;
 
 use crate::dimension;
 use crate::error::{self, ShapeError};

--- a/src/impl_constructors.rs
+++ b/src/impl_constructors.rs
@@ -52,23 +52,6 @@ where
         unsafe { Self::from_shape_vec_unchecked(v.len() as Ix, v) }
     }
 
-    /// Create a one-dimensional array from an iterable.
-    ///
-    /// **Panics** if the length is greater than `isize::MAX`.
-    ///
-    /// ```rust
-    /// use ndarray::{Array, arr1};
-    ///
-    /// let array = Array::from_iter((0..5).map(|x| x * x));
-    /// assert!(array == arr1(&[0, 1, 4, 9, 16]))
-    /// ```
-    pub fn from_iter<I>(iterable: I) -> Self
-    where
-        I: IntoIterator<Item = A>,
-    {
-        Self::from_vec(iterable.into_iter().collect())
-    }
-
     /// Create a one-dimensional array with `n` evenly spaced elements from
     /// `start` to `end` (inclusive). `A` must be a floating point type.
     ///

--- a/src/impl_constructors.rs
+++ b/src/impl_constructors.rs
@@ -42,6 +42,7 @@ where
     ///
     /// let array = Array::from_vec(vec![1., 2., 3., 4.]);
     /// ```
+    #[deprecated(note = "use standard `from`", since = "0.13.0")]
     pub fn from_vec(v: Vec<A>) -> Self {
         if mem::size_of::<A>() == 0 {
             assert!(
@@ -153,7 +154,7 @@ where
     where
         A: Float,
     {
-        Some(Self::from_vec(to_vec(geomspace::geomspace(start, end, n)?)))
+        Some(Self::from(to_vec(geomspace::geomspace(start, end, n)?)))
     }
 }
 

--- a/src/impl_constructors.rs
+++ b/src/impl_constructors.rs
@@ -40,7 +40,7 @@ where
     /// ```rust
     /// use ndarray::Array;
     ///
-    /// let array = Array::from_vec(vec![1., 2., 3., 4.]);
+    /// let array = Array::from(vec![1., 2., 3., 4.]);
     /// ```
     #[deprecated(note = "use standard `from`", since = "0.13.0")]
     pub fn from_vec(v: Vec<A>) -> Self {
@@ -95,7 +95,7 @@ where
     where
         A: Float,
     {
-        Self::from_vec(to_vec(linspace::linspace(start, end, n)))
+        Self::from(to_vec(linspace::linspace(start, end, n)))
     }
 
     /// Create a one-dimensional array with elements from `start` to `end`
@@ -113,7 +113,7 @@ where
     where
         A: Float,
     {
-        Self::from_vec(to_vec(linspace::range(start, end, step)))
+        Self::from(to_vec(linspace::range(start, end, step)))
     }
 
     /// Create a one-dimensional array with `n` logarithmically spaced
@@ -141,7 +141,7 @@ where
     where
         A: Float,
     {
-        Self::from_vec(to_vec(logspace::logspace(base, start, end, n)))
+        Self::from(to_vec(logspace::logspace(base, start, end, n)))
     }
 
     /// Create a one-dimensional array with `n` geometrically spaced elements

--- a/src/impl_constructors.rs
+++ b/src/impl_constructors.rs
@@ -44,13 +44,7 @@ where
     /// ```
     #[deprecated(note = "use standard `from`", since = "0.13.0")]
     pub fn from_vec(v: Vec<A>) -> Self {
-        if mem::size_of::<A>() == 0 {
-            assert!(
-                v.len() <= isize::MAX as usize,
-                "Length must fit in `isize`.",
-            );
-        }
-        unsafe { Self::from_shape_vec_unchecked(v.len() as Ix, v) }
+        Self::from(v)
     }
 
     // FIXME: Having this uncommented means that `from_iter` references this

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -1010,6 +1010,7 @@ where
     /// ```
     /// use ndarray::Array;
     /// use ndarray::{arr3, Axis};
+    /// use std::iter::FromIterator;
     ///
     /// let a = Array::from_iter(0..28).into_shape((2, 7, 2)).unwrap();
     /// let mut iter = a.axis_chunks_iter(Axis(1), 2);

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -697,10 +697,9 @@ pub unsafe fn deref_raw_view_mut_into_view_mut_with_life<'a, A, D: Dimension>(
 ///
 /// use ndarray::multislice;
 /// use ndarray::prelude::*;
-/// use std::iter::FromIterator;
 ///
 /// # fn main() {
-/// let mut arr = Array1::from_iter(0..12);
+/// let mut arr: Array1<_> = (0..12).collect();
 /// let (a, b, c, d) = multislice!(arr, [0..5], mut [6..;2], [1..6], mut [7..;2]);
 /// assert_eq!(a, array![0, 1, 2, 3, 4]);
 /// assert_eq!(b, array![6, 8, 10]);
@@ -717,9 +716,8 @@ pub unsafe fn deref_raw_view_mut_into_view_mut_with_life<'a, A, D: Dimension>(
 ///   # extern crate ndarray;
 ///   # use ndarray::multislice;
 ///   # use ndarray::prelude::*;
-///   # use std::iter::FromIterator;
 ///   # fn main() {
-///   let mut arr = Array1::from_iter(0..12);
+///   let mut arr: Array1<_> = (0..12).collect();
 ///   multislice!(arr, [0..5], mut [1..;2]); // panic!
 ///   # }
 ///   ```
@@ -730,9 +728,8 @@ pub unsafe fn deref_raw_view_mut_into_view_mut_with_life<'a, A, D: Dimension>(
 ///   # extern crate ndarray;
 ///   # use ndarray::multislice;
 ///   # use ndarray::prelude::*;
-///   # use std::iter::FromIterator;
 ///   # fn main() {
-///   let mut arr = Array1::from_iter(0..12);
+///   let mut arr: Array1<_> = (0..12).collect();
 ///   multislice!(arr, mut [0..5], mut [1..;2]); // panic!
 ///   # }
 ///   ```

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -697,6 +697,7 @@ pub unsafe fn deref_raw_view_mut_into_view_mut_with_life<'a, A, D: Dimension>(
 ///
 /// use ndarray::multislice;
 /// use ndarray::prelude::*;
+/// use std::iter::FromIterator;
 ///
 /// # fn main() {
 /// let mut arr = Array1::from_iter(0..12);
@@ -716,6 +717,7 @@ pub unsafe fn deref_raw_view_mut_into_view_mut_with_life<'a, A, D: Dimension>(
 ///   # extern crate ndarray;
 ///   # use ndarray::multislice;
 ///   # use ndarray::prelude::*;
+///   # use std::iter::FromIterator;
 ///   # fn main() {
 ///   let mut arr = Array1::from_iter(0..12);
 ///   multislice!(arr, [0..5], mut [1..;2]); // panic!
@@ -728,6 +730,7 @@ pub unsafe fn deref_raw_view_mut_into_view_mut_with_life<'a, A, D: Dimension>(
 ///   # extern crate ndarray;
 ///   # use ndarray::multislice;
 ///   # use ndarray::prelude::*;
+///   # use std::iter::FromIterator;
 ///   # fn main() {
 ///   let mut arr = Array1::from_iter(0..12);
 ///   multislice!(arr, mut [0..5], mut [1..;2]); // panic!

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -10,6 +10,7 @@ use ndarray::indices;
 use ndarray::prelude::*;
 use ndarray::{arr3, multislice, rcarr2};
 use ndarray::{Slice, SliceInfo, SliceOrIndex};
+use std::iter::FromIterator;
 
 macro_rules! assert_panics {
     ($body:expr) => {

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -662,7 +662,7 @@ fn test_sub() {
     assert_eq!(s2.shape(), &[4, 2]);
     let n = ArcArray::linspace(8., 15., 8).reshape((4, 2));
     assert_eq!(n, s2);
-    let m = ArcArray::from_vec(vec![2., 3., 10., 11.]).reshape((2, 2));
+    let m = ArcArray::from(vec![2., 3., 10., 11.]).reshape((2, 2));
     assert_eq!(m, mat.index_axis(Axis(1), 1));
 }
 
@@ -1027,7 +1027,7 @@ fn array0_into_scalar() {
 
 #[test]
 fn owned_array1() {
-    let mut a = Array::from_vec(vec![1, 2, 3, 4]);
+    let mut a = Array::from(vec![1, 2, 3, 4]);
     for elt in a.iter_mut() {
         *elt = 2;
     }
@@ -1230,7 +1230,7 @@ fn from_vec_dim_stride_2d_rejects() {
 
 #[test]
 fn views() {
-    let a = ArcArray::from_vec(vec![1, 2, 3, 4]).reshape((2, 2));
+    let a = ArcArray::from(vec![1, 2, 3, 4]).reshape((2, 2));
     let b = a.view();
     assert_eq!(a, b);
     assert_eq!(a.shape(), b.shape());
@@ -1247,7 +1247,7 @@ fn views() {
 
 #[test]
 fn view_mut() {
-    let mut a = ArcArray::from_vec(vec![1, 2, 3, 4]).reshape((2, 2));
+    let mut a = ArcArray::from(vec![1, 2, 3, 4]).reshape((2, 2));
     for elt in &mut a.view_mut() {
         *elt = 0;
     }
@@ -1266,7 +1266,7 @@ fn view_mut() {
 
 #[test]
 fn slice_mut() {
-    let mut a = ArcArray::from_vec(vec![1, 2, 3, 4]).reshape((2, 2));
+    let mut a = ArcArray::from(vec![1, 2, 3, 4]).reshape((2, 2));
     for elt in a.slice_mut(s![.., ..]) {
         *elt = 0;
     }

--- a/tests/azip.rs
+++ b/tests/azip.rs
@@ -3,6 +3,7 @@ extern crate ndarray;
 
 use ndarray::prelude::*;
 use ndarray::Zip;
+use std::iter::FromIterator;
 
 use itertools::{assert_equal, cloned};
 

--- a/tests/broadcast.rs
+++ b/tests/broadcast.rs
@@ -52,7 +52,7 @@ fn test_broadcast() {
     let (_, n, k) = (16, 16, 16);
     let x1 = 1.;
     // b0 broadcast 1 -> n, k
-    let x = Array::from_vec(vec![x1]);
+    let x = Array::from(vec![x1]);
     let b0 = x.broadcast((n, k)).unwrap();
     // b1 broadcast n -> n, k
     let b1 = Array::from_elem(n, x1);
@@ -72,7 +72,7 @@ fn test_broadcast_1d() {
     let n = 16;
     let x1 = 1.;
     // b0 broadcast 1 -> n
-    let x = Array::from_vec(vec![x1]);
+    let x = Array::from(vec![x1]);
     let b0 = x.broadcast(n).unwrap();
     let b2 = Array::from_elem(n, x1);
 

--- a/tests/iterators.rs
+++ b/tests/iterators.rs
@@ -7,6 +7,7 @@ use ndarray::{arr2, arr3, aview1, indices, s, Axis, Data, Dimension, Slice};
 
 use itertools::assert_equal;
 use itertools::{enumerate, rev};
+use std::iter::FromIterator;
 
 #[test]
 fn double_ended() {

--- a/tests/iterators.rs
+++ b/tests/iterators.rs
@@ -396,9 +396,7 @@ fn axis_chunks_iter_corner_cases() {
 fn axis_chunks_iter_zero_stride() {
     {
         // stride 0 case
-        let b = Array::from_vec(vec![0f32; 0])
-            .into_shape((5, 0, 3))
-            .unwrap();
+        let b = Array::from(vec![0f32; 0]).into_shape((5, 0, 3)).unwrap();
         let shapes: Vec<_> = b
             .axis_chunks_iter(Axis(0), 2)
             .map(|v| v.raw_dim())
@@ -408,9 +406,7 @@ fn axis_chunks_iter_zero_stride() {
 
     {
         // stride 0 case reverse
-        let b = Array::from_vec(vec![0f32; 0])
-            .into_shape((5, 0, 3))
-            .unwrap();
+        let b = Array::from(vec![0f32; 0]).into_shape((5, 0, 3)).unwrap();
         let shapes: Vec<_> = b
             .axis_chunks_iter(Axis(0), 2)
             .rev()
@@ -421,7 +417,7 @@ fn axis_chunks_iter_zero_stride() {
 
     // From issue #542, ZST element
     {
-        let a = Array::from_vec(vec![(); 3]);
+        let a = Array::from(vec![(); 3]);
         let chunks: Vec<_> = a.axis_chunks_iter(Axis(0), 2).collect();
         assert_eq!(chunks, vec![a.slice(s![0..2]), a.slice(s![2..])]);
     }
@@ -603,7 +599,7 @@ fn test_rfold() {
             acc
         });
         assert_eq!(
-            Array1::from_vec(output),
+            Array1::from(output),
             Array::from_iter((1..10).rev().map(|i| i * 2))
         );
     }

--- a/tests/ix0.rs
+++ b/tests/ix0.rs
@@ -44,7 +44,7 @@ fn test_ix0_add_add() {
 
 #[test]
 fn test_ix0_add_broad() {
-    let mut b = Array::from_vec(vec![5., 6.]);
+    let mut b = Array::from(vec![5., 6.]);
     let mut a = Array::zeros(Ix0());
     a += 1.;
     b += &a;

--- a/tests/ixdyn.rs
+++ b/tests/ixdyn.rs
@@ -140,7 +140,7 @@ fn test_0_add_add() {
 
 #[test]
 fn test_0_add_broad() {
-    let mut b = Array::from_vec(vec![5., 6.]);
+    let mut b = Array::from(vec![5., 6.]);
     let mut a = Array::zeros(vec![]);
     a += 1.;
     b += &a;

--- a/tests/oper.rs
+++ b/tests/oper.rs
@@ -8,6 +8,7 @@ use ndarray::prelude::*;
 use ndarray::{rcarr1, rcarr2};
 use ndarray::{Data, LinalgScalar};
 use ndarray::{Ix, Ixs};
+use std::iter::FromIterator;
 
 use approx::assert_abs_diff_eq;
 use defmac::defmac;

--- a/tests/oper.rs
+++ b/tests/oper.rs
@@ -456,7 +456,7 @@ fn mat_mul_broadcast() {
     let (m, n, k) = (16, 16, 16);
     let a = range_mat(m, n);
     let x1 = 1.;
-    let x = Array::from_vec(vec![x1]);
+    let x = Array::from(vec![x1]);
     let b0 = x.broadcast((n, k)).unwrap();
     let b1 = Array::from_elem(n, x1);
     let b1 = b1.broadcast((n, k)).unwrap();

--- a/tests/windows.rs
+++ b/tests/windows.rs
@@ -3,6 +3,7 @@ extern crate ndarray;
 
 use ndarray::prelude::*;
 use ndarray::Zip;
+use std::iter::FromIterator;
 
 // Edge Cases for Windows iterator:
 //


### PR DESCRIPTION
ref https://github.com/rust-ndarray/ndarray/pull/642#discussion_r296068930

Is this the right direction?

I'm only now understanding how the rust import system works; I initially didn't realize you'd need an additional `use` statement each time to use `from_iter`. Should we be using `.collect()` in the examples? Or adding the `std::iter::FromIterator;` in the `ndarray` standard prelude? 