### PR TITLE
Support uninitialized elements in .assign() and .fill()

### DIFF
--- a/src/impl_constructors.rs
+++ b/src/impl_constructors.rs
@@ -471,8 +471,9 @@ where
     /// ### Safety
     ///
     /// Accessing uninitalized values is undefined behaviour. You must
-    /// overwrite *all* the elements in the array after it is created; for
-    /// example using the methods `.fill()` or `.assign()`.
+    /// overwrite *all* the elements in the array after it is created; this must
+    /// be done carefully, for example using the methods `.fill()` or `.assign()`,
+    /// which are documented to support this use case.
     ///
     /// The contents of the array is indeterminate before initialization and it
     /// is an error to perform operations that use the previous values. For


### PR DESCRIPTION
The trick is simply to traverse the target array using a raw view / raw
pointers; this means we don't create any references to
potentially-uninitialized values.

Assignment `*x = y.clone()` is used where x is a *mut A, y is a &A;
this will work as intended when A: Copy; assignment should not need that
the value being overwritten, when Copy, is initialized.

Unfortunately we use Zip here instead of the older methods
(zip_mut_with, unordered_foreach_mut); because Zip implements equivalent
functionality but in a generic way. The access pattern and performance
is not guaranteed to be identical.

Related to issue #685 