### PR TITLE
Add support for empty s![] call

### DIFF
--- a/src/slice.rs
+++ b/src/slice.rs
@@ -604,6 +604,17 @@ macro_rules! s(
             }
         }
     };
+    // empty call, i.e. `s![]`
+    (@parse ::std::marker::PhantomData::<$crate::Ix0>, []) => {
+        {
+            #[allow(unsafe_code)]
+            unsafe {
+                $crate::SliceInfo::new_unchecked([], ::std::marker::PhantomData::<$crate::Ix0>)
+            }
+        }
+    };
+    // Catch-all clause for syntax errors
+    (@parse $($t:tt)*) => { compile_error!("Invalid syntax in s![] call.") };
     // convert range/index into SliceOrIndex
     (@convert $r:expr) => {
         <$crate::SliceOrIndex as ::std::convert::From<_>>::from($r)
@@ -612,8 +623,6 @@ macro_rules! s(
     (@convert $r:expr, $s:expr) => {
         <$crate::SliceOrIndex as ::std::convert::From<_>>::from($r).step_by($s as isize)
     };
-    // Catch-all clause for syntax errors
-    (@parse $($t:tt)*) => { compile_error!("Invalid syntax in s![], expected at least one index or range") };
     ($($t:tt)*) => {
         // The extra `*&` is a workaround for this compiler bug:
         // https://github.com/rust-lang/rust/issues/23014

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -92,6 +92,13 @@ fn test_slice() {
     assert!(vi.iter().zip(A.iter()).all(|(a, b)| a == b));
 }
 
+#[deny(unsafe_code)]
+#[test]
+fn test_slice_ix0() {
+    let arr = arr0(5);
+    assert_eq!(arr.slice(s![]), aview0(&5));
+}
+
 #[test]
 fn test_slice_edge_cases() {
     let mut arr = Array3::<u8>::zeros((3, 4, 5));


### PR DESCRIPTION
This is nice just for consistency with the other dimensionalities. I'm not sure if it's useful in practice, but it doesn't do any harm.

Related to #714 and #693.