### PR TITLE
Add error message for invalid syntax in s![]

### DIFF
--- a/src/slice.rs
+++ b/src/slice.rs
@@ -612,6 +612,8 @@ macro_rules! s(
     (@convert $r:expr, $s:expr) => {
         <$crate::SliceOrIndex as ::std::convert::From<_>>::from($r).step_by($s as isize)
     };
+    // Catch-all clause for syntax errors
+    (@parse $($t:tt)*) => { compile_error!("Invalid syntax in s![], expected at least one index or range") };
     ($($t:tt)*) => {
         // The extra `*&` is a workaround for this compiler bug:
         // https://github.com/rust-lang/rust/issues/23014


### PR DESCRIPTION
Invalid syntax, like for example empty `s![]` or clearly invalid
productions like `s![;;]` etc, end up in this new catch-all branch of
the macro and produce a clearer error message.

```rust
    error: Invalid syntax in s![], expected at least one index or range
      --> src/foo.rs:11:13
       |
    11 |     a.slice(s![]);
       |             ^^^^
```

Fixes #693 