### PR TITLE
Add methods to collect Zip into an array

### DIFF
--- a/src/argument_traits.rs
+++ b/src/argument_traits.rs
@@ -1,0 +1,31 @@
+use std::cell::Cell;
+use std::mem::MaybeUninit;
+
+
+/// A producer element that can be assigned to once
+pub trait AssignElem<T> {
+    /// Assign the value `input` to the element that self represents.
+    fn assign_elem(self, input: T);
+}
+
+/// Assignable element, simply `*self = input`.
+impl<'a, T> AssignElem<T> for &'a mut T {
+    fn assign_elem(self, input: T) {
+        *self = input;
+    }
+}
+
+/// Assignable element, simply `self.set(input)`.
+impl<'a, T> AssignElem<T> for &'a Cell<T> {
+    fn assign_elem(self, input: T) {
+        self.set(input);
+    }
+}
+
+/// Assignable element, the item in the MaybeUninit is overwritten (prior value, if any, is not
+/// read or dropped).
+impl<'a, T> AssignElem<T> for &'a mut MaybeUninit<T> {
+    fn assign_elem(self, input: T) {
+        *self = MaybeUninit::new(input);
+    }
+}

--- a/src/impl_constructors.rs
+++ b/src/impl_constructors.rs
@@ -13,6 +13,7 @@
 #![allow(clippy::match_wild_err_arm)]
 
 use num_traits::{Float, One, Zero};
+use std::mem::MaybeUninit;
 
 use crate::dimension;
 use crate::error::{self, ShapeError};
@@ -515,5 +516,24 @@ where
         let mut v = Vec::with_capacity(size);
         v.set_len(size);
         Self::from_shape_vec_unchecked(shape, v)
+    }
+}
+
+impl<S, A, D> ArrayBase<S, D>
+where
+    S: DataOwned<Elem = MaybeUninit<A>>,
+    D: Dimension,
+{
+    pub(crate) fn maybe_uninit<Sh>(shape: Sh) -> Self
+    where
+        Sh: ShapeBuilder<Dim = D>,
+    {
+        unsafe {
+            let shape = shape.into_shape();
+            let size = size_of_shape_checked_unwrap!(&shape.dim);
+            let mut v = Vec::with_capacity(size);
+            v.set_len(size);
+            Self::from_shape_vec_unchecked(shape, v)
+        }
     }
 }

--- a/src/impl_owned_array.rs
+++ b/src/impl_owned_array.rs
@@ -1,4 +1,8 @@
+use std::mem::MaybeUninit;
+use std::mem::transmute;
+
 use crate::imp_prelude::*;
+use crate::OwnedRepr;
 
 /// Methods specific to `Array0`.
 ///
@@ -55,5 +59,35 @@ where
     /// of the array (`.iter()` order) and of the returned vector will be the same.
     pub fn into_raw_vec(self) -> Vec<A> {
         self.data.0
+    }
+}
+
+/// Methods specific to `Array` of `MaybeUninit`.
+///
+/// ***See also all methods for [`ArrayBase`]***
+///
+/// [`ArrayBase`]: struct.ArrayBase.html
+impl<A, D> Array<MaybeUninit<A>, D>
+where
+    D: Dimension,
+{
+    /// Assert that the array's storage's elements are all fully initialized, and conver
+    /// the array from element type `MaybeUninit<A>` to `A`.
+    pub(crate) unsafe fn assume_init(self) -> Array<A, D> {
+        // NOTE: Fully initialized includes elements not reachable in current slicing/view.
+        //
+        // Should this method be generalized to all array types?
+        // (Will need a way to map the RawData<Elem=X> to RawData<Elem=Y> of same kind)
+
+        let Array { data, ptr, dim, strides } = self;
+        let data = transmute::<OwnedRepr<MaybeUninit<A>>, OwnedRepr<A>>(data);
+        let ptr = ptr.cast::<A>();
+
+        Array {
+            data,
+            ptr,
+            dim,
+            strides,
+        }
     }
 }

--- a/src/layout/layoutfmt.rs
+++ b/src/layout/layoutfmt.rs
@@ -7,7 +7,6 @@
 // except according to those terms.
 
 use super::Layout;
