### PR TITLE
Require std::hash::Hash trait on Dimension::Pattern

### DIFF
--- a/src/dimension/dimension_trait.rs
+++ b/src/dimension/dimension_trait.rs
@@ -7,6 +7,7 @@
 // except according to those terms.
 
 use std::fmt::Debug;
+use std::hash::Hash;
 use std::ops::{Add, AddAssign, Mul, MulAssign, Sub, SubAssign};
 use std::ops::{Index, IndexMut};
 
@@ -71,7 +72,7 @@ pub trait Dimension:
     /// - For `Ix2`: `(usize, usize)`
     /// - and so on..
     /// - For `IxDyn`: `IxDyn`
-    type Pattern: IntoDimension<Dim = Self> + Clone + Debug + PartialEq + Eq + Default;
+    type Pattern: IntoDimension<Dim = Self> + Clone + Debug + PartialEq + Eq + Hash + Default;
     /// Next smaller dimension (if applicable)
     type Smaller: Dimension;
     /// Next larger dimension


### PR DESCRIPTION
I was trying to create a generic sparse N-dimensional array type, using `Dimension::Pattern` as the keys in a `std::collections::HashMap`, but `std::hash::Hash` is not required to be implemented by `Dimension::Pattern`. All of `Dimension::Pattern`'s implementations do have `std::hash::Hash`, and `Dimension` is never implemented outside of ndarray, so this shouldn't cause any problems in calling code.

I'm still somewhat new to Rust, so please do tell if there's something I'm missing.