### PR TITLE
fixup build error on linux

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -8,4 +8,7 @@ fn main() {
     if cfg!(feature = "test-blas-openblas-sys") {
         println!("cargo:rustc-link-lib={}=openblas", "dylib");
     }
+    if cfg!(all(not(target_os = "macos"), feature = "blas")) {
+        println!("cargo:rustc-link-lib={}=blas", "dylib");
+    }
 }


### PR DESCRIPTION
When compiling with `features=["blas"]` on linux, I would hit the
following error:
```
src/linalg/impl_linalg.rs:115: undefined reference to `cblas_ddot'
```

I believe cblas_ddot is included on macos, but not on any other OS, and
would therefor need some linker argument.