### PR TITLE
Fix compilation warnings.

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -70,9 +70,11 @@ impl PartialEq for ShapeError {
     }
 }
 
-impl Error for ShapeError {
-    fn description(&self) -> &str {
-        match self.kind() {
+impl Error for ShapeError {}
+
+impl fmt::Display for ShapeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let description = match self.kind() {
             ErrorKind::IncompatibleShape => "incompatible shapes",
             ErrorKind::IncompatibleLayout => "incompatible memory layout",
             ErrorKind::RangeLimited => "the shape does not fit in type limits",
@@ -80,19 +82,14 @@ impl Error for ShapeError {
             ErrorKind::Unsupported => "unsupported operation",
             ErrorKind::Overflow => "arithmetic overflow",
             ErrorKind::__Incomplete => "this error variant is not in use",
-        }
-    }
-}
-
-impl fmt::Display for ShapeError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "ShapeError/{:?}: {}", self.kind(), self.description())
+        };
+        write!(f, "ShapeError/{:?}: {}", self.kind(), description)
     }
 }
 
 impl fmt::Debug for ShapeError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "ShapeError/{:?}: {}", self.kind(), self.description())
+        write!(f, "{}", self)
     }
 }
 


### PR DESCRIPTION
This PR fixes these warnings that show up on Nightly:

```
warning: use of deprecated item 'std::error::Error::description': use the Display impl or to_string()
  --> src/error.rs:89:60
   |
89 |         write!(f, "ShapeError/{:?}: {}", self.kind(), self.description())
   |                                                            ^^^^^^^^^^^
   |
   = note: `#[warn(deprecated)]` on by default

warning: use of deprecated item 'std::error::Error::description': use the Display impl or to_string()
  --> src/error.rs:95:60
   |
95 |         write!(f, "ShapeError/{:?}: {}", self.kind(), self.description())
   |                                                            ^^^^^^^^^^^
```