### PR TITLE
Fix clippy (beta version) warnings

### DIFF
--- a/src/impl_constructors.rs
+++ b/src/impl_constructors.rs
@@ -425,6 +425,8 @@ where
     /// Creates an array from a vector and interpret it according to the
     /// provided shape and strides. (No cloning of elements needed.)
     ///
+    /// # Safety
+    ///
     /// The caller must ensure that the following conditions are met:
     ///
     /// 1. The ndim of `dim` and `strides` must be the same.

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -572,6 +572,10 @@ where
     /// Return a reference to the element at `index`.
     ///
     /// **Note:** only unchecked for non-debug builds of ndarray.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that the index is in-bounds.
     #[inline]
     pub unsafe fn uget<I>(&self, index: I) -> &A
     where
@@ -587,8 +591,16 @@ where
     ///
     /// Return a mutable reference to the element at `index`.
     ///
-    /// **Note:** Only unchecked for non-debug builds of ndarray.<br>
-    /// **Note:** (For `ArcArray`) The array must be uniquely held when mutating it.
+    /// **Note:** Only unchecked for non-debug builds of ndarray.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that:
+    ///
+    /// 1. the index is in-bounds and
+    ///
+    /// 2. the data is uniquely held by the array. (This property is guaranteed
+    ///    for `Array` and `ArrayViewMut`, but not for `ArcArray` or `CowArray`.)
     #[inline]
     pub unsafe fn uget_mut<I>(&mut self, index: I) -> &mut A
     where
@@ -622,8 +634,16 @@ where
     ///
     /// Indices may be equal.
     ///
-    /// **Note:** only unchecked for non-debug builds of ndarray.<br>
-    /// **Note:** (For `ArcArray`) The array must be uniquely held.
+    /// **Note:** only unchecked for non-debug builds of ndarray.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that:
+    ///
+    /// 1. both `index1 and `index2` are in-bounds and
+    ///
+    /// 2. the data is uniquely held by the array. (This property is guaranteed
+    ///    for `Array` and `ArrayViewMut`, but not for `ArcArray` or `CowArray`.)
     pub unsafe fn uswap<I>(&mut self, index1: I, index2: I)
     where
         S: DataMut,

--- a/src/impl_raw_views.rs
+++ b/src/impl_raw_views.rs
@@ -31,7 +31,9 @@ where
     /// Create an `RawArrayView<A, D>` from shape information and a raw pointer
     /// to the elements.
     ///
-    /// Unsafe because caller is responsible for ensuring all of the following:
+    /// # Safety
+    ///
+    /// The caller is responsible for ensuring all of the following:
     ///
     /// * `ptr` must be non-null, and it must be safe to [`.offset()`] `ptr` by
     ///   zero.
@@ -77,10 +79,12 @@ where
 
     /// Converts to a read-only view of the array.
     ///
-    /// **Warning** from a safety standpoint, this is equivalent to
-    /// dereferencing a raw pointer for every element in the array. You must
-    /// ensure that all of the data is valid, ensure that the pointer is
-    /// aligned, and choose the correct lifetime.
+    /// # Safety
+    ///
+    /// From a safety standpoint, this is equivalent to dereferencing a raw
+    /// pointer for every element in the array. You must ensure that all of the
+    /// data is valid, ensure that the pointer is aligned, and choose the
+    /// correct lifetime.
     #[inline]
     pub unsafe fn deref_into_view<'a>(self) -> ArrayView<'a, A, D> {
         debug_assert!(
@@ -163,7 +167,9 @@ where
     /// Create an `RawArrayViewMut<A, D>` from shape information and a raw
     /// pointer to the elements.
     ///
-    /// Unsafe because caller is responsible for ensuring all of the following:
+    /// # Safety
+    ///
+    /// The caller is responsible for ensuring all of the following:
     ///
     /// * `ptr` must be non-null, and it must be safe to [`.offset()`] `ptr` by
     ///   zero.
@@ -215,10 +221,12 @@ where
 
     /// Converts to a read-only view of the array.
     ///
-    /// **Warning** from a safety standpoint, this is equivalent to
-    /// dereferencing a raw pointer for every element in the array. You must
-    /// ensure that all of the data is valid, ensure that the pointer is
-    /// aligned, and choose the correct lifetime.
+    /// # Safety
+    ///
+    /// From a safety standpoint, this is equivalent to dereferencing a raw
+    /// pointer for every element in the array. You must ensure that all of the
+    /// data is valid, ensure that the pointer is aligned, and choose the
+    /// correct lifetime.
     #[inline]
     pub unsafe fn deref_into_view<'a>(self) -> ArrayView<'a, A, D> {
         debug_assert!(
@@ -230,10 +238,12 @@ where
 
     /// Converts to a mutable view of the array.
     ///
-    /// **Warning** from a safety standpoint, this is equivalent to
-    /// dereferencing a raw pointer for every element in the array. You must
-    /// ensure that all of the data is valid, ensure that the pointer is
-    /// aligned, and choose the correct lifetime.
+    /// # Safety
+    ///
+    /// From a safety standpoint, this is equivalent to dereferencing a raw
+    /// pointer for every element in the array. You must ensure that all of the
+    /// data is valid, ensure that the pointer is aligned, and choose the
+    /// correct lifetime.
     #[inline]
     pub unsafe fn deref_into_view_mut<'a>(self) -> ArrayViewMut<'a, A, D> {
         debug_assert!(

--- a/src/impl_views/constructors.rs
+++ b/src/impl_views/constructors.rs
@@ -65,7 +65,9 @@ where
     /// Create an `ArrayView<A, D>` from shape information and a raw pointer to
     /// the elements.
     ///
-    /// Unsafe because caller is responsible for ensuring all of the following:
+    /// # Safety
+    ///
+    /// The caller is responsible for ensuring all of the following:
     ///
     /// * The elements seen by moving `ptr` according to the shape and strides
     ///   must live at least as long as `'a` and must not be not mutably
@@ -159,7 +161,9 @@ where
     /// Create an `ArrayViewMut<A, D>` from shape information and a
     /// raw pointer to the elements.
     ///
-    /// Unsafe because caller is responsible for ensuring all of the following:
+    /// # Safety
+    ///
+    /// The caller is responsible for ensuring all of the following:
     ///
     /// * The elements seen by moving `ptr` according to the shape and strides
     ///   must live at least as long as `'a` and must not be aliased for the

--- a/src/impl_views/indexing.rs
+++ b/src/impl_views/indexing.rs
@@ -90,6 +90,10 @@ pub trait IndexLonger<I> {
     /// [1]: struct.ArrayBase.html#method.uget
     ///
     /// **Note:** only unchecked for non-debug builds of ndarray.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that the index is in-bounds.
     unsafe fn uget(self, index: I) -> Self::Output;
 }
 

--- a/src/iterators/windows.rs
+++ b/src/iterators/windows.rs
@@ -41,7 +41,7 @@ impl<'a, A, D: Dimension> Windows<'a, A, D> {
 
         unsafe {
             Windows {
-                base: ArrayView::from_shape_ptr(size.clone().strides(a.strides), a.ptr.as_ptr()),
+                base: ArrayView::from_shape_ptr(size.strides(a.strides), a.ptr.as_ptr()),
                 window,
                 strides: window_strides,
             }


### PR DESCRIPTION
Most of these changes are adding `# Safety` headings to the docs of unsafe functions/methods. The other change is removing an unnecessary `.clone()`.