### PR TITLE
ndarray-rand documentation fixes

### DIFF
--- a/ndarray-rand/src/lib.rs
+++ b/ndarray-rand/src/lib.rs
@@ -50,10 +50,6 @@ where
     /// overflows usize.
     ///
     /// ```
-    /// extern crate rand;
-    /// extern crate ndarray;
-    /// extern crate ndarray_rand;
-    ///
     /// use rand::distributions::Uniform;
     /// use ndarray::Array;
     /// use ndarray_rand::RandomExt;
@@ -109,10 +105,6 @@ where
 /// A wrapper type that allows casting f64 distributions to f32
 ///
 /// ```
-/// extern crate rand;
-/// extern crate ndarray;
-/// extern crate ndarray_rand;
-///
 /// use rand::distributions::Normal;
 /// use ndarray::Array;
 /// use ndarray_rand::{RandomExt, F32};

--- a/ndarray-rand/src/lib.rs
+++ b/ndarray-rand/src/lib.rs
@@ -50,7 +50,7 @@ where
     /// overflows usize.
     ///
     /// ```
-    /// use rand::distributions::Uniform;
+    /// use rand_distr::Uniform;
     /// use ndarray::Array;
     /// use ndarray_rand::RandomExt;
     ///
@@ -105,12 +105,12 @@ where
 /// A wrapper type that allows casting f64 distributions to f32
 ///
 /// ```
-/// use rand::distributions::Normal;
+/// use rand_distr::Normal;
 /// use ndarray::Array;
 /// use ndarray_rand::{RandomExt, F32};
 ///
 /// # fn main() {
-/// let a = Array::random((2, 5), F32(Normal::new(0., 1.)));
+/// let a = Array::random((2, 5), F32(Normal::new(0., 1.).unwrap()));
 /// println!("{:8.4}", a);
 /// // Example Output:
 /// // [[ -0.6910,   1.1730,   1.0902,  -0.4092,  -1.7340],


### PR DESCRIPTION
Update examples in documentation to

1. skip extern crate lines which are not needed now
2. Use rand_distr since using the code in the old examples would give deprecation warnings