### PR TITLE
zip_mut_with 'f' order

### DIFF
--- a/benches/iter.rs
+++ b/benches/iter.rs
@@ -370,3 +370,23 @@ fn iter_axis_chunks_5_iter_sum(bench: &mut Bencher) {
             .sum::<f32>()
     });
 }
+
+pub fn zip_mut_with(data: &Array3<f32>, out: &mut Array3<f32>) {
+    out.zip_mut_with(&data, |o, &i| {
+        *o = i;
+    });
+}
+
+#[bench]
+fn zip_mut_with_cc(b: &mut Bencher) {
+    let data: Array3<f32> = Array3::zeros((ISZ, ISZ, ISZ));
+    let mut out = Array3::zeros(data.dim());
+    b.iter(|| black_box(zip_mut_with(&data, &mut out)));
+}
+
+#[bench]
+fn zip_mut_with_ff(b: &mut Bencher) {
+    let data: Array3<f32> = Array3::zeros((ISZ, ISZ, ISZ).f());
+    let mut out = Array3::zeros(data.dim().f());
+    b.iter(|| black_box(zip_mut_with(&data, &mut out)));
+}

--- a/src/dimension/dimension_trait.rs
+++ b/src/dimension/dimension_trait.rs
@@ -229,6 +229,25 @@ pub trait Dimension:
         !end_iteration
     }
 
+    /// Returns `true` iff `strides1` and `strides2` are equivalent for the
+    /// shape `self`.
+    ///
+    /// The strides are equivalent if, for each axis with length > 1, the
+    /// strides are equal.
+    ///
+    /// Note: Returns `false` if any of the ndims don't match.
+    #[doc(hidden)]
+    fn strides_equivalent<D>(&self, strides1: &Self, strides2: &D) -> bool
+    where
+        D: Dimension,
+    {
+        let shape_ndim = self.ndim();
+        shape_ndim == strides1.ndim()
+            && shape_ndim == strides2.ndim()
+            && izip!(self.slice(), strides1.slice(), strides2.slice())
+                .all(|(&d, &s1, &s2)| d <= 1 || s1 as isize == s2 as isize)
+    }
+
     #[doc(hidden)]
     /// Return stride offset for index.
     fn stride_offset(index: &Self, strides: &Self) -> isize {

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -1917,8 +1917,7 @@ where
     {
         debug_assert_eq!(self.shape(), rhs.shape());
 
-        // Same shape and order should have same strides
-        if self.strides() == rhs.strides() {
+        if self.dim.strides_equivalent(&self.strides, &rhs.strides) {
             if let Some(self_s) = self.as_slice_memory_order_mut() {
                 if let Some(rhs_s) = rhs.as_slice_memory_order() {
                     for (s, r) in self_s.iter_mut().zip(rhs_s) {


### PR DESCRIPTION
As adviced by @jturner314 in #749, I now use `as_slice_memory_order` in `zip_mut_with_same_shape` for same-order arrays. (I also wanted to optimize `zip_indexed` but it's more complex so I'll probably do it later)

I modified `zip_mut_with_same_shape` more than I intended at first because there were some useless statements. At that point, we have same-shape arrays, so they have the same length, which make the slicing useless.

The bench I added show that 'cc' is not slower than it was and 'ff' is as fast as 'cc'. On windows and WSL.