### PR TITLE
Add .split_at() methods for AxisChunksIter/Mut

### DIFF
--- a/src/iterators/mod.rs
+++ b/src/iterators/mod.rs
@@ -825,6 +825,19 @@ impl<A, D: Dimension> AxisIterCore<A, D> {
         };
         (left, right)
     }
+
+    /// Does the same thing as `.next()` but also returns the index of the item
+    /// relative to the start of the axis.
+    fn next_with_index(&mut self) -> Option<(usize, *mut A)> {
+        let index = self.index;
+        self.next().map(|ptr| (index, ptr))
+    }
+
+    /// Does the same thing as `.next_back()` but also returns the index of the
+    /// item relative to the start of the axis.
+    fn next_back_with_index(&mut self) -> Option<(usize, *mut A)> {
+        self.next_back().map(|ptr| (self.end, ptr))
+    }
 }
 
 impl<A, D> Iterator for AxisIterCore<A, D>
@@ -1299,8 +1312,9 @@ macro_rules! chunk_iter_impl {
             type Item = $array<'a, A, D>;
 
             fn next(&mut self) -> Option<Self::Item> {
-                let index = self.iter.index;
-                self.iter.next().map(|ptr| self.get_subview(index, ptr))
+                self.iter
+                    .next_with_index()
+                    .map(|(index, ptr)| self.get_subview(index, ptr))
             }
 
             fn size_hint(&self) -> (usize, Option<usize>) {
@@ -1314,8 +1328,8 @@ macro_rules! chunk_iter_impl {
         {
             fn next_back(&mut self) -> Option<Self::Item> {
                 self.iter
-                    .next_back()
-                    .map(|ptr| self.get_subview(self.iter.end, ptr))
+                    .next_back_with_index()
+                    .map(|(index, ptr)| self.get_subview(index, ptr))
             }
         }
 

--- a/src/iterators/mod.rs
+++ b/src/iterators/mod.rs
@@ -1303,6 +1303,31 @@ macro_rules! chunk_iter_impl {
                     }
                 }
             }
+
+            /// Splits the iterator at index, yielding two disjoint iterators.
+            ///
+            /// `index` is relative to the current state of the iterator (which is not
+            /// necessarily the start of the axis).
+            ///
+            /// **Panics** if `index` is strictly greater than the iterator's remaining
+            /// length.
+            pub fn split_at(self, index: usize) -> (Self, Self) {
+                let (left, right) = self.iter.split_at(index);
+                (
+                    Self {
+                        iter: left,
+                        partial_chunk_index: self.partial_chunk_index,
+                        partial_chunk_dim: self.partial_chunk_dim.clone(),
+                        life: self.life,
+                    },
+                    Self {
+                        iter: right,
+                        partial_chunk_index: self.partial_chunk_index,
+                        partial_chunk_dim: self.partial_chunk_dim,
+                        life: self.life,
+                    },
+                )
+            }
         }
 
         impl<'a, A, D> Iterator for $iter<'a, A, D>


### PR DESCRIPTION
This adds `.split_at()` methods for `AxisChunksIter` and `AxisChunksIterMut`. Once this is merged, it will be straightforward to implement #639 in terms of `.split_at()`.