### PR TITLE
Deny warnings in CI (except for nightly channel)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,16 @@ matrix:
     - rust: 1.32.0
       env:
        - FEATURES='test docs'
+       - RUSTFLAGS='-D warnings'
     - rust: stable
       env:
        - FEATURES='test docs'
+       - RUSTFLAGS='-D warnings'
     - rust: beta
       env:
        - FEATURES='test docs'
        - CHANNEL='beta'
+       - RUSTFLAGS='-D warnings'
     - rust: nightly
       env:
        - FEATURES='test docs'

--- a/serialization-tests/tests/serialize.rs
+++ b/serialization-tests/tests/serialize.rs
@@ -9,7 +9,7 @@ extern crate rmp_serde;
 #[cfg(feature = "ron")]
 extern crate ron;
 
-use ndarray::{arr0, arr1, arr2, s, ArrayD, IxDyn, RcArray, RcArray1, RcArray2};
+use ndarray::{arr0, arr1, arr2, s, ArcArray, ArrayD, Ix2, IxDyn};
 
 #[test]
 fn serial_many_dim_serde() {
@@ -17,7 +17,7 @@ fn serial_many_dim_serde() {
         let a = arr0::<f32>(2.72);
         let serial = serde_json::to_string(&a).unwrap();
         println!("Serde encode {:?} => {:?}", a, serial);
-        let res = serde_json::from_str::<RcArray<f32, _>>(&serial);
+        let res = serde_json::from_str::<ArcArray<f32, _>>(&serial);
         println!("{:?}", res);
         assert_eq!(a, res.unwrap());
     }
@@ -26,7 +26,7 @@ fn serial_many_dim_serde() {
         let a = arr1::<f32>(&[2.72, 1., 2.]);
         let serial = serde_json::to_string(&a).unwrap();
         println!("Serde encode {:?} => {:?}", a, serial);
-        let res = serde_json::from_str::<RcArray1<f32>>(&serial);
+        let res = serde_json::from_str::<ArcArray<f32, _>>(&serial);
         println!("{:?}", res);
         assert_eq!(a, res.unwrap());
     }
@@ -35,21 +35,21 @@ fn serial_many_dim_serde() {
         let a = arr2(&[[3., 1., 2.2], [3.1, 4., 7.]]);
         let serial = serde_json::to_string(&a).unwrap();
         println!("Serde encode {:?} => {:?}", a, serial);
-        let res = serde_json::from_str::<RcArray2<f32>>(&serial);
+        let res = serde_json::from_str::<ArcArray<f32, _>>(&serial);
         println!("{:?}", res);
         assert_eq!(a, res.unwrap());
         let text = r##"{"v":1,"dim":[2,3],"data":[3,1,2.2,3.1,4,7]}"##;
-        let b = serde_json::from_str::<RcArray2<f32>>(text);
+        let b = serde_json::from_str::<ArcArray<f32, _>>(text);
         assert_eq!(a, b.unwrap());
     }
 
     {
         // Test a sliced array.
-        let mut a = RcArray::linspace(0., 31., 32).reshape((2, 2, 2, 4));
+        let mut a = ArcArray::linspace(0., 31., 32).reshape((2, 2, 2, 4));
         a.slice_collapse(s![..;-1, .., .., ..2]);
         let serial = serde_json::to_string(&a).unwrap();
         println!("Encode {:?} => {:?}", a, serial);
-        let res = serde_json::from_str::<RcArray<f32, _>>(&serial);
+        let res = serde_json::from_str::<ArcArray<f32, _>>(&serial);
         println!("{:?}", res);
         assert_eq!(a, res.unwrap());
     }
@@ -61,7 +61,7 @@ fn serial_ixdyn_serde() {
         let a = arr0::<f32>(2.72).into_dyn();
         let serial = serde_json::to_string(&a).unwrap();
         println!("Serde encode {:?} => {:?}", a, serial);
-        let res = serde_json::from_str::<RcArray<f32, _>>(&serial);
+        let res = serde_json::from_str::<ArcArray<f32, _>>(&serial);
         println!("{:?}", res);
         assert_eq!(a, res.unwrap());
     }
@@ -98,13 +98,13 @@ fn serial_ixdyn_serde() {
 fn serial_wrong_count_serde() {
     // one element too few
     let text = r##"{"v":1,"dim":[2,3],"data":[3,1,2.2,3.1,4]}"##;
-    let arr = serde_json::from_str::<RcArray2<f32>>(text);
+    let arr = serde_json::from_str::<ArcArray<f32, Ix2>>(text);
     println!("{:?}", arr);
     assert!(arr.is_err());
 
     // future version
     let text = r##"{"v":200,"dim":[2,3],"data":[3,1,2.2,3.1,4,7]}"##;
-    let arr = serde_json::from_str::<RcArray2<f32>>(text);
+    let arr = serde_json::from_str::<ArcArray<f32, Ix2>>(text);
     println!("{:?}", arr);
     assert!(arr.is_err());
 }
@@ -120,7 +120,7 @@ fn serial_many_dim_serde_msgpack() {
             .unwrap();
 
         let mut deserializer = rmp_serde::Deserializer::new(&buf[..]);
-        let a_de: RcArray<f32, _> = serde::Deserialize::deserialize(&mut deserializer).unwrap();
+        let a_de: ArcArray<f32, _> = serde::Deserialize::deserialize(&mut deserializer).unwrap();
 
         assert_eq!(a, a_de);
     }
@@ -134,7 +134,7 @@ fn serial_many_dim_serde_msgpack() {
             .unwrap();
 
         let mut deserializer = rmp_serde::Deserializer::new(&buf[..]);
-        let a_de: RcArray<f32, _> = serde::Deserialize::deserialize(&mut deserializer).unwrap();
+        let a_de: ArcArray<f32, _> = serde::Deserialize::deserialize(&mut deserializer).unwrap();
 
         assert_eq!(a, a_de);
     }
@@ -148,14 +148,14 @@ fn serial_many_dim_serde_msgpack() {
             .unwrap();
 
         let mut deserializer = rmp_serde::Deserializer::new(&buf[..]);
-        let a_de: RcArray<f32, _> = serde::Deserialize::deserialize(&mut deserializer).unwrap();
+        let a_de: ArcArray<f32, _> = serde::Deserialize::deserialize(&mut deserializer).unwrap();
 
         assert_eq!(a, a_de);
     }
 
     {
         // Test a sliced array.
-        let mut a = RcArray::linspace(0., 31., 32).reshape((2, 2, 2, 4));
+        let mut a = ArcArray::linspace(0., 31., 32).reshape((2, 2, 2, 4));
         a.slice_collapse(s![..;-1, .., .., ..2]);
 
         let mut buf = Vec::new();
@@ -164,7 +164,7 @@ fn serial_many_dim_serde_msgpack() {
             .unwrap();
 
         let mut deserializer = rmp_serde::Deserializer::new(&buf[..]);
-        let a_de: RcArray<f32, _> = serde::Deserialize::deserialize(&mut deserializer).unwrap();
+        let a_de: ArcArray<f32, _> = serde::Deserialize::deserialize(&mut deserializer).unwrap();
 
         assert_eq!(a, a_de);
     }
@@ -181,7 +181,7 @@ fn serial_many_dim_ron() {
 
         let a_s = ron_serialize(&a).unwrap();
 
-        let a_de: RcArray<f32, _> = ron_deserialize(&a_s).unwrap();
+        let a_de: ArcArray<f32, _> = ron_deserialize(&a_s).unwrap();
 
         assert_eq!(a, a_de);
     }
@@ -191,7 +191,7 @@ fn serial_many_dim_ron() {
 
         let a_s = ron_serialize(&a).unwrap();
 
-        let a_de: RcArray<f32, _> = ron_deserialize(&a_s).unwrap();
+        let a_de: ArcArray<f32, _> = ron_deserialize(&a_s).unwrap();
 
         assert_eq!(a, a_de);
     }
@@ -201,19 +201,19 @@ fn serial_many_dim_ron() {
 
         let a_s = ron_serialize(&a).unwrap();
 
-        let a_de: RcArray<f32, _> = ron_deserialize(&a_s).unwrap();
+        let a_de: ArcArray<f32, _> = ron_deserialize(&a_s).unwrap();
 
         assert_eq!(a, a_de);
     }
 
     {
         // Test a sliced array.
-        let mut a = RcArray::linspace(0., 31., 32).reshape((2, 2, 2, 4));
+        let mut a = ArcArray::linspace(0., 31., 32).reshape((2, 2, 2, 4));
         a.slice_collapse(s![..;-1, .., .., ..2]);
 
         let a_s = ron_serialize(&a).unwrap();
 
-        let a_de: RcArray<f32, _> = ron_deserialize(&a_s).unwrap();
+        let a_de: ArcArray<f32, _> = ron_deserialize(&a_s).unwrap();
 
         assert_eq!(a, a_de);
     }


### PR DESCRIPTION
I was surprised to read in #661 that there are warnings that we haven't fixed. This PR makes the build fail if there are any compiler warnings, except on the nightly channel.

It's tempting to add `#![deny(warnings)]` to the top of `lib.rs`, but when working on `ndarray`, I don't really want warnings to get in the way of development. So, I'm proposing just denying warnings in CI.