### PR TITLE
Prepare 0.13.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 Cargo.lock
 target/
-.idea/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ approx = { version = "0.3.2", optional = true }
 
 # Use via the `blas` crate feature!
 cblas-sys = { version = "0.1.4", optional = true, default-features = false }
-blas-src = { version = "0.4.0", optional = true, default-features = false }
+blas-src = { version = "0.2.0", optional = true, default-features = false }
 
 matrixmultiply = { version = "0.2.0" }
 serde = { version = "1.0", optional = true }

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,47 @@
+Version 0.13.1 (2020-04)
+===========================
+
+New features
+------------
+
+- New *amazing* slicing methods `multi_slice_*` by [@jturner314]
+  https://github.com/rust-ndarray/ndarray/pull/717
+- New method `.cast()` for raw views by [@bluss]
+  https://github.com/rust-ndarray/ndarray/pull/734
+- New aliases `ArcArray1`, `ArcArray2` by [@d-dorazio]
+  https://github.com/rust-ndarray/ndarray/pull/741
+- New array constructor `from_shape_simple_fn` by [@bluss]
+  https://github.com/rust-ndarray/ndarray/pull/728
+- `Dimension::Larger` now requires `RemoveAxis` by [@TheLortex]
+  https://github.com/rust-ndarray/ndarray/pull/792
+
+
+Enhancements
+------------
+
+- Remove itertools as dependency by [@bluss]
+  https://github.com/rust-ndarray/ndarray/pull/730
+- Improve `zip_mut_with` (and thus arithmetic ops) for f-order arrays by [@nilgoyette]
+  https://github.com/rust-ndarray/ndarray/pull/754
+- Implement `fold` for `IndicesIter` by [@jturner314]
+  https://github.com/rust-ndarray/ndarray/pull/733
+
+API changes
+-----------
+
+- Remove alignment restriction on raw views by [@jturner314]
+  https://github.com/rust-ndarray/ndarray/pull/738
+
+Other changes
+-------------
+
+- Fix documentation in ndarray for numpy users by [@jturner314]
+- Improve blas version documentation by [@jturner314]
+- Doc improvements by [@mockersf] https://github.com/rust-ndarray/ndarray/pull/751
+- Doc and lint related improvements by [@viniciusd] https://github.com/rust-ndarray/ndarray/pull/750
+- Release management by [@bluss]
+
+
 Version 0.13.0 (2019-09-23)
 ===========================
 
@@ -895,3 +939,8 @@ Earlier releases
 [@termoshtt]: https://github.com/termoshtt
 [@rth]: https://github.com/rth
 [@nitsky]: https://github.com/nitsky
+[@d-dorazio]: https://github.com/d-dorazio
+[@nilgoyette]: https://github.com/nilgoyette
+[@TheLortex]: https://github.com/TheLortex
+[@mockersf]: https://github.com/mockersf
+[@viniciusd]: https://github.com/viniciusd

--- a/blas-tests/Cargo.toml
+++ b/blas-tests/Cargo.toml
@@ -10,7 +10,7 @@ test = false
 [dev-dependencies]
 approx = "0.3.2"
 ndarray = { path = "../", features = ["approx", "blas"] }
-blas-src = { version = "0.4.0", default-features = false, features = ["openblas"] }
-openblas-src = { version = "0.7.0", default-features = false, features = ["cblas", "system"] }
+blas-src = { version = "0.2.0", default-features = false, features = ["openblas"] }
+openblas-src = { version = "0.6.0", default-features = false, features = ["cblas", "system"] }
 defmac = "0.2"
 num-traits = "0.2"

--- a/scripts/all-tests.sh
+++ b/scripts/all-tests.sh
@@ -6,7 +6,6 @@ set -e
 FEATURES=$1
 CHANNEL=$2
 
-([ "$CHANNEL" != "beta" ] || (rustup component add rustfmt && cargo fmt --all -- --check))
 cargo build --verbose --no-default-features
 # Testing both dev and release profiles helps find bugs, especially in low level code
 cargo test --verbose --no-default-features

--- a/src/indexes.rs
+++ b/src/indexes.rs
@@ -273,18 +273,14 @@ where
         if !self.has_remaining {
             return (0, Some(0));
         }
-        let l = match self.index {
-            ref ix => {
-                let gone = self
-                    .dim
-                    .fortran_strides()
-                    .slice()
-                    .iter()
-                    .zip(ix.slice().iter())
-                    .fold(0, |s, (&a, &b)| s + a as usize * b as usize);
-                self.dim.size() - gone
-            }
-        };
+        let gone = self
+            .dim
+            .fortran_strides()
+            .slice()
+            .iter()
+            .zip(self.index.slice().iter())
+            .fold(0, |s, (&a, &b)| s + a as usize * b as usize);
+        let l = self.dim.size() - gone;
         (l, Some(l))
     }
 }


### PR DESCRIPTION
Prepare 0.13.1 release.

Temporarily reverts breaking change #768 so that we can push out a minor version, the rest of the changes are intended to all be non-breaking changes, a mix of new features and fixes (see changelog)