### PR TITLE
Remove main function from doctests

### DIFF
--- a/src/free_functions.rs
+++ b/src/free_functions.rs
@@ -16,23 +16,18 @@ use crate::{dimension, ArcArray1, ArcArray2};
 /// three dimensions.
 ///
 /// ```
-/// extern crate ndarray;
-///
 /// use ndarray::array;
+/// let a1 = array![1, 2, 3, 4];
 ///
-/// fn main() {
-///     let a1 = array![1, 2, 3, 4];
+/// let a2 = array![[1, 2],
+///                 [3, 4]];
 ///
-///     let a2 = array![[1, 2],
-///                     [3, 4]];
+/// let a3 = array![[[1, 2], [3, 4]],
+///                 [[5, 6], [7, 8]]];
 ///
-///     let a3 = array![[[1, 2], [3, 4]],
-///                     [[5, 6], [7, 8]]];
-///
-///     assert_eq!(a1.shape(), &[4]);
-///     assert_eq!(a2.shape(), &[2, 2]);
-///     assert_eq!(a3.shape(), &[2, 2, 2]);
-/// }
+/// assert_eq!(a1.shape(), &[4]);
+/// assert_eq!(a2.shape(), &[2, 2]);
+/// assert_eq!(a3.shape(), &[2, 2, 2]);
 /// ```
 ///
 /// This macro uses `vec![]`, and has the same ownership semantics;
@@ -115,19 +110,14 @@ pub fn aview2<A, V: FixedInitializer<Elem = A>>(xs: &[V]) -> ArrayView2<'_, A> {
 /// Create a one-dimensional read-write array view with elements borrowing `xs`.
 ///
 /// ```
-/// extern crate ndarray;
-///
 /// use ndarray::{aview_mut1, s};
-///
 /// // Create an array view over some data, then slice it and modify it.
-/// fn main() {
-///     let mut data = [0; 1024];
-///     {
-///         let mut a = aview_mut1(&mut data).into_shape((32, 32)).unwrap();
-///         a.slice_mut(s![.., ..;3]).fill(5);
-///     }
-///     assert_eq!(&data[..10], [5, 0, 0, 5, 0, 0, 5, 0, 0, 5]);
+/// let mut data = [0; 1024];
+/// {
+///     let mut a = aview_mut1(&mut data).into_shape((32, 32)).unwrap();
+///     a.slice_mut(s![.., ..;3]).fill(5);
 /// }
+/// assert_eq!(&data[..10], [5, 0, 0, 5, 0, 0, 5, 0, 0, 5]);
 /// ```
 pub fn aview_mut1<A>(xs: &mut [A]) -> ArrayViewMut1<'_, A> {
     ArrayViewMut::from(xs)
@@ -143,20 +133,18 @@ pub fn aview_mut1<A>(xs: &mut [A]) -> ArrayViewMut1<'_, A> {
 /// ```
 /// use ndarray::aview_mut2;
 ///
-/// fn main() {
-///     // The inner (nested) array must be of length 1 to 16, but the outer
-///     // can be of any length.
-///     let mut data = [[0.; 2]; 128];
-///     {
-///         // Make a 128 x 2 mut array view then turn it into 2 x 128
-///         let mut a = aview_mut2(&mut data).reversed_axes();
-///         // Make the first row ones and second row minus ones.
-///         a.row_mut(0).fill(1.);
-///         a.row_mut(1).fill(-1.);
-///     }
-///     // look at the start of the result
-///     assert_eq!(&data[..3], [[1., -1.], [1., -1.], [1., -1.]]);
+/// // The inner (nested) array must be of length 1 to 16, but the outer
+/// // can be of any length.
+/// let mut data = [[0.; 2]; 128];
+/// {
+///     // Make a 128 x 2 mut array view then turn it into 2 x 128
+///     let mut a = aview_mut2(&mut data).reversed_axes();
+///     // Make the first row ones and second row minus ones.
+///     a.row_mut(0).fill(1.);
+///     a.row_mut(1).fill(-1.);
 /// }
+/// // look at the start of the result
+/// assert_eq!(&data[..3], [[1., -1.], [1., -1.], [1., -1.]]);
 /// ```
 pub fn aview_mut2<A, V: FixedInitializer<Elem = A>>(xs: &mut [V]) -> ArrayViewMut2<'_, A> {
     let cols = V::len();

--- a/src/impl_constructors.rs
+++ b/src/impl_constructors.rs
@@ -132,7 +132,6 @@ where
     /// use approx::assert_abs_diff_eq;
     /// use ndarray::{Array, arr1};
     ///
-    /// # fn example() -> Option<()> {
     /// # #[cfg(feature = "approx")] {
     /// let array = Array::geomspace(1e0, 1e3, 4)?;
     /// assert_abs_diff_eq!(array, arr1(&[1e0, 1e1, 1e2, 1e3]), epsilon = 1e-12);