-use super::LayoutPriv;
 
 const LAYOUT_NAMES: &[&str] = &["C", "F"];
 

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -1,35 +1,28 @@
 mod layoutfmt;
 
-// public but users don't interact with it
+// public struct but users don't interact with it
 #[doc(hidden)]
 /// Memory layout description
 #[derive(Copy, Clone)]
 pub struct Layout(u32);
 
-pub trait LayoutPriv: Sized {
-    fn new(x: u32) -> Self;
-    fn and(self, flag: Self) -> Self;
-    fn is(self, flag: u32) -> bool;
-    fn flag(self) -> u32;
-}
-
-impl LayoutPriv for Layout {
+impl Layout {
     #[inline(always)]
-    fn new(x: u32) -> Self {
+    pub(crate) fn new(x: u32) -> Self {
         Layout(x)
     }
 
     #[inline(always)]
-    fn is(self, flag: u32) -> bool {
+    pub(crate) fn is(self, flag: u32) -> bool {
         self.0 & flag != 0
     }
     #[inline(always)]
-    fn and(self, flag: Layout) -> Layout {
+    pub(crate) fn and(self, flag: Layout) -> Layout {
         Layout(self.0 & flag.0)
     }
 
     #[inline(always)]
-    fn flag(self) -> u32 {
+    pub(crate) fn flag(self) -> u32 {
         self.0
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,6 +149,8 @@ mod array_approx;
 mod array_serde;
 mod arrayformat;
 mod arraytraits;
+mod argument_traits;
+pub use crate::argument_traits::AssignElem;
 mod data_traits;
 
 pub use crate::aliases::*;

--- a/src/zip/mod.rs
+++ b/src/zip/mod.rs
@@ -18,7 +18,6 @@ use crate::Layout;
 use crate::NdIndex;
 
 use crate::indexes::{indices, Indices};
-use crate::layout::LayoutPriv;
 use crate::layout::{CORDER, FORDER};
 
 /// Return if the expression is a break value.

--- a/src/zip/zipmacro.rs
+++ b/src/zip/zipmacro.rs
@@ -122,6 +122,12 @@ macro_rules! azip {
             $(.and($prod))*
             .$apply(|$first_pat, $($pat),*| $body)
     };
+
+    // Unindexed with one or more producer, no loop body
+    (@build $apply:ident $first_prod:expr $(, $prod:expr)* $(,)?) => {
+        $crate::Zip::from($first_prod)
+            $(.and($prod))*
+    };
     // catch-all rule
     (@build $($t:tt)*) => { compile_error!("Invalid syntax in azip!()") };
     ($($t:tt)*) => {

--- a/tests/azip.rs
+++ b/tests/azip.rs
@@ -50,6 +50,34 @@ fn test_azip2_3() {
 }
 
 #[test]
+#[cfg(feature = "approx")]
+fn test_zip_collect() {
+    use approx::assert_abs_diff_eq;
+
+    // test Zip::apply_collect and that it preserves c/f layout.
+
+    let b = Array::from_shape_fn((5, 10), |(i, j)| 1. / (i + 2 * j + 1) as f32);
+    let c = Array::from_shape_fn((5, 10), |(i, j)| f32::exp((i + j) as f32));
+
+    {
+        let a = Zip::from(&b).and(&c).apply_collect(|x, y| x + y);
+
+        assert_abs_diff_eq!(a, &b + &c, epsilon = 1e-6);
+        assert_eq!(a.strides(), b.strides());
+    }
+
+    {
+        let b = b.t();
+        let c = c.t();
+
+        let a = Zip::from(&b).and(&c).apply_collect(|x, y| x + y);
+
+        assert_abs_diff_eq!(a, &b + &c, epsilon = 1e-6);
+        assert_eq!(a.strides(), b.strides());
+    }
+}
+
+#[test]
 fn test_azip_syntax_trailing_comma() {
     let mut b = Array::<i32, _>::zeros((5, 5));
     let mut c = Array::<i32, _>::ones((5, 5));

--- a/tests/azip.rs
+++ b/tests/azip.rs
@@ -78,6 +78,37 @@ fn test_zip_collect() {
 }
 
 #[test]
+#[cfg(feature = "approx")]
+fn test_zip_assign_into() {
+    use approx::assert_abs_diff_eq;
+
+    let mut a = Array::<f32, _>::zeros((5, 10));
+    let b = Array::from_shape_fn((5, 10), |(i, j)| 1. / (i + 2 * j + 1) as f32);
+    let c = Array::from_shape_fn((5, 10), |(i, j)| f32::exp((i + j) as f32));
+
+    Zip::from(&b).and(&c).apply_assign_into(&mut a, |x, y| x + y);
+
+    assert_abs_diff_eq!(a, &b + &c, epsilon = 1e-6);
+}
+
+#[test]
+#[cfg(feature = "approx")]
+fn test_zip_assign_into_cell() {
+    use approx::assert_abs_diff_eq;
+    use std::cell::Cell;
+
+    let a = Array::<Cell<f32>, _>::default((5, 10));
+    let b = Array::from_shape_fn((5, 10), |(i, j)| 1. / (i + 2 * j + 1) as f32);
+    let c = Array::from_shape_fn((5, 10), |(i, j)| f32::exp((i + j) as f32));
+
+    Zip::from(&b).and(&c).apply_assign_into(&a, |x, y| x + y);
+    let a2 = a.mapv(|elt| elt.get());
+
+    assert_abs_diff_eq!(a2, &b + &c, epsilon = 1e-6);
+}
+
+
+#[test]
 fn test_azip_syntax_trailing_comma() {
     let mut b = Array::<i32, _>::zeros((5, 5));
     let mut c = Array::<i32, _>::ones((5, 5));

--- a/tests/par_zip.rs
+++ b/tests/par_zip.rs
@@ -70,3 +70,45 @@ fn test_zip_index_4() {
         assert_eq!(*elt, j);
     }
 }
+
+#[test]
+#[cfg(feature = "approx")]
+fn test_zip_collect() {
+    use approx::assert_abs_diff_eq;
+
+    // test Zip::apply_collect and that it preserves c/f layout.
+
+    let b = Array::from_shape_fn((M, N), |(i, j)| 1. / (i + 2 * j + 1) as f32);
+    let c = Array::from_shape_fn((M, N), |(i, j)| f32::ln((1 + i + j) as f32));
+
+    {
+        let a = Zip::from(&b).and(&c).par_apply_collect(|x, y| x + y);
+
+        assert_abs_diff_eq!(a, &b + &c, epsilon = 1e-6);
+        assert_eq!(a.strides(), b.strides());
+    }
+
+    {
+        let b = b.t();
+        let c = c.t();
+
+        let a = Zip::from(&b).and(&c).par_apply_collect(|x, y| x + y);
+
+        assert_abs_diff_eq!(a, &b + &c, epsilon = 1e-6);
+        assert_eq!(a.strides(), b.strides());
+    }
+}
+
+#[test]
+#[cfg(feature = "approx")]
+fn test_zip_assign_into() {
+    use approx::assert_abs_diff_eq;
+
+    let mut a = Array::<f32, _>::zeros((M, N));
+    let b = Array::from_shape_fn((M, N), |(i, j)| 1. / (i + 2 * j + 1) as f32);
+    let c = Array::from_shape_fn((M, N), |(i, j)| f32::ln((1 + i + j) as f32));
+
+    Zip::from(&b).and(&c).par_apply_assign_into(&mut a, |x, y| x + y);
+
+    assert_abs_diff_eq!(a, &b + &c, epsilon = 1e-6);
+}


### PR DESCRIPTION
Add

- Zip::apply_collect
- Zip::apply_assign_into
- Zip::par_apply_collect
- Zip::par_apply_assign_into

Add internal (for now) constructors for `MaybeUninit<T>`-filled arrays.
Restrict to Copy elements to use collect (because we don't implement dropping a
halfway filled array yet).

This is added to all but the last arity of Zip (because the last item is needed for the result that we collect into.

The assignment functions are generalized so that we can assign to `&mut T`, `&mut MaybeUninit<T>` and `&Cell<T>` when we have elements of `T`. This seems powerful, and could be a concept that's explored further (methods .assign() and .fill() come to mind).
A very minor question is what to name and in which module to put the new trait for this - `AssignElem<T>`.

Fixes #755 