### PR TITLE
ENH Add Array2::from_diag

### DIFF
--- a/src/impl_constructors.rs
+++ b/src/impl_constructors.rs
@@ -171,6 +171,20 @@ where
         }
         eye
     }
+
+    /// Create a 2D matrix from its diagonal
+    pub fn from_diag(diag: &ArrayBase<S, Ix1>) -> Self
+    where
+        S: DataMut,
+        A: Clone + Zero + One,
+    {
+        let mut eye = Self::zeros((diag.len(), diag.len()));
+        for (idx, val) in diag.iter().enumerate() {
+            eye[[idx, idx]] = val.clone();
+        }
+        eye
+    }
+
 }
 
 #[cfg(not(debug_assertions))]

--- a/src/impl_constructors.rs
+++ b/src/impl_constructors.rs
@@ -173,16 +173,16 @@ where
     }
 
     /// Create a 2D matrix from its diagonal
-    pub fn from_diag(diag: &ArrayBase<S, Ix1>) -> Self
+    pub fn from_diag<S2>(diag: &ArrayBase<S2, Ix1>) -> Self
     where
+        A: Clone + Zero,
         S: DataMut,
-        A: Clone + Zero + One,
+        S2: Data<Elem = A>,
     {
-        let mut eye = Self::zeros((diag.len(), diag.len()));
-        for (idx, val) in diag.iter().enumerate() {
-            eye[[idx, idx]] = val.clone();
-        }
-        eye
+        let n = diag.len();
+        let mut arr = Self::zeros((n, n));
+        arr.diag_mut().assign(&diag);
+        arr
     }
 }
 

--- a/src/impl_constructors.rs
+++ b/src/impl_constructors.rs
@@ -179,11 +179,9 @@ where
     /// ```rust
     /// use ndarray::{Array2, arr1, arr2};
     ///
-    /// # #[cfg(feature = "approx")] {
     /// let diag = arr1(&[1, 2]);
     /// let array = Array2::from_diag(&diag);
     /// assert_eq!(array, arr2(&[[1, 0], [0, 2]]));
-    /// # }
     pub fn from_diag<S2>(diag: &ArrayBase<S2, Ix1>) -> Self
     where
         A: Clone + Zero,

--- a/src/impl_constructors.rs
+++ b/src/impl_constructors.rs
@@ -182,6 +182,7 @@ where
     /// let diag = arr1(&[1, 2]);
     /// let array = Array2::from_diag(&diag);
     /// assert_eq!(array, arr2(&[[1, 0], [0, 2]]));
+    /// ```
     pub fn from_diag<S2>(diag: &ArrayBase<S2, Ix1>) -> Self
     where
         A: Clone + Zero,

--- a/src/impl_constructors.rs
+++ b/src/impl_constructors.rs
@@ -184,7 +184,6 @@ where
         }
         eye
     }
-
 }
 
 #[cfg(not(debug_assertions))]

--- a/src/impl_constructors.rs
+++ b/src/impl_constructors.rs
@@ -173,6 +173,17 @@ where
     }
 
     /// Create a 2D matrix from its diagonal
+    ///
+    /// **Panics** if `diag.len() * diag.len()` would overflow `isize`.
+    ///
+    /// ```rust
+    /// use ndarray::{Array2, arr1, arr2};
+    ///
+    /// # #[cfg(feature = "approx")] {
+    /// let diag = arr1(&[1, 2]);
+    /// let array = Array2::from_diag(&diag);
+    /// assert_eq!(array, arr2(&[[1, 0], [0, 2]]));
+    /// # }
     pub fn from_diag<S2>(diag: &ArrayBase<S2, Ix1>) -> Self
     where
         A: Clone + Zero,

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -1954,6 +1954,16 @@ fn test_array_clone_same_view() {
     assert_eq!(a, b);
 }
 
+
+#[test]
+fn test_array2_from_diag() {
+    let diag = arr1(&[0, 1, 2]);
+    let x = Array2::from_diag(&diag);
+    let x_exp = arr2(&[[0, 0, 0], [0, 1, 0], [0, 0, 2]]);
+    assert_eq!(x, x_exp);
+}
+
+
 #[test]
 fn array_macros() {
     // array

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -1960,6 +1960,12 @@ fn test_array2_from_diag() {
     let x = Array2::from_diag(&diag);
     let x_exp = arr2(&[[0, 0, 0], [0, 1, 0], [0, 0, 2]]);
     assert_eq!(x, x_exp);
+
+    // check 0 length array
+    let diag = Array1::<f64>::zeros(0);
+    let x = Array2::from_diag(&diag);
+    assert_eq!(x.ndim(), 2);
+    assert_eq!(x.shape(), [0, 0]);
 }
 
 #[test]

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -1954,7 +1954,6 @@ fn test_array_clone_same_view() {
     assert_eq!(a, b);
 }
 
-
 #[test]
 fn test_array2_from_diag() {
     let diag = arr1(&[0, 1, 2]);
@@ -1962,7 +1961,6 @@ fn test_array2_from_diag() {
     let x_exp = arr2(&[[0, 0, 0], [0, 1, 0], [0, 0, 2]]);
     assert_eq!(x, x_exp);
 }
-
 
 #[test]
 fn array_macros() {


### PR DESCRIPTION
Adds a `Array2::from_diag` method to create 2D arrays from a diagonal.

Closes #672