@@ -140,10 +139,6 @@ where
     /// let array = Array::geomspace(-1e3, -1e0, 4)?;
     /// assert_abs_diff_eq!(array, arr1(&[-1e3, -1e2, -1e1, -1e0]), epsilon = 1e-12);
     /// # }
-    /// # Some(())
-    /// # }
-    /// #
-    /// # fn main() { example().unwrap() }
     /// ```
     pub fn geomspace(start: A, end: A, n: usize) -> Option<Self>
     where
@@ -485,8 +480,6 @@ where
     /// ### Examples
     ///
     /// ```
-    /// extern crate ndarray;
-    ///
     /// use ndarray::{s, Array2};
     ///
     /// // Example Task: Let's create a column shifted copy of a in b
@@ -503,9 +496,7 @@ where
     ///     b
     /// }
     ///
-    /// # fn main() {
-    /// #   shift_by_two(&Array2::zeros((8, 8)));
-    /// # }
+    /// # shift_by_two(&Array2::zeros((8, 8)));
     /// ```
     pub unsafe fn uninitialized<Sh>(shape: Sh) -> Self
     where

--- a/src/impl_constructors.rs
+++ b/src/impl_constructors.rs
@@ -143,7 +143,7 @@ where
     /// # Some(())
     /// # }
     /// #
-    /// # fn main() { example().unwrap() }
+    /// # example().unwrap();
     /// ```
     pub fn geomspace(start: A, end: A, n: usize) -> Option<Self>
     where

--- a/src/impl_constructors.rs
+++ b/src/impl_constructors.rs
@@ -133,10 +133,10 @@ where
     /// use ndarray::{Array, arr1};
     ///
     /// # #[cfg(feature = "approx")] {
-    /// let array = Array::geomspace(1e0, 1e3, 4)?;
+    /// let array = Array::geomspace(1e0, 1e3, 4).unwrap();
     /// assert_abs_diff_eq!(array, arr1(&[1e0, 1e1, 1e2, 1e3]), epsilon = 1e-12);
     ///
-    /// let array = Array::geomspace(-1e3, -1e0, 4)?;
+    /// let array = Array::geomspace(-1e3, -1e0, 4).unwrap();
     /// assert_abs_diff_eq!(array, arr1(&[-1e3, -1e2, -1e1, -1e0]), epsilon = 1e-12);
     /// # }
     /// ```

--- a/src/impl_constructors.rs
+++ b/src/impl_constructors.rs
@@ -132,13 +132,18 @@ where
     /// use approx::assert_abs_diff_eq;
     /// use ndarray::{Array, arr1};
     ///
+    /// # fn example() -> Option<()> {
     /// # #[cfg(feature = "approx")] {
-    /// let array = Array::geomspace(1e0, 1e3, 4).unwrap();
+    /// let array = Array::geomspace(1e0, 1e3, 4)?;
     /// assert_abs_diff_eq!(array, arr1(&[1e0, 1e1, 1e2, 1e3]), epsilon = 1e-12);
     ///
-    /// let array = Array::geomspace(-1e3, -1e0, 4).unwrap();
+    /// let array = Array::geomspace(-1e3, -1e0, 4)?;
     /// assert_abs_diff_eq!(array, arr1(&[-1e3, -1e2, -1e1, -1e0]), epsilon = 1e-12);
     /// # }
+    /// # Some(())
+    /// # }
+    /// #
+    /// # fn main() { example().unwrap() }
     /// ```
     pub fn geomspace(start: A, end: A, n: usize) -> Option<Self>
     where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -483,11 +483,8 @@ pub type Ixs = isize;
 /// [`.multi_slice_move()`]: type.ArrayViewMut.html#method.multi_slice_move
 ///
 /// ```
-/// extern crate ndarray;
 ///
 /// use ndarray::{arr2, arr3, s};
-///
-/// fn main() {
 ///
 /// // 2 submatrices of 2 rows with 3 elements per row, means a shape of `[2, 2, 3]`.
 ///
@@ -546,7 +543,6 @@ pub type Ixs = isize;
 ///                [5, 7]]);
 /// assert_eq!(s0, i);
 /// assert_eq!(s1, j);
-/// }
 /// ```
 ///
 /// ## Subviews
@@ -579,11 +575,9 @@ pub type Ixs = isize;
 /// [`.outer_iter_mut()`]: #method.outer_iter_mut
 ///
 /// ```
-/// extern crate ndarray;
 ///
 /// use ndarray::{arr3, aview1, aview2, s, Axis};
 ///
-/// # fn main() {
 ///
 /// // 2 submatrices of 2 rows with 3 elements per row, means a shape of `[2, 2, 3]`.
 ///
@@ -617,7 +611,6 @@ pub type Ixs = isize;
 /// // You can take multiple subviews at once (and slice at the same time)
 /// let double_sub = a.slice(s![1, .., 0]);
 /// assert_eq!(double_sub, aview1(&[7, 10]));
-/// # }
 /// ```
 ///
 /// ## Arithmetic Operations
