### PR TITLE
Add multi_slice_* methods (supports flat tuples only)

### DIFF
--- a/src/dimension/mod.rs
+++ b/src/dimension/mod.rs
@@ -544,7 +544,6 @@ fn slice_min_max(axis_len: usize, slice: Slice) -> Option<(usize, usize)> {
 }
 
 /// Returns `true` iff the slices intersect.
-#[allow(dead_code)]
 pub fn slices_intersect<D: Dimension>(
     dim: &D,
     indices1: &D::SliceArg,

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -381,7 +381,7 @@ where
         M: MultiSlice<'a, A, D>,
         S: DataMut,
     {
-        unsafe { info.slice_and_deref(self.raw_view_mut()) }
+        info.multi_slice_move(self.view_mut())
     }
 
     /// Slice the array, possibly changing the number of dimensions.

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -28,6 +28,7 @@ use crate::iter::{
     AxisChunksIter, AxisChunksIterMut, AxisIter, AxisIterMut, ExactChunks, ExactChunksMut,
     IndexedIter, IndexedIterMut, Iter, IterMut, Lanes, LanesMut, Windows,
 };
+use crate::slice::MultiSlice;
 use crate::stacking::stack;
 use crate::{NdIndex, Slice, SliceInfo, SliceOrIndex};
 
@@ -348,6 +349,39 @@ where
         S: DataMut,
     {
         self.view_mut().slice_move(info)
+    }
+
+    /// Return multiple disjoint, sliced, mutable views of the array.
+    ///
+    /// See [*Slicing*](#slicing) for full documentation.
+    /// See also [`SliceInfo`] and [`D::SliceArg`].
+    ///
+    /// [`SliceInfo`]: struct.SliceInfo.html
+    /// [`D::SliceArg`]: trait.Dimension.html#associatedtype.SliceArg
+    ///
+    /// **Panics** if any of the following occur:
+    ///
+    /// * if any of the views would intersect (i.e. if any element would appear in multiple slices)
+    /// * if an index is out of bounds or step size is zero
+    /// * if `D` is `IxDyn` and `info` does not match the number of array axes
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use ndarray::{arr2, s};
+    ///
+    /// let mut a = arr2(&[[1, 2, 3], [4, 5, 6]]);
+    /// let (mut edges, mut middle) = a.multi_slice_mut((s![.., ..;2], s![.., 1]));
+    /// edges.fill(1);
+    /// middle.fill(0);
+    /// assert_eq!(a, arr2(&[[1, 0, 1], [1, 0, 1]]));
+    /// ```
+    pub fn multi_slice_mut<'a, M>(&'a mut self, info: M) -> M::Output
+    where
+        M: MultiSlice<'a, A, D>,
+        S: DataMut,
+    {
+        unsafe { info.slice_and_deref(self.raw_view_mut()) }
     }
 
     /// Slice the array, possibly changing the number of dimensions.

--- a/src/impl_views/splitting.rs
+++ b/src/impl_views/splitting.rs
@@ -129,10 +129,10 @@ where
     /// * if any of the views would intersect (i.e. if any element would appear in multiple slices)
     /// * if an index is out of bounds or step size is zero
     /// * if `D` is `IxDyn` and `info` does not match the number of array axes
-    pub fn multi_slice_move<M>(mut self, info: M) -> M::Output
+    pub fn multi_slice_move<M>(self, info: M) -> M::Output
     where
         M: MultiSlice<'a, A, D>,
     {
-        unsafe { info.slice_and_deref(self.raw_view_mut()) }
+        info.multi_slice_move(self)
     }
 }

--- a/src/impl_views/splitting.rs
+++ b/src/impl_views/splitting.rs
@@ -7,6 +7,7 @@
 // except according to those terms.
 
 use crate::imp_prelude::*;
+use crate::slice::MultiSlice;
 
 /// Methods for read-only array views.
 impl<'a, A, D> ArrayView<'a, A, D>
@@ -108,5 +109,30 @@ where
             let (left, right) = self.into_raw_view_mut().split_at(axis, index);
             (left.deref_into_view_mut(), right.deref_into_view_mut())
         }
