### PR TITLE
Add .nrows(), .ncols() and old names .rows(), .cols() are now deprecated

### DIFF
--- a/examples/bounds_check_elim.rs
+++ b/examples/bounds_check_elim.rs
@@ -88,8 +88,8 @@ pub fn test1d_while(a: &Array1<f64>) -> f64 {
 #[no_mangle]
 pub fn test2d_ranges(a: &Array2<f64>) -> f64 {
     let mut sum = 0.;
-    for i in 0..a.rows() {
-        for j in 0..a.cols() {
+    for i in 0..a.nrows() {
+        for j in 0..a.ncols() {
             sum += a[[i, j]];
         }
     }
@@ -100,9 +100,9 @@ pub fn test2d_ranges(a: &Array2<f64>) -> f64 {
 pub fn test2d_whiles(a: &Array2<f64>) -> f64 {
     let mut sum = 0.;
     let mut i = 0;
-    while i < a.rows() {
+    while i < a.nrows() {
         let mut j = 0;
-        while j < a.cols() {
+        while j < a.ncols() {
             sum += a[[i, j]];
             j += 1;
         }

--- a/examples/life.rs
+++ b/examples/life.rs
@@ -59,7 +59,7 @@ fn iterate(z: &mut Board, scratch: &mut Board) {
 
 fn turn_on_corners(z: &mut Board) {
     let n = z.nrows();
-    let m = z.cols();
+    let m = z.ncols();
     z[[1, 1]] = 1;
     z[[1, m - 2]] = 1;
     z[[n - 2, 1]] = 1;

--- a/examples/life.rs
+++ b/examples/life.rs
@@ -58,7 +58,7 @@ fn iterate(z: &mut Board, scratch: &mut Board) {
 }
 
 fn turn_on_corners(z: &mut Board) {
-    let n = z.rows();
+    let n = z.nrows();
     let m = z.cols();
     z[[1, 1]] = 1;
     z[[1, m - 2]] = 1;

--- a/src/doc/ndarray_for_numpy_users/mod.rs
+++ b/src/doc/ndarray_for_numpy_users/mod.rs
@@ -554,7 +554,7 @@
 //! NumPy | `ndarray` | Notes
 //! ------|-----------|------
 //! `len(a)` or `a.shape[0]` | [`a.nrows()`][.nrows()] | get the number of rows in a 2-D array
-//! `a.shape[1]` | [`a.cols()`][.cols()] | get the number of columns in a 2-D array
+//! `a.shape[1]` | [`a.ncols()`][.ncols()] | get the number of columns in a 2-D array
 //! `a[1]` or `a[1,:]` | [`a.row(1)`][.row()] or [`a.row_mut(1)`][.row_mut()] | view (or mutable view) of row 1 in a 2-D array
 //! `a[:,4]` | [`a.column(4)`][.column()] or [`a.column_mut(4)`][.column_mut()] | view (or mutable view) of column 4 in a 2-D array
 //! `a.shape[0] == a.shape[1]` | [`a.is_square()`][.is_square()] | check if the array is square
@@ -571,7 +571,7 @@
 //! [.assign()]: ../../struct.ArrayBase.html#method.assign
 //! [.axis_iter()]: ../../struct.ArrayBase.html#method.axis_iter
 //! [azip!]: ../../macro.azip.html
-//! [.cols()]: ../../struct.ArrayBase.html#method.cols
+//! [.ncols()]: ../../struct.ArrayBase.html#method.ncols
 //! [.column()]: ../../struct.ArrayBase.html#method.column
 //! [.column_mut()]: ../../struct.ArrayBase.html#method.column_mut
 //! [CowArray]: ../../type.CowArray.html

--- a/src/doc/ndarray_for_numpy_users/mod.rs
+++ b/src/doc/ndarray_for_numpy_users/mod.rs
@@ -553,7 +553,7 @@
 //!
 //! NumPy | `ndarray` | Notes
 //! ------|-----------|------
-//! `len(a)` or `a.shape[0]` | [`a.rows()`][.rows()] | get the number of rows in a 2-D array
+//! `len(a)` or `a.shape[0]` | [`a.nrows()`][.nrows()] | get the number of rows in a 2-D array
 //! `a.shape[1]` | [`a.cols()`][.cols()] | get the number of columns in a 2-D array
 //! `a[1]` or `a[1,:]` | [`a.row(1)`][.row()] or [`a.row_mut(1)`][.row_mut()] | view (or mutable view) of row 1 in a 2-D array
 //! `a[:,4]` | [`a.column(4)`][.column()] or [`a.column_mut(4)`][.column_mut()] | view (or mutable view) of column 4 in a 2-D array
@@ -615,7 +615,7 @@
 //! [.reversed_axes()]: ../../struct.ArrayBase.html#method.reversed_axes
 //! [.row()]: ../../struct.ArrayBase.html#method.row
 //! [.row_mut()]: ../../struct.ArrayBase.html#method.row_mut
-//! [.rows()]: ../../struct.ArrayBase.html#method.rows
+//! [.nrows()]: ../../struct.ArrayBase.html#method.nrows
 //! [s!]: ../../macro.s.html
 //! [.sum()]: ../../struct.ArrayBase.html#method.sum
 //! [.slice()]: ../../struct.ArrayBase.html#method.slice

--- a/src/impl_2d.rs
+++ b/src/impl_2d.rs
@@ -35,8 +35,14 @@ where
     }
 
     /// Return the number of rows (length of `Axis(0)`) in the two-dimensional array.
-    pub fn rows(&self) -> usize {
+    pub fn nrows(&self) -> usize {
         self.len_of(Axis(0))
+    }
+
+    /// Return the number of rows (length of `Axis(0)`) in the two-dimensional array.
+    #[deprecated(note="Renamed to .nrows(), please use the new name")]
+    pub fn rows(&self) -> usize {
+        self.nrows()
     }
 
     /// Return an array view of column `index`.
@@ -60,12 +66,18 @@ where
     }
 
     /// Return the number of columns (length of `Axis(1)`) in the two-dimensional array.
-    pub fn cols(&self) -> usize {
+    pub fn ncols(&self) -> usize {
         self.len_of(Axis(1))
+    }
+
+    /// Return the number of columns (length of `Axis(1)`) in the two-dimensional array.
+    #[deprecated(note="Renamed to .ncols(), please use the new name")]
+    pub fn cols(&self) -> usize {
+        self.ncols()
     }
 
     /// Return true if the array is square, false otherwise.
     pub fn is_square(&self) -> bool {
-        self.rows() == self.cols()
+        self.nrows() == self.ncols()
     }
 }

--- a/src/impl_2d.rs
+++ b/src/impl_2d.rs
@@ -40,7 +40,7 @@ where
     }
 
     /// Return the number of rows (length of `Axis(0)`) in the two-dimensional array.
-    #[deprecated(note="Renamed to .nrows(), please use the new name")]
+    #[deprecated(note = "Renamed to .nrows(), please use the new name")]
     pub fn rows(&self) -> usize {
         self.nrows()
     }
@@ -71,7 +71,7 @@ where
     }
 
     /// Return the number of columns (length of `Axis(1)`) in the two-dimensional array.
-    #[deprecated(note="Renamed to .ncols(), please use the new name")]
+    #[deprecated(note = "Renamed to .ncols(), please use the new name")]
     pub fn cols(&self) -> usize {
         self.ncols()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -404,7 +404,7 @@ pub type Ixs = isize;
 ///
 /// // 2. Use Zip to pair each row in 2D `a` with elements in 1D `b`
 /// use ndarray::Zip;
-/// let mut b = Array::zeros(a.rows());
+/// let mut b = Array::zeros(a.nrows());
 ///
 /// Zip::from(a.genrows())
 ///     .and(&mut b)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -409,7 +409,7 @@ pub type Ixs = isize;
 /// Zip::from(a.genrows())
 ///     .and(&mut b)
 ///     .apply(|a_row, b_elt| {
-///         *b_elt = a_row[a.cols() - 1] - a_row[0];
+///         *b_elt = a_row[a.ncols() - 1] - a_row[0];
 ///     });
 /// ```
 ///

--- a/src/zip/mod.rs
+++ b/src/zip/mod.rs
@@ -448,7 +448,7 @@ impl<'a, A, D: Dimension> NdProducer for ArrayViewMut<'a, A, D> {
 ///
 /// use ndarray::{Array1, Axis};
 ///
-/// let mut totals = Array1::zeros(a.rows());
+/// let mut totals = Array1::zeros(a.nrows());
 ///
 /// Zip::from(&mut totals)
 ///     .and(a.genrows())

--- a/src/zip/zipmacro.rs
+++ b/src/zip/zipmacro.rs
@@ -102,7 +102,7 @@
 ///     //
 ///     // The row is an array view; use the 'ref' rule on the row, to avoid the
 ///     // default which is to dereference the produced item.
-///     let mut totals = Array1::zeros(a.rows());
+///     let mut totals = Array1::zeros(a.nrows());
 ///
 ///     azip!(mut totals, ref row (a.genrows()) in {
 ///         *totals = row.sum();

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -1852,8 +1852,8 @@ fn test_swap() {
     let mut a = arr2(&[[1, 2, 3], [4, 5, 6], [7, 8, 9]]);
     let b = a.clone();
 
-    for i in 0..a.rows() {
-        for j in i + 1..a.cols() {
+    for i in 0..a.nrows() {
+        for j in i + 1..a.ncols() {
             a.swap((i, j), (j, i));
         }
     }
@@ -1865,8 +1865,8 @@ fn test_uswap() {
     let mut a = arr2(&[[1, 2, 3], [4, 5, 6], [7, 8, 9]]);
     let b = a.clone();
 
-    for i in 0..a.rows() {
-        for j in i + 1..a.cols() {
+    for i in 0..a.nrows() {
+        for j in i + 1..a.ncols() {
             unsafe { a.uswap((i, j), (j, i)) };
         }
     }

--- a/tests/zst.rs
+++ b/tests/zst.rs
@@ -7,8 +7,8 @@ fn test_swap() {
 
     let b = a.clone();
 
-    for i in 0..a.rows() {
-        for j in i + 1..a.cols() {
+    for i in 0..a.nrows() {
+        for j in i + 1..a.ncols() {
             a.swap((i, j), (j, i));
         }
     }


### PR DESCRIPTION
.rows()/.cols() are renamed to nrows/ncols respectively, to make space
for putting the row iterable/ndproducer in this place instead.

The deprecated methods will be removed in the release after they were
first deprecated.

These new names and the deprecations are the first step towards renaming genrows/gencolumns  #698 