### PR TITLE
Use 2018 edition for ndarray-rand

### DIFF
--- a/ndarray-rand/Cargo.toml
+++ b/ndarray-rand/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "ndarray-rand"
 version = "0.9.0"
+edition = "2018"
 authors = ["bluss"]
 license = "MIT/Apache-2.0"
 

--- a/ndarray-rand/src/lib.rs
+++ b/ndarray-rand/src/lib.rs
@@ -9,8 +9,6 @@
 //! Constructors for randomized arrays. `rand` integration for `ndarray`.
 //!
 //! See [**`RandomExt`**](trait.RandomExt.html) for usage examples.
-extern crate ndarray;
-extern crate rand;
 
 use rand::distributions::Distribution;
 use rand::rngs::SmallRng;

--- a/ndarray-rand/tests/tests.rs
+++ b/ndarray-rand/tests/tests.rs
@@ -1,4 +1,3 @@
-
 use ndarray::Array;
 use ndarray_rand::RandomExt;
 use rand::distributions::Uniform;

--- a/ndarray-rand/tests/tests.rs
+++ b/ndarray-rand/tests/tests.rs
@@ -1,6 +1,3 @@
-extern crate ndarray;
-extern crate ndarray_rand;
-extern crate rand;
 
 use ndarray::Array;
 use ndarray_rand::RandomExt;


### PR DESCRIPTION
Can do this more broadly once we've decided on https://github.com/rust-ndarray/ndarray/issues/637