+    }
+
+    /// Split the view into multiple disjoint slices.
+    ///
+    /// This is similar to [`.multi_slice_mut()`], but `.multi_slice_move()`
+    /// consumes `self` and produces views with lifetimes matching that of
+    /// `self`.
+    ///
+    /// See [*Slicing*](#slicing) for full documentation.
+    /// See also [`SliceInfo`] and [`D::SliceArg`].
+    ///
+    /// [`.multi_slice_mut()`]: struct.ArrayBase.html#method.multi_slice_mut
+    /// [`SliceInfo`]: struct.SliceInfo.html
+    /// [`D::SliceArg`]: trait.Dimension.html#associatedtype.SliceArg
+    ///
+    /// **Panics** if any of the following occur:
+    ///
+    /// * if any of the views would intersect (i.e. if any element would appear in multiple slices)
+    /// * if an index is out of bounds or step size is zero
+    /// * if `D` is `IxDyn` and `info` does not match the number of array axes
+    pub fn multi_slice_move<M>(mut self, info: M) -> M::Output
+    where
+        M: MultiSlice<'a, A, D>,
+    {
+        unsafe { info.slice_and_deref(self.raw_view_mut()) }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -475,6 +475,13 @@ pub type Ixs = isize;
 /// [`.slice_move()`]: #method.slice_move
 /// [`.slice_collapse()`]: #method.slice_collapse
 ///
+/// It's possible to take multiple simultaneous *mutable* slices with the
+/// [`.multi_slice_mut()`] or (for [`ArrayViewMut`] only)
+/// [`.multi_slice_move()`].
+///
+/// [`.multi_slice_mut()`]: #method.multi_slice_mut
+/// [`.multi_slice_move()`]: type.ArrayViewMut.html#method.multi_slice_move
+///
 /// ```
 /// extern crate ndarray;
 ///
@@ -525,6 +532,20 @@ pub type Ixs = isize;
 ///                [12, 11, 10]]);
 /// assert_eq!(f, g);
 /// assert_eq!(f.shape(), &[2, 3]);
+///
+/// // Let's take two disjoint, mutable slices of a matrix with
+/// //
+/// // - One containing all the even-index columns in the matrix
+/// // - One containing all the odd-index columns in the matrix
+/// let mut h = arr2(&[[0, 1, 2, 3],
+///                    [4, 5, 6, 7]]);
+/// let (s0, s1) = h.multi_slice_mut((s![.., ..;2], s![.., 1..;2]));
+/// let i = arr2(&[[0, 2],
+///                [4, 6]]);
+/// let j = arr2(&[[1, 3],
+///                [5, 7]]);
+/// assert_eq!(s0, i);
+/// assert_eq!(s1, j);
 /// }
 /// ```
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -475,7 +475,7 @@ pub type Ixs = isize;
 /// [`.slice_move()`]: #method.slice_move
 /// [`.slice_collapse()`]: #method.slice_collapse
 ///
-/// It's possible to take multiple simultaneous *mutable* slices with the
+/// It's possible to take multiple simultaneous *mutable* slices with
 /// [`.multi_slice_mut()`] or (for [`ArrayViewMut`] only)
 /// [`.multi_slice_move()`].
 ///

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -643,7 +643,7 @@ where
     /// The type of the slices created by `.multi_slice_move()`.
     type Output;
 
-    /// Slice the raw view into multiple raw views, and dereference them.
+    /// Split the view into multiple disjoint slices.
     ///
     /// **Panics** if performing any individual slice panics or if the slices
     /// are not disjoint (i.e. if they intersect).

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -660,20 +660,6 @@ where
     fn multi_slice_move(&self, _view: ArrayViewMut<'a, A, D>) -> Self::Output {}
 }
 
-impl<'a, A, D, Do0> MultiSlice<'a, A, D> for (SliceInfo<D::SliceArg, Do0>,)
-where
-    A: 'a,
-    D: Dimension,
-    D::SliceArg: Sized,
-    Do0: Dimension,
-{
-    type Output = (ArrayViewMut<'a, A, Do0>,);
-
-    fn multi_slice_move(&self, view: ArrayViewMut<'a, A, D>) -> Self::Output {
-        (view.slice_move(&self.0),)
-    }
-}
-
 impl<'a, A, D, Do0> MultiSlice<'a, A, D> for (&SliceInfo<D::SliceArg, Do0>,)
 where
     A: 'a,
@@ -689,27 +675,9 @@ where
 
 macro_rules! impl_multislice_tuple {
     ([$($but_last:ident)*] $last:ident) => {
-        impl_multislice_tuple!(@impl_owned ($($but_last,)* $last,));
-        impl_multislice_tuple!(@impl_ref ($($but_last,)* $last,), [$($but_last)*] $last);
+        impl_multislice_tuple!(@def_impl ($($but_last,)* $last,), [$($but_last)*] $last);
     };
-    (@impl_owned ($($all:ident,)*)) => {
-        impl<'a, A, D, $($all,)*> MultiSlice<'a, A, D> for ($(SliceInfo<D::SliceArg, $all>,)*)
-        where
-            A: 'a,
-            D: Dimension,
-            D::SliceArg: Sized,
-            $($all: Dimension,)*
-        {
-            type Output = ($(ArrayViewMut<'a, A, $all>,)*);
-
-            fn multi_slice_move(&self, view: ArrayViewMut<'a, A, D>) -> Self::Output {
-                #[allow(non_snake_case)]
-                let ($($all,)*) = self;
-                ($($all,)*).multi_slice_move(view)
-            }
-        }
-    };
-    (@impl_ref ($($all:ident,)*), [$($but_last:ident)*] $last:ident) => {
+    (@def_impl ($($all:ident,)*), [$($but_last:ident)*] $last:ident) => {
         impl<'a, A, D, $($all,)*> MultiSlice<'a, A, D> for ($(&SliceInfo<D::SliceArg, $all>,)*)
         where
             A: 'a,

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -701,14 +701,7 @@ macro_rules! impl_multislice_tuple {
             fn multi_slice_move(&self, view: ArrayViewMut<'a, A, D>) -> Self::Output {
                 #[allow(non_snake_case)]
                 let ($($Do,)*) = self;
-
-                let shape = view.raw_dim();
-                assert!(!impl_multislice_tuple!(@intersects_self &shape, ($(&$Do,)*)));
-
-                let raw_view = view.into_raw_view_mut();
-                unsafe {
-                    ($(raw_view.clone().slice_move(&$Do).deref_into_view_mut(),)*)
-                }
+                ($($Do,)*).multi_slice_move(view)
             }
         }
 

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -343,29 +343,39 @@ fn test_slice_collapse_with_indices() {
 }
 
 #[test]
-#[allow(clippy::cognitive_complexity)]
 fn test_multislice() {
-    defmac!(test_multislice arr, s1, s2 => {
-        let copy = arr.clone();
-        assert_eq!(
-            arr.multi_slice_mut((s1, s2)),
-            (copy.clone().slice_mut(s1), copy.clone().slice_mut(s2))
-        );
-    });
+    macro_rules! do_test {
+        ($arr:expr, $($s:expr),*) => {
+            {
+                let arr = $arr;
+                let copy = arr.clone();
+                assert_eq!(
+                    arr.multi_slice_mut(($($s,)*)),
+                    ($(copy.clone().slice_mut($s),)*)
+                );
+            }
+        };
+    }
+
     let mut arr = Array1::from_iter(0..48).into_shape((8, 6)).unwrap();
 
     assert_eq!(
         (arr.clone().view_mut(),),
         arr.multi_slice_mut((s![.., ..],)),
     );
-    test_multislice!(&mut arr, s![0, ..], s![1, ..]);
-    test_multislice!(&mut arr, s![0, ..], s![-1, ..]);
-    test_multislice!(&mut arr, s![0, ..], s![1.., ..]);
-    test_multislice!(&mut arr, s![1, ..], s![..;2, ..]);
-    test_multislice!(&mut arr, s![..2, ..], s![2.., ..]);
-    test_multislice!(&mut arr, s![1..;2, ..], s![..;2, ..]);
-    test_multislice!(&mut arr, s![..;-2, ..], s![..;2, ..]);
-    test_multislice!(&mut arr, s![..;12, ..], s![3..;3, ..]);
+    assert_eq!(arr.multi_slice_mut(()), ());
+    do_test!(&mut arr, s![0, ..]);
+    do_test!(&mut arr, s![0, ..], s![1, ..]);
+    do_test!(&mut arr, s![0, ..], s![-1, ..]);
+    do_test!(&mut arr, s![0, ..], s![1.., ..]);
+    do_test!(&mut arr, s![1, ..], s![..;2, ..]);
+    do_test!(&mut arr, s![..2, ..], s![2.., ..]);
+    do_test!(&mut arr, s![1..;2, ..], s![..;2, ..]);
+    do_test!(&mut arr, s![..;-2, ..], s![..;2, ..]);
+    do_test!(&mut arr, s![..;12, ..], s![3..;3, ..]);
+    do_test!(&mut arr, s![3, ..], s![..-1;-2, ..]);
+    do_test!(&mut arr, s![0, ..], s![1, ..], s![2, ..]);
+    do_test!(&mut arr, s![0, ..], s![1, ..], s![2, ..], s![3, ..]);
 }
 
 #[test]
@@ -390,10 +400,22 @@ fn test_multislice_intersecting() {
         let mut arr = Array2::<u8>::zeros((8, 6));
         arr.multi_slice_mut((s![2, ..], s![..-1;-2, ..]));
     });
-    {
+    assert_panics!({
         let mut arr = Array2::<u8>::zeros((8, 6));
-        arr.multi_slice_mut((s![3, ..], s![-1..;-2, ..]));
-    }
+        arr.multi_slice_mut((s![4, ..], s![3, ..], s![3, ..]));
+    });
+    assert_panics!({
+        let mut arr = Array2::<u8>::zeros((8, 6));
+        arr.multi_slice_mut((s![3, ..], s![4, ..], s![3, ..]));
+    });
+    assert_panics!({
+        let mut arr = Array2::<u8>::zeros((8, 6));
+        arr.multi_slice_mut((s![3, ..], s![3, ..], s![4, ..]));
+    });
+    assert_panics!({
+        let mut arr = Array2::<u8>::zeros((8, 6));
+        arr.multi_slice_mut((s![3, ..], s![3, ..], s![4, ..], s![3, ..]));
+    });
 }
 
 #[should_panic]

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -354,7 +354,7 @@ fn test_multislice() {
     });
     let mut arr = Array1::from_iter(0..48).into_shape((8, 6)).unwrap();
 
-    assert_eq!(arr.clone().view(), arr.multi_slice_mut(s![.., ..]));
+    assert_eq!((arr.clone().view_mut(),), arr.multi_slice_mut((s![.., ..],)));
     test_multislice!(&mut arr, s![0, ..], s![1, ..]);
     test_multislice!(&mut arr, s![0, ..], s![-1, ..]);
     test_multislice!(&mut arr, s![0, ..], s![1.., ..]);

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -354,7 +354,10 @@ fn test_multislice() {
     });
     let mut arr = Array1::from_iter(0..48).into_shape((8, 6)).unwrap();
 
-    assert_eq!((arr.clone().view_mut(),), arr.multi_slice_mut((s![.., ..],)));
+    assert_eq!(
+        (arr.clone().view_mut(),),
+        arr.multi_slice_mut((s![.., ..],)),
+    );
     test_multislice!(&mut arr, s![0, ..], s![1, ..]);
     test_multislice!(&mut arr, s![0, ..], s![-1, ..]);
     test_multislice!(&mut arr, s![0, ..], s![1.., ..]);


### PR DESCRIPTION
This is an alternative implementation of #716 that supports only flat tuples of slicing information. This means that it's no longer possible to perform arbitrarily many slices in a single call. The implementations are also limited only to the cases `(SliceInfo, SliceInfo, ...)` and `(&SliceInfo, &SliceInfo, ...)`, so slicing with e.g. `(SliceInfo, &SliceInfo, ...)` is not supported.

Despite the fact that the trait implementations are more limited than #716, I prefer this version because the implementation is simpler, it's easier to understand, and the unsafe code is more contained.

The implementation is done, but the tests need improvement.

Fixes #687. Closes #716.