### PR TITLE
Fix description of required layout for into_shape

### DIFF
--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -1443,8 +1443,8 @@ where
     }
 
     /// Transform the array into `shape`; any shape with the same number of
-    /// elements is accepted, but the source array or view must be
-    /// contiguous, otherwise we cannot rearrange the dimension.
+    /// elements is accepted, but the source array or view must be in standard
+    /// or column-major (Fortran) layout.
     ///
     /// **Errors** if the shapes don't have the same number of elements.<br>
     /// **Errors** if the input array is not c- or f-contiguous.


### PR DESCRIPTION
Previously, the first paragraph of the docs indicated that any contiguous array was accepted, while the second paragraph indicated that only c- or f-contiguous arrays were accepted. The second paragraph is correct. This commit fixes the description in the first paragraph to match.

Fixes #766.