### PR TITLE
Prepare for 0.13.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "ndarray"
-version = "0.12.1"
+version = "0.13.0"
 edition = "2018"
 authors = [
   "bluss",

--- a/README.rst
+++ b/README.rst
@@ -70,7 +70,7 @@ How to use with cargo
 ::
 
     [dependencies]
-    ndarray = "0.12.1"
+    ndarray = "0.13.0"
 
 How to enable blas integration. Depend on ``blas-src`` directly to pick a blas
 provider. Depend on the same ``blas-src`` version as ``ndarray`` does, for the
@@ -80,7 +80,7 @@ provider::
 
 
     [dependencies]
-    ndarray = { version = "0.12.1", features = ["blas"] }
+    ndarray = { version = "0.13.0", features = ["blas"] }
     blas-src = { version = "0.2.0", default-features = false, features = ["openblas"] }
     openblas-src = { version = "0.6.0", default-features = false, features = ["cblas", "system"] }
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,5 @@
-Version 0.13.0 (in development)
-===============================
+Version 0.13.0
+==============
 
 New features
 ------------

--- a/ndarray-rand/Cargo.toml
+++ b/ndarray-rand/Cargo.toml
@@ -14,7 +14,7 @@ description = "Constructors for randomized arrays. `rand` integration for `ndarr
 keywords = ["multidimensional", "matrix", "rand", "ndarray"]
 
 [dependencies]
-ndarray = { version = "0.12.0", path = ".." }
+ndarray = { version = "0.13", path = ".." }
 rand_distr = "0.2.1"
 
 [dependencies.rand]

--- a/parallel/Cargo.toml
+++ b/parallel/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["data-structures", "science", "concurrency"]
 
 [dependencies]
 rayon = { version = "1.0" }
-ndarray = { version = "0.12.0", path = "../" }
+ndarray = { version = "0.13", path = "../" }
 
 [dev-dependencies]
 num_cpus = "1.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,7 @@
 //!     needs matching memory layout to be efficient (with some exceptions).
 //!   + Efficient floating point matrix multiplication even for very large
 //!     matrices; can optionally use BLAS to improve it further.
-//! - **Requires Rust 1.32**
+//! - **Requires Rust 1.37 or later**
 //!
 //! ## Crate Feature Flags
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 #![crate_name = "ndarray"]
-#![doc(html_root_url = "https://docs.rs/ndarray/0.12/")]
+#![doc(html_root_url = "https://docs.rs/ndarray/0.13/")]
 #![allow(
     clippy::many_single_char_names,
     clippy::deref_addrof,


### PR DESCRIPTION
This updates the version numbers to 0.13.0. Once this is merged, I think we're ready to release 0.13.0!

cc #670