### PR TITLE
Dimension::Larger should implement RemoveAxis

### DIFF
--- a/src/dimension/dimension_trait.rs
+++ b/src/dimension/dimension_trait.rs
@@ -75,7 +75,7 @@ pub trait Dimension:
     /// Next smaller dimension (if applicable)
     type Smaller: Dimension;
     /// Next larger dimension
-    type Larger: Dimension;
+    type Larger: Dimension + RemoveAxis;
 
     /// Returns the number of dimensions (number of axes).
     fn ndim(&self) -> usize;


### PR DESCRIPTION
Hi, this is something that has been useful to me while doing generic programming on array dimensions. All the implementors of `Dimension` already verify `T::Larger: RemoveAxis`, so this doesn't break anything internally.  