### PR TITLE
Update `par_azip!()` syntax to match `azip!()`

### DIFF
--- a/benches/par_rayon.rs
+++ b/benches/par_rayon.rs
@@ -131,7 +131,7 @@ fn rayon_add(bench: &mut Bencher) {
     let c = Array2::<f64>::zeros((ADDN, ADDN));
     let d = Array2::<f64>::zeros((ADDN, ADDN));
     bench.iter(|| {
-        par_azip!(mut a, b, c, d in {
+        par_azip!((a in &mut a, b in &b, c in &c, d in &d) {
             *a += b.exp() + c.exp() + d.exp();
         });
     });

--- a/src/zip/zipmacro.rs
+++ b/src/zip/zipmacro.rs
@@ -101,32 +101,25 @@
 /// ```
 #[macro_export]
 macro_rules! azip {
-    // Indexed with a single producer and no trailing comma.
-    ((index $index:pat, $first_pat:pat in $first_prod:expr) $body:expr) => {
+    // Indexed with a single producer
+    // we allow an optional trailing comma after the producers in each rule.
+    ((index $index:pat, $first_pat:pat in $first_prod:expr $(,)?) $body:expr) => {
         $crate::Zip::indexed($first_prod).apply(|$index, $first_pat| $body)
     };
-    // Indexed with more than one producer and no trailing comma.
-    ((index $index:pat, $first_pat:pat in $first_prod:expr, $($pat:pat in $prod:expr),*) $body:expr) => {
+    // Indexed with more than one producer
+    ((index $index:pat, $first_pat:pat in $first_prod:expr, $($pat:pat in $prod:expr),* $(,)?) $body:expr) => {
         $crate::Zip::indexed($first_prod)
             $(.and($prod))*
             .apply(|$index, $first_pat, $($pat),*| $body)
     };
-    // Indexed with trailing comma.
-    ((index $index:pat, $($pat:pat in $prod:expr),+,) $body:expr) => {
-        azip!((index $index, $($pat in $prod),+) $body)
-    };
-    // Unindexed with a single producer and no trailing comma.
-    (($first_pat:pat in $first_prod:expr) $body:expr) => {
+    // Unindexed with a single producer
+    (($first_pat:pat in $first_prod:expr $(,)?) $body:expr) => {
         $crate::Zip::from($first_prod).apply(|$first_pat| $body)
     };
-    // Unindexed with more than one producer and no trailing comma.
-    (($first_pat:pat in $first_prod:expr, $($pat:pat in $prod:expr),*) $body:expr) => {
+    // Unindexed with more than one producer
+    (($first_pat:pat in $first_prod:expr, $($pat:pat in $prod:expr),* $(,)?) $body:expr) => {
         $crate::Zip::from($first_prod)
             $(.and($prod))*
             .apply(|$first_pat, $($pat),*| $body)
-    };
-    // Unindexed with trailing comma.
-    (($($pat:pat in $prod:expr),+,) $body:expr) => {
-        azip!(($($pat in $prod),+) $body)
     };
 }

--- a/tests/azip.rs
+++ b/tests/azip.rs
@@ -50,6 +50,16 @@ fn test_azip2_3() {
 }
 
 #[test]
+fn test_azip_syntax_trailing_comma() {
+    let mut b = Array::<i32, _>::zeros((5, 5));
+    let mut c = Array::<i32, _>::ones((5, 5));
+    let a = b.clone();
+    azip!((b in &mut b, c in &mut c, ) swap(b, c));
+    assert_eq!(a, c);
+    assert!(a != b);
+}
+
+#[test]
 #[cfg(feature = "approx")]
 fn test_azip2_sum() {
     use approx::assert_abs_diff_eq;

--- a/tests/par_azip.rs
+++ b/tests/par_azip.rs
@@ -1,5 +1,6 @@
 #![cfg(feature = "rayon")]
 
+#[cfg(feature = "approx")]
 use itertools::enumerate;
 use ndarray::parallel::prelude::*;
 use ndarray::prelude::*;
@@ -9,7 +10,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 fn test_par_azip1() {
     let mut a = Array::zeros(62);
     let b = Array::from_elem(62, 42);
-    par_azip!(mut a in { *a = 42 });
+    par_azip!((a in &mut a) { *a = 42 });
     assert_eq!(a, b);
 }
 
@@ -17,7 +18,7 @@ fn test_par_azip1() {
 fn test_par_azip2() {
     let mut a = Array::zeros((5, 7));
     let b = Array::from_shape_fn(a.dim(), |(i, j)| 1. / (i + 2 * j) as f32);
-    par_azip!(mut a, b in { *a = b; });
+    par_azip!((a in &mut a, &b in &b, ) *a = b );
     assert_eq!(a, b);
 }
 
@@ -33,7 +34,7 @@ fn test_par_azip3() {
         *elt = i as f32;
     }
 
-    par_azip!(mut a (&mut a[..]), b (&b[..]), mut c (&mut c[..]) in {
+    par_azip!((a in &mut a[..], &b in &b[..], c in &mut c[..]) {
         *a += b / 10.;
         *c = a.sin();
     });
@@ -48,7 +49,7 @@ fn test_zip_dim_mismatch_1() {
     let mut d = a.raw_dim();
     d[0] += 1;
     let b = Array::from_shape_fn(d, |(i, j)| 1. / (i + 2 * j) as f32);
-    par_azip!(mut a, b in { *a = b; });
+    par_azip!((a in &mut a, &b in &b) { *a = b; });
 }
 
 #[test]
@@ -59,7 +60,7 @@ fn test_indices_1() {
     }
 
     let count = AtomicUsize::new(0);
-    par_azip!(index i, elt (&a1) in {
+    par_azip!((index i, &elt in &a1) {
         count.fetch_add(1, Ordering::SeqCst);
         assert_eq!(elt, i);
     });


### PR DESCRIPTION
Update the syntax to match. First refactor `azip!()` slightly, so that we can reuse it wholesale from `par_azip`.

cc #670 
cc #721 