### PR TITLE
Fix flatten example in ndarray_for_numpy_users

### DIFF
--- a/src/doc/ndarray_for_numpy_users/mod.rs
+++ b/src/doc/ndarray_for_numpy_users/mod.rs
@@ -536,7 +536,7 @@
 //! `a[:,np.newaxis]` or `np.expand_dims(a, axis=1)` | [`a.insert_axis(Axis(1))`][.insert_axis()] | create an array from `a`, inserting a new axis 1
 //! `a.transpose()` or `a.T` | [`a.t()`][.t()] or [`a.reversed_axes()`][.reversed_axes()] | transpose of array `a` (view for `.t()` or by-move for `.reversed_axes()`)
 //! `np.diag(a)` | [`a.diag()`][.diag()] | view the diagonal of `a`
-//! `a.flatten()` | [`Array::from_iter(a.iter())`][::from_iter()] | create a 1-D array by flattening `a`
+//! `a.flatten()` | [`use std::iter::FromIterator; Array::from_iter(a.iter().cloned())`][::from_iter()] | create a 1-D array by flattening `a`
 //!
 //! ## Iteration
 //!


### PR DESCRIPTION
The old example was missing `.cloned()`. Additionally, it didn't clearly indicate that `use std::iter::FromIterator` is necessary.

Fixes #779.