### PR TITLE
Remove unnecessary parens around types

### DIFF
--- a/src/dimension/dynindeximpl.rs
+++ b/src/dimension/dynindeximpl.rs
@@ -16,7 +16,7 @@ impl<T> Deref for IxDynRepr<T> {
     fn deref(&self) -> &[T] {
         match *self {
             IxDynRepr::Inline(len, ref ar) => {
-                debug_assert!(len as (usize) <= ar.len());
+                debug_assert!(len as usize <= ar.len());
                 unsafe { ar.get_unchecked(..len as usize) }
             }
             IxDynRepr::Alloc(ref ar) => &*ar,
@@ -28,7 +28,7 @@ impl<T> DerefMut for IxDynRepr<T> {
     fn deref_mut(&mut self) -> &mut [T] {
         match *self {
             IxDynRepr::Inline(len, ref mut ar) => {
-                debug_assert!(len as (usize) <= ar.len());
+                debug_assert!(len as usize <= ar.len());
                 unsafe { ar.get_unchecked_mut(..len as usize) }
             }
             IxDynRepr::Alloc(ref mut ar) => &mut *ar,


### PR DESCRIPTION
rust-lang/rust#64169 adds a compiler warning for parenthesis around simple types. It has already made its way into the beta channel.

Also, thoughts on adding `-D warnings` to the nightly channel build as well? Gotta confess it was weird when I saw it failing because of this reason on beta while it didn't on nightly