### PR TITLE
Clarify versions of BLAS dependencies in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,6 +84,15 @@ provider::
     blas-src = { version = "0.4.0", default-features = false, features = ["openblas"] }
     openblas-src = { version = "0.7.0", default-features = false, features = ["cblas", "system"] }
 
+For official releases of ``ndarray``, the versions are:
+
+=========== ============ ================
+``ndarray`` ``blas-src`` ``openblas-src``
+=========== ============ ================
+0.13.0      0.2.0        0.6.0
+0.12.\*     0.2.0        0.6.0
+0.11.\*     0.1.2        0.5.0
+=========== ============ ================
 
 Recent Changes
 --------------

--- a/README.rst
+++ b/README.rst
@@ -81,8 +81,8 @@ provider::
 
     [dependencies]
     ndarray = { version = "0.13.0", features = ["blas"] }
-    blas-src = { version = "0.4.0", default-features = false, features = ["openblas"] }
-    openblas-src = { version = "0.7.0", default-features = false, features = ["cblas", "system"] }
+    blas-src = { version = "0.2.0", default-features = false, features = ["openblas"] }
+    openblas-src = { version = "0.6.0", default-features = false, features = ["cblas", "system"] }
 
 For official releases of ``ndarray``, the versions are:
 


### PR DESCRIPTION
This adds a table of the BLAS versions corresponding to old `ndarray` versions. It also changes the versions of the dependencies in the example to be consistent with the version of `ndarray` in the example.