### PR TITLE
Remove alignment restriction on RawArrayView/Mut

### DIFF
--- a/src/impl_raw_views.rs
+++ b/src/impl_raw_views.rs
@@ -33,8 +33,8 @@ where
     ///
     /// Unsafe because caller is responsible for ensuring all of the following:
     ///
-    /// * `ptr` must be non-null and aligned, and it must be safe to
-    ///   [`.offset()`] `ptr` by zero.
+    /// * `ptr` must be non-null, and it must be safe to [`.offset()`] `ptr` by
+    ///   zero.
     ///
     /// * It must be safe to [`.offset()`] the pointer repeatedly along all
     ///   axes and calculate the `count`s for the `.offset()` calls without
@@ -70,7 +70,6 @@ where
         let strides = shape.strides;
         if cfg!(debug_assertions) {
             assert!(!ptr.is_null(), "The pointer must be non-null.");
-            assert!(is_aligned(ptr), "The pointer must be aligned.");
             dimension::max_abs_offset_check_overflow::<A, _>(&dim, &strides).unwrap();
         }
         RawArrayView::new_(ptr, dim, strides)
@@ -80,9 +79,14 @@ where
     ///
     /// **Warning** from a safety standpoint, this is equivalent to
     /// dereferencing a raw pointer for every element in the array. You must
-    /// ensure that all of the data is valid and choose the correct lifetime.
+    /// ensure that all of the data is valid, ensure that the pointer is
+    /// aligned, and choose the correct lifetime.
     #[inline]
     pub unsafe fn deref_into_view<'a>(self) -> ArrayView<'a, A, D> {
+        debug_assert!(
+            is_aligned(self.ptr.as_ptr()),
+            "The pointer must be aligned."
+        );
         ArrayView::new(self.ptr, self.dim, self.strides)
     }
 
@@ -130,12 +134,6 @@ where
             "size mismatch in raw view cast"
         );
         let ptr = self.ptr.cast::<B>();
-        debug_assert!(
-            is_aligned(ptr.as_ptr()),
-            "alignment mismatch in raw view cast"
-        );
-        /* Alignment checked with debug assertion: alignment could be dynamically correct,
-         * and we don't have a check that compiles out for that. */
         unsafe { RawArrayView::new(ptr, self.dim, self.strides) }
     }
 }
@@ -167,8 +165,8 @@ where
     ///
     /// Unsafe because caller is responsible for ensuring all of the following:
     ///
-    /// * `ptr` must be non-null and aligned, and it must be safe to
-    ///   [`.offset()`] `ptr` by zero.
+    /// * `ptr` must be non-null, and it must be safe to [`.offset()`] `ptr` by
+    ///   zero.
     ///
     /// * It must be safe to [`.offset()`] the pointer repeatedly along all
     ///   axes and calculate the `count`s for the `.offset()` calls without
@@ -204,7 +202,6 @@ where
         let strides = shape.strides;
         if cfg!(debug_assertions) {
             assert!(!ptr.is_null(), "The pointer must be non-null.");
-            assert!(is_aligned(ptr), "The pointer must be aligned.");
             dimension::max_abs_offset_check_overflow::<A, _>(&dim, &strides).unwrap();
         }
         RawArrayViewMut::new_(ptr, dim, strides)
@@ -220,9 +217,14 @@ where
     ///
     /// **Warning** from a safety standpoint, this is equivalent to
     /// dereferencing a raw pointer for every element in the array. You must
-    /// ensure that all of the data is valid and choose the correct lifetime.
+    /// ensure that all of the data is valid, ensure that the pointer is
+    /// aligned, and choose the correct lifetime.
     #[inline]
     pub unsafe fn deref_into_view<'a>(self) -> ArrayView<'a, A, D> {
+        debug_assert!(
+            is_aligned(self.ptr.as_ptr()),
+            "The pointer must be aligned."
+        );
         ArrayView::new(self.ptr, self.dim, self.strides)
     }
 
@@ -230,9 +232,14 @@ where
     ///
     /// **Warning** from a safety standpoint, this is equivalent to
     /// dereferencing a raw pointer for every element in the array. You must
-    /// ensure that all of the data is valid and choose the correct lifetime.
+    /// ensure that all of the data is valid, ensure that the pointer is
+    /// aligned, and choose the correct lifetime.
     #[inline]
     pub unsafe fn deref_into_view_mut<'a>(self) -> ArrayViewMut<'a, A, D> {
+        debug_assert!(
+            is_aligned(self.ptr.as_ptr()),
+            "The pointer must be aligned."
+        );
         ArrayViewMut::new(self.ptr, self.dim, self.strides)
     }
 
@@ -267,12 +274,6 @@ where
             "size mismatch in raw view cast"
         );
         let ptr = self.ptr.cast::<B>();
-        debug_assert!(
-            is_aligned(ptr.as_ptr()),
-            "alignment mismatch in raw view cast"
-        );
-        /* Alignment checked with debug assertion: alignment could be dynamically correct,
-         * and we don't have a check that compiles out for that. */
         unsafe { RawArrayViewMut::new(ptr, self.dim, self.strides) }
     }
 }


### PR DESCRIPTION
This makes `.cast()` safe without a check for alignment.

This might be a breaking change because we [documented](https://docs.rs/ndarray/0.13.0/ndarray/type.RawArrayView.html) that `RawArrayView/Mut` had alignment requirements. I suppose it depends on how that statement could be interpreted. Someone could think that it would mean that, given any `RawArrayView`, it would be safe to call `.deref_into_view()` without ensuring that the pointer was aligned. IMO, though, since we didn't say exactly what the alignment restrictions were, no one should have made that assumption.