### PR TITLE
[WIP] TravisCI: add sccache to the pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: rust
 # use trusty for newer openblas
 sudo: required
 dist: trusty
+cache: cargo
 matrix:
   include:
     - rust: 1.31.0
@@ -22,13 +23,25 @@ env:
   global:
     - HOST=x86_64-unknown-linux-gnu
     - CARGO_INCREMENTAL=0
+    - DIST_SCCACHE=1
+    # Maximum space sccache cache will use on disk.
+    # This is the smallest possible value (as of sccache 0.29)
+    - SCCACHE_CACHE_SIZE="1G"
+    - SCCACHE_DIR=$TRAVIS_HOME/.cache/sccache
+    - PATH=$PATH:$TRAVIS_HOME/bin
+    - RUSTC_WRAPPER="sccache"
 addons:
   apt:
     packages:
       - libopenblas-dev
       - gfortran
+before_cache:
+  # this is a noop to avoid cache files deletion
+  # see: https://docs.travis-ci.com/user/languages/rust/#dependency-management
 before_script:
   - rustup component add rustfmt
+  - ./scripts/get-sccache.sh
+  - sccache --version
 script:
   - |
     cargo fmt --all -- --check &&

--- a/scripts/get-sccache.sh
+++ b/scripts/get-sccache.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+set -x
+set -e
+
+# WARNING: installing and compiling sccache using cargo is slow
+# and compiling on Rust 1.31 will fail
+# so we will download binaries
+
+SC_URL="https://github.com/mozilla/sccache/releases/download"
+SC_VER=0.2.9
+SC_ARCH=x86_64
+SC_PLAT=unknown-linux-musl # or apple-darwin, pc-windows-msvc
+
+wget "$SC_URL/$SC_VER/sccache-$SC_VER-$SC_ARCH-$SC_PLAT.tar.gz" -O - | tar xvz
+mv "sccache-$SC_VER-$SC_ARCH-$SC_PLAT/sccache" $TRAVIS_HOME/bin/
+
+exit 0


### PR DESCRIPTION
working on #664 

Hi, this PR enables `sccache` on your Rust builds.

I don't see a huge speed up to be honest (In [my test builds](https://travis-ci.com/apiraino/ndarray/builds/120052210) I can only shave off ~10 minutes), I'm still trying to figure out [why I have a very low rate of cache hits](https://github.com/mozilla/sccache/issues/484).

ref: https://docs.travis-ci.com/user/languages/rust/#dependency-management