### PR TITLE
Make OwnedRepr an "aliasable owner" instead of using Vec

### DIFF
--- a/src/data_repr.rs
+++ b/src/data_repr.rs
@@ -1,0 +1,97 @@
+
+use std::mem;
+use std::ptr::NonNull;
+use std::slice;
+use crate::extension::nonnull;
+
+/// Array's representation.
+///
+/// *Don’t use this type directly—use the type alias
+/// [`Array`](type.Array.html) for the array type!*
+// Like a Vec, but with non-unique ownership semantics
+#[derive(Debug)]
+pub struct OwnedRepr<A> {
+    ptr: NonNull<A>,
+    len: usize,
+    capacity: usize,
+}
+
+impl<A> OwnedRepr<A> {
+    pub(crate) fn from(mut v: Vec<A>) -> Self {
+        let len = v.len();
+        let capacity = v.capacity();
+        let ptr = nonnull::nonnull_from_vec_data(&mut v);
+        mem::forget(v);
+        Self {
+            ptr,
+            len,
+            capacity,
+        }
+    }
+
+    pub(crate) fn into_vec(mut self) -> Vec<A> {
+        let v = self.take_as_vec();
+        mem::forget(self);
+        v
+    }
+
+    pub(crate) fn as_slice(&self) -> &[A] {
+        unsafe {
+            slice::from_raw_parts(self.ptr.as_ptr(), self.len)
+        }
+    }
+
+    pub(crate) fn len(&self) -> usize { self.len }
+
+    pub(crate) fn as_ptr(&self) -> *const A {
+        self.ptr.as_ptr()
+    }
+
+    pub(crate) fn as_nonnull_mut(&mut self) -> NonNull<A> {
+        self.ptr
+    }
+
+    fn take_as_vec(&mut self) -> Vec<A> {
+        let capacity = self.capacity;
+        let len = self.len;
+        self.len = 0;
+        self.capacity = 0;
+        unsafe {
+            Vec::from_raw_parts(self.ptr.as_ptr(), len, capacity)
+        }
+    }
+}
+
+impl<A> Clone for OwnedRepr<A>
+    where A: Clone
+{
+    fn clone(&self) -> Self {
+        Self::from(self.as_slice().to_owned())
+    }
+
+    fn clone_from(&mut self, other: &Self) {
+        let mut v = self.take_as_vec();
+        let other = other.as_slice();
+
+        if v.len() > other.len() {
+            v.truncate(other.len());
+        }
+        let (front, back) = other.split_at(v.len());
+        v.clone_from_slice(front);
+        v.extend_from_slice(back);
+        *self = Self::from(v);
+    }
+}
+
+impl<A> Drop for OwnedRepr<A> {
+    fn drop(&mut self) {
+        if self.capacity > 0 {
+            // drop as a Vec.
+            self.take_as_vec();
+        }
+    }
+}
+
+unsafe impl<A> Sync for OwnedRepr<A> where A: Sync { }
+unsafe impl<A> Send for OwnedRepr<A> where A: Send { }
+

--- a/src/impl_owned_array.rs
+++ b/src/impl_owned_array.rs
@@ -19,22 +19,22 @@ impl<A> Array<A, Ix0> {
     /// let scalar: Foo = array.into_scalar();
     /// assert_eq!(scalar, Foo);
     /// ```
-    pub fn into_scalar(mut self) -> A {
+    pub fn into_scalar(self) -> A {
         let size = ::std::mem::size_of::<A>();
         if size == 0 {
             // Any index in the `Vec` is fine since all elements are identical.
-            self.data.0.remove(0)
+            self.data.into_vec().remove(0)
         } else {
             // Find the index in the `Vec` corresponding to `self.ptr`.
             // (This is necessary because the element in the array might not be
             // the first element in the `Vec`, such as if the array was created
             // by `array![1, 2, 3, 4].slice_move(s![2])`.)
             let first = self.ptr.as_ptr() as usize;
-            let base = self.data.0.as_ptr() as usize;
+            let base = self.data.as_ptr() as usize;
             let index = (first - base) / size;
             debug_assert_eq!((first - base) % size, 0);
             // Remove the element at the index and return it.
-            self.data.0.remove(index)
+            self.data.into_vec().remove(index)
         }
     }
 }
@@ -54,6 +54,6 @@ where
     /// If the array is in standard memory layout, the logical element order
     /// of the array (`.iter()` order) and of the returned vector will be the same.
     pub fn into_raw_vec(self) -> Vec<A> {
-        self.data.0
+        self.data.into_vec()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,6 +150,7 @@ mod array_serde;
 mod arrayformat;
 mod arraytraits;
 mod data_traits;
+mod data_repr;
 
 pub use crate::aliases::*;
 
@@ -1386,12 +1387,8 @@ pub type RawArrayView<A, D> = ArrayBase<RawViewRepr<*const A>, D>;
 /// [`from_shape_ptr`](#method.from_shape_ptr) for details.
 pub type RawArrayViewMut<A, D> = ArrayBase<RawViewRepr<*mut A>, D>;
 
-/// Array's representation.
-///
-/// *Don’t use this type directly—use the type alias
-/// [`Array`](type.Array.html) for the array type!*
-#[derive(Clone, Debug)]
-pub struct OwnedRepr<A>(Vec<A>);
+pub use data_repr::OwnedRepr;
+
 
 /// RcArray's representation.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1402,7 +1402,7 @@ pub use self::OwnedArcRepr as OwnedRcRepr;
 /// *Don’t use this type directly—use the type alias
 /// [`ArcArray`](type.ArcArray.html) for the array type!*
 #[derive(Debug)]
-pub struct OwnedArcRepr<A>(Arc<Vec<A>>);
+pub struct OwnedArcRepr<A>(Arc<OwnedRepr<A>>);
 
 impl<A> Clone for OwnedArcRepr<A> {
     fn clone(&self) -> Self {


### PR DESCRIPTION
The owned array has used a `Vec<T>` that it owns, and kept a separate "head pointer" `ptr` on the side; the head pointer points to the first element in the array, somewhere inside the vector's data.

The Vec uses a "unique" owning pointer - not a building block that is available outside std - so just like Box, it should in principle not be possible to modify the vector's data through anything else than its own data pointer. Our head pointer can violate this.

We replace the Vec with a deconstructed vector; it's equivalent but uses `NonNull<T>` for its pointer, so it's an aliasable owner.

This does not change how owned arrays are allocated, only how it is modelled in the type system. The change affects all the owned arrays (Array, ArcArray, CowArray).

cc #796 

In principle, this problem is described in issue Kimundi/owning-ref-rs#49

This soundness concern does not currently seem to yield any problems in practice, because the compiler does not take advantage of the properties of Vec's unique pointer.