### PR TITLE
Simplify Zip::all implementation

### DIFF
--- a/src/zip/mod.rs
+++ b/src/zip/mod.rs
@@ -934,14 +934,14 @@ macro_rules! map_impl {
             pub fn all<F>(mut self, mut predicate: F) -> bool
                 where F: FnMut($($p::Item),*) -> bool
             {
-                self.apply_core(true, move |_, args| {
+                !self.apply_core((), move |_, args| {
                     let ($($p,)*) = args;
                     if predicate($($p),*) {
-                        FoldWhile::Continue(true)
+                        FoldWhile::Continue(())
                     } else {
-                        FoldWhile::Done(false)
+                        FoldWhile::Done(())
                     }
-                }).into_inner()
+                }).is_done()
             }
 
             expand_if!(@bool [$notlast]


### PR DESCRIPTION
We notice FoldWhile::Continue/Done is already a boolean itself and the
payload bool is redundant.