@@ -1063,7 +1056,6 @@ pub type Ixs = isize;
 /// ```rust
 /// use ndarray::{array, Array2};
 ///
-/// # fn main() -> Result<(), Box<std::error::Error>> {
 /// let ncols = 3;
 /// let mut data = Vec::new();
 /// let mut nrows = 0;
@@ -1075,8 +1067,6 @@ pub type Ixs = isize;
 /// }
 /// let arr = Array2::from_shape_vec((nrows, ncols), data)?;
 /// assert_eq!(arr, array![[0, 0, 0], [1, 1, 1]]);
-/// # Ok(())
-/// # }
 /// ```
 ///
 /// If neither of these options works for you, and you really need to convert
@@ -1089,7 +1079,6 @@ pub type Ixs = isize;
 /// ```rust
 /// use ndarray::{array, Array2, Array3};
 ///
-/// # fn main() -> Result<(), Box<std::error::Error>> {
 /// let nested: Vec<Array2<i32>> = vec![
 ///     array![[1, 2, 3], [4, 5, 6]],
 ///     array![[7, 8, 9], [10, 11, 12]],
@@ -1102,8 +1091,6 @@ pub type Ixs = isize;
 ///     [[1, 2, 3], [4, 5, 6]],
 ///     [[7, 8, 9], [10, 11, 12]],
 /// ]);
-/// # Ok(())
-/// # }
 /// ```
 ///
 /// Note that this implementation assumes that the nested `Vec`s are all the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1067,6 +1067,7 @@ pub type Ixs = isize;
 /// }
 /// let arr = Array2::from_shape_vec((nrows, ncols), data)?;
 /// assert_eq!(arr, array![[0, 0, 0], [1, 1, 1]]);
+/// # Ok::<(), io::Error>(())
 /// ```
 ///
 /// If neither of these options works for you, and you really need to convert
@@ -1091,6 +1092,7 @@ pub type Ixs = isize;
 ///     [[1, 2, 3], [4, 5, 6]],
 ///     [[7, 8, 9], [10, 11, 12]],
 /// ]);
+/// # Ok::<(), io::Error>(())
 /// ```
 ///
 /// Note that this implementation assumes that the nested `Vec`s are all the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1067,7 +1067,7 @@ pub type Ixs = isize;
 /// }
 /// let arr = Array2::from_shape_vec((nrows, ncols), data)?;
 /// assert_eq!(arr, array![[0, 0, 0], [1, 1, 1]]);
-/// # Ok::<(), ()>(())
+/// # Ok::<(), ndarray::ShapeError>(())
 /// ```
 ///
 /// If neither of these options works for you, and you really need to convert
@@ -1092,7 +1092,7 @@ pub type Ixs = isize;
 ///     [[1, 2, 3], [4, 5, 6]],
 ///     [[7, 8, 9], [10, 11, 12]],
 /// ]);
-/// # Ok::<(), ()>(())
+/// # Ok::<(), ndarray::ShapeError>(())
 /// ```
 ///
 /// Note that this implementation assumes that the nested `Vec`s are all the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1067,7 +1067,7 @@ pub type Ixs = isize;
 /// }
 /// let arr = Array2::from_shape_vec((nrows, ncols), data)?;
 /// assert_eq!(arr, array![[0, 0, 0], [1, 1, 1]]);
-/// # Ok::<(), io::Error>(())
+/// # Ok::<(), ()>(())
 /// ```
 ///
 /// If neither of these options works for you, and you really need to convert
@@ -1092,7 +1092,7 @@ pub type Ixs = isize;
 ///     [[1, 2, 3], [4, 5, 6]],
 ///     [[7, 8, 9], [10, 11, 12]],
 /// ]);
-/// # Ok::<(), io::Error>(())
+/// # Ok::<(), ()>(())
 /// ```
 ///
 /// Note that this implementation assumes that the nested `Vec`s are all the

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -12,7 +12,6 @@
 //! and macros that you can import easily as a group.
 //!
 //! ```
-//! extern crate ndarray;
 //!
 //! use ndarray::prelude::*;
 //! # fn main() { }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -14,7 +14,6 @@
 //! ```
 //!
 //! use ndarray::prelude::*;
-//! # fn main() { }
 //! ```
 
 #[doc(no_inline)]


### PR DESCRIPTION
This pull requests addresses the [needless_doctest_main](https://rust-lang.github.io/rust-clippy/master/index.html#needless_doctest_main) linting issues.

Most of the remaining ones are with regards missing `Safety` section in the docs, using clippy words, [missing_safety_doc](https://rust-lang.github.io/rust-clippy/master/index.html#missing_safety_doc), which was added by rust-lang/rust-clippy#4608. Those aren't as straightforward for fixing as they require a per-case analysis in order to verify the safety pre-requisites.

There is also one occurrency of a [redundant clone](https://rust-lang.github.io/rust-clippy/master/index.html#redundant_clone)