### PR TITLE
Merge in ndarray-parallel 0.9.1 release

### DIFF
--- a/parallel/Cargo.toml
+++ b/parallel/Cargo.toml
@@ -1,13 +1,15 @@
 [package]
 name = "ndarray-parallel"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["bluss"]
 license = "MIT/Apache-2.0"
 
 repository = "https://github.com/bluss/rust-ndarray"
 documentation = "https://docs.rs/ndarray-parallel/"
 
-description = "Parallelization for ndarray (using rayon)."
+description = """Parallelization for ndarray using rayon.
+(Deprecated - use ndarray with rayon directly.)
+"""
 
 keywords = ["data-structure", "multidimensional", "parallel", "concurrent"]
 categories = ["data-structures", "science", "concurrency"]
@@ -22,3 +24,8 @@ itertools = { version = "0.7.0", default-features = false }
 
 [package.metadata.release]
 no-dev-version = true
+tag-name = "parallel-{{version}}"
+
+[badges]
+# Replaced by rayon support directly in ndarray
+maintenance = { status = "deprecated" }

--- a/parallel/README.rst
+++ b/parallel/README.rst
@@ -49,6 +49,10 @@ How to use with cargo::
 Recent Changes (ndarray-parallel)
 ---------------------------------
 
+- 0.9.1
+
+  - Mark crate as deprecated, replaced by direct support in ndarray.
+
 - 0.9.0
 
   - Upgrade for ndarray 0.12.0

--- a/parallel/src/lib.rs
+++ b/parallel/src/lib.rs
@@ -1,5 +1,8 @@
 //! Parallelization features for ndarray.
 //!
+//! ***This crate is deprecated and was replaced by equivalent `rayon` support
+//! directly integrated to `ndarray`.***
+//!
 //! The array views and references to owned arrays all implement
 //! `NdarrayIntoParallelIterator` (*); the default parallel iterators (each element
 //! by reference or mutable reference) have no ordering guarantee in their


### PR DESCRIPTION
This was the last release of ndarray-parallel, just to mark it deprecated (it still uses ndarray 0.12 etc).
Merge in the last changes if possible, before deleting it.