### PR TITLE
Rename crate feature serde-1 to just serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,6 @@ cblas-sys = { version = "0.1.4", optional = true, default-features = false }
 blas-src = { version = "0.2.0", optional = true, default-features = false }
 
 matrixmultiply = { version = "0.2.0" }
-# Use via the `serde-1` crate feature!
 serde = { version = "1.0", optional = true }
 rawpointer = { version = "0.2" }
 
@@ -57,7 +56,7 @@ itertools = { version = "0.8.0", default-features = false, features = ["use_std"
 # See README for more instructions
 blas = ["cblas-sys", "blas-src"]
 
-# Serde 1.0
+# Old name for the serde feature
 serde-1 = ["serde"]
 
 # These features are used for testing
@@ -65,7 +64,7 @@ test-blas-openblas-sys = ["blas"]
 test = ["test-blas-openblas-sys"]
 
 # This feature is used for docs
-docs = ["approx", "serde-1", "rayon"]
+docs = ["approx", "serde", "rayon"]
 
 [profile.release]
 [profile.bench]

--- a/README.rst
+++ b/README.rst
@@ -47,10 +47,10 @@ Crate Feature Flags
 The following crate feature flags are available. They are configured in
 your `Cargo.toml`.
 
-- ``serde-1``
+- ``serde``
 
   - Optional, compatible with Rust stable
-  - Enables serialization support for serde 1.0
+  - Enables serialization support for serde 1.x
 
 - ``rayon``
 

--- a/serialization-tests/Cargo.toml
+++ b/serialization-tests/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 test = false
 
 [dependencies]
-ndarray = { path = "../", features = ["serde-1"] }
+ndarray = { path = "../", features = ["serde"] }
 
 [features]
 default = ["ron"]

--- a/src/array_serde.rs
+++ b/src/array_serde.rs
@@ -32,7 +32,7 @@ where
     }
 }
 
-/// **Requires crate feature `"serde-1"`**
+/// **Requires crate feature `"serde"`**
 impl<I> Serialize for Dim<I>
 where
     I: Serialize,
@@ -45,7 +45,7 @@ where
     }
 }
 
-/// **Requires crate feature `"serde-1"`**
+/// **Requires crate feature `"serde"`**
 impl<'de, I> Deserialize<'de> for Dim<I>
 where
     I: Deserialize<'de>,
@@ -58,7 +58,7 @@ where
     }
 }
 
-/// **Requires crate feature `"serde-1"`**
+/// **Requires crate feature `"serde"`**
 impl Serialize for IxDyn {
     fn serialize<Se>(&self, serializer: Se) -> Result<Se::Ok, Se::Error>
     where
@@ -68,7 +68,7 @@ impl Serialize for IxDyn {
     }
 }
 
-/// **Requires crate feature `"serde-1"`**
+/// **Requires crate feature `"serde"`**
 impl<'de> Deserialize<'de> for IxDyn {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -79,7 +79,7 @@ impl<'de> Deserialize<'de> for IxDyn {
     }
 }
 
-/// **Requires crate feature `"serde-1"`**
+/// **Requires crate feature `"serde"`**
 impl<A, D, S> Serialize for ArrayBase<S, D>
 where
     A: Serialize,
@@ -141,7 +141,7 @@ impl<S, Di> ArrayVisitor<S, Di> {
 
 static ARRAY_FIELDS: &[&str] = &["v", "dim", "data"];
 
-/// **Requires crate feature `"serde-1"`**
+/// **Requires crate feature `"serde"`**
 impl<'de, A, Di, S> Deserialize<'de> for ArrayBase<S, Di>
 where
     A: Deserialize<'de>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,9 +68,9 @@
 //! The following crate feature flags are available. They are configured in your
 //! `Cargo.toml`.
 //!
-//! - `serde-1`
+//! - `serde`
 //!   - Optional, compatible with Rust stable
-//!   - Enables serialization support for serde 1.0
+//!   - Enables serialization support for serde 1.x
 //! - `rayon`
 //!   - Optional, compatible with Rust stable
 //!   - Enables parallel iterators, parallelized methods and [`par_azip!`].
@@ -135,7 +135,7 @@ mod private;
 mod aliases;
 #[cfg(feature = "approx")]
 mod array_approx;
-#[cfg(feature = "serde-1")]
+#[cfg(feature = "serde")]
 mod array_serde;
 mod arrayformat;
 mod arraytraits;


### PR DESCRIPTION
Old name is deprecated.
Cargo supports dependency renames now, so this feature name with version
is no longer needed.