### PR TITLE
Zip: Handle preferred memory layout of inhomogenous inputs better

### DIFF
--- a/benches/iter.rs
+++ b/benches/iter.rs
@@ -381,12 +381,12 @@ pub fn zip_mut_with(data: &Array3<f32>, out: &mut Array3<f32>) {
 fn zip_mut_with_cc(b: &mut Bencher) {
     let data: Array3<f32> = Array3::zeros((ISZ, ISZ, ISZ));
     let mut out = Array3::zeros(data.dim());
-    b.iter(|| black_box(zip_mut_with(&data, &mut out)));
+    b.iter(|| zip_mut_with(&data, &mut out));
 }
 
 #[bench]
 fn zip_mut_with_ff(b: &mut Bencher) {
     let data: Array3<f32> = Array3::zeros((ISZ, ISZ, ISZ).f());
     let mut out = Array3::zeros(data.dim().f());
-    b.iter(|| black_box(zip_mut_with(&data, &mut out)));
+    b.iter(|| zip_mut_with(&data, &mut out));
 }

--- a/benches/zip.rs
+++ b/benches/zip.rs
@@ -1,0 +1,109 @@
+#![feature(test)]
+extern crate test;
+use test::{black_box, Bencher};
+use ndarray::{Array3, ShapeBuilder, Zip};
+
+pub fn zip_copy(data: &Array3<f32>, out: &mut Array3<f32>) {
+    Zip::from(data).and(out).apply(|&i, o| {
+        *o = i;
+    });
+}
+
+pub fn zip_indexed(data: &Array3<f32>, out: &mut Array3<f32>) {
+    Zip::indexed(data).and(out).apply(|idx, &i, o| {
+        *o = i;
+    });
+}
+
+pub fn zip_mut_with(data: &Array3<f32>, out: &mut Array3<f32>) {
+    out.zip_mut_with(&data, |o, &i| {
+        *o = i;
+    });
+}
+
+// array size in benchmarks
+const SZ3: (usize, usize, usize) = (137, 171, 151);
+
+#[bench]
+fn zip_cf(b: &mut Bencher) {
+    let data: Array3<f32> = Array3::zeros(SZ3);
+    let mut out = Array3::zeros(data.dim().f());
+    b.iter(|| black_box(zip_copy(&data, &mut out)));
+}
+
+#[bench]
+fn zip_cc(b: &mut Bencher) {
+    let data: Array3<f32> = Array3::zeros(SZ3);
+    let mut out = Array3::zeros(data.dim());
+    b.iter(|| black_box(zip_copy(&data, &mut out)));
+}
+
+#[bench]
+fn zip_fc(b: &mut Bencher) {
+    let data: Array3<f32> = Array3::zeros(SZ3.f());
+    let mut out = Array3::zeros(data.dim());
+    b.iter(|| black_box(zip_copy(&data, &mut out)));
+}
+
+#[bench]
+fn zip_ff(b: &mut Bencher) {
+    let data: Array3<f32> = Array3::zeros(SZ3.f());
+    let mut out = Array3::zeros(data.dim().f());
+    b.iter(|| black_box(zip_copy(&data, &mut out)));
+}
+
+#[bench]
+fn zip_indexed_cf(b: &mut Bencher) {
+    let data: Array3<f32> = Array3::zeros(SZ3);
+    let mut out = Array3::zeros(data.dim().f());
+    b.iter(|| black_box(zip_indexed(&data, &mut out)));
+}
+
+#[bench]
+fn zip_indexed_cc(b: &mut Bencher) {
+    let data: Array3<f32> = Array3::zeros(SZ3);
+    let mut out = Array3::zeros(data.dim());
+    b.iter(|| black_box(zip_indexed(&data, &mut out)));
+}
+
+#[bench]
+fn zip_indexed_fc(b: &mut Bencher) {
+    let data: Array3<f32> = Array3::zeros(SZ3.f());
+    let mut out = Array3::zeros(data.dim());
+    b.iter(|| black_box(zip_indexed(&data, &mut out)));
+}
+
+#[bench]
+fn zip_indexed_ff(b: &mut Bencher) {
+    let data: Array3<f32> = Array3::zeros(SZ3.f());
+    let mut out = Array3::zeros(data.dim().f());
+    b.iter(|| black_box(zip_indexed(&data, &mut out)));
+}
+
+#[bench]
+fn zip_mut_with_cf(b: &mut Bencher) {
+    let data: Array3<f32> = Array3::zeros(SZ3);
+    let mut out = Array3::zeros(data.dim().f());
+    b.iter(|| black_box(zip_mut_with(&data, &mut out)));
+}
+
+#[bench]
+fn zip_mut_with_cc(b: &mut Bencher) {
+    let data: Array3<f32> = Array3::zeros(SZ3);
+    let mut out = Array3::zeros(data.dim());
+    b.iter(|| black_box(zip_mut_with(&data, &mut out)));
+}
+
+#[bench]
+fn zip_mut_with_fc(b: &mut Bencher) {
+    let data: Array3<f32> = Array3::zeros(SZ3.f());
+    let mut out = Array3::zeros(data.dim());
+    b.iter(|| black_box(zip_mut_with(&data, &mut out)));
+}
+
+#[bench]
+fn zip_mut_with_ff(b: &mut Bencher) {
+    let data: Array3<f32> = Array3::zeros(SZ3.f());
+    let mut out = Array3::zeros(data.dim().f());
+    b.iter(|| black_box(zip_mut_with(&data, &mut out)));
+}

--- a/benches/zip.rs
+++ b/benches/zip.rs
@@ -1,6 +1,6 @@
 #![feature(test)]
 extern crate test;
-use test::{Bencher};
+use test::{black_box, Bencher};
 use ndarray::{Array3, ShapeBuilder, Zip};
 use ndarray::s;
 use ndarray::IntoNdProducer;
@@ -33,6 +33,7 @@ pub fn zip_copy_split<'a, A, P, Q>(data: P, out: Q)
 
 pub fn zip_indexed(data: &Array3<f32>, out: &mut Array3<f32>) {
     Zip::indexed(data).and(out).apply(|idx, &i, o| {
+        let _ = black_box(idx);
         *o = i;
     });
 }

--- a/src/layout/layoutfmt.rs
+++ b/src/layout/layoutfmt.rs
@@ -8,7 +8,7 @@
 
 use super::Layout;
 
-const LAYOUT_NAMES: &[&str] = &["C", "F"];
+const LAYOUT_NAMES: &[&str] = &["C", "F", "c", "f"];
 
 use std::fmt;
 

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -25,27 +25,24 @@ impl Layout {
     pub(crate) fn flag(self) -> u32 {
         self.0
     }
-}
 
-impl Layout {
-    #[doc(hidden)]
     #[inline(always)]
-    pub fn one_dimensional() -> Layout {
+    pub(crate) fn one_dimensional() -> Layout {
         Layout(CORDER | FORDER)
     }
-    #[doc(hidden)]
+
     #[inline(always)]
-    pub fn c() -> Layout {
+    pub(crate) fn c() -> Layout {
         Layout(CORDER)
     }
-    #[doc(hidden)]
+
     #[inline(always)]
-    pub fn f() -> Layout {
+    pub(crate) fn f() -> Layout {
         Layout(FORDER)
     }
+
     #[inline(always)]
-    #[doc(hidden)]
-    pub fn none() -> Layout {
+    pub(crate) fn none() -> Layout {
         Layout(0)
     }
 }

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -1,6 +1,8 @@
 mod layoutfmt;
 
-// public struct but users don't interact with it
+// Layout it a bitset used for internal layout description of
+// arrays, producers and sets of producers.
+// The type is public but users don't interact with it.
 #[doc(hidden)]
 /// Memory layout description
 #[derive(Copy, Clone)]
@@ -8,44 +10,62 @@ pub struct Layout(u32);
 
 impl Layout {
     #[inline(always)]
-    pub(crate) fn new(x: u32) -> Self {
-        Layout(x)
-    }
-
-    #[inline(always)]
     pub(crate) fn is(self, flag: u32) -> bool {
         self.0 & flag != 0
     }
+
+    /// Return layout common to both inputs
     #[inline(always)]
-    pub(crate) fn and(self, flag: Layout) -> Layout {
-        Layout(self.0 & flag.0)
+    pub(crate) fn intersect(self, other: Layout) -> Layout {
+        Layout(self.0 & other.0)
     }
 
+    /// Return a layout that simultaneously "is" what both of the inputs are
     #[inline(always)]
-    pub(crate) fn flag(self) -> u32 {
-        self.0
+    pub(crate) fn also(self, other: Layout) -> Layout {
+        Layout(self.0 | other.0)
     }
 
     #[inline(always)]
     pub(crate) fn one_dimensional() -> Layout {
-        Layout(CORDER | FORDER)
+        Layout::c().also(Layout::f())
     }
 
     #[inline(always)]
     pub(crate) fn c() -> Layout {
-        Layout(CORDER)
+        Layout(CORDER | CPREFER)
     }
 
     #[inline(always)]
     pub(crate) fn f() -> Layout {
-        Layout(FORDER)
+        Layout(FORDER | FPREFER)
+    }
+
+    #[inline(always)]
+    pub(crate) fn cpref() -> Layout {
+        Layout(CPREFER)
+    }
+
+    #[inline(always)]
+    pub(crate) fn fpref() -> Layout {
+        Layout(FPREFER)
     }
 
     #[inline(always)]
     pub(crate) fn none() -> Layout {
         Layout(0)
     }
+
+    /// A simple "score" method which scores positive for preferring C-order, negative for F-order
+    /// Subject to change when we can describe other layouts
+    pub(crate) fn tendency(self) -> i32 {
+        (self.is(CORDER) as i32 - self.is(FORDER) as i32) +
+        (self.is(CPREFER) as i32 - self.is(FPREFER) as i32)
+
+    }
 }
 
 pub const CORDER: u32 = 0b01;
 pub const FORDER: u32 = 0b10;
+pub const CPREFER: u32 = 0b0100;
+pub const FPREFER: u32 = 0b1000;

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -69,3 +69,77 @@ pub const CORDER: u32 = 0b01;
 pub const FORDER: u32 = 0b10;
 pub const CPREFER: u32 = 0b0100;
 pub const FPREFER: u32 = 0b1000;
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::imp_prelude::*;
+    use crate::NdProducer;
+
+    type M = Array2<f32>;
+
+    #[test]
+    fn contig_layouts() {
+        let a = M::zeros((5, 5));
+        let b = M::zeros((5, 5).f());
+        let ac = a.view().layout();
+        let af = b.view().layout();
+        assert!(ac.is(CORDER) && ac.is(CPREFER));
+        assert!(!ac.is(FORDER) && !ac.is(FPREFER));
+        assert!(!af.is(CORDER) && !af.is(CPREFER));
+        assert!(af.is(FORDER) && af.is(FPREFER));
+    }
+
+    #[test]
+    fn stride_layouts() {
+        let a = M::zeros((5, 5));
+
+        {
+            let v1 = a.slice(s![1.., ..]).layout();
+            let v2 = a.slice(s![.., 1..]).layout();
+
+            assert!(v1.is(CORDER) && v1.is(CPREFER));
+            assert!(!v1.is(FORDER) && !v1.is(FPREFER));
+            assert!(!v2.is(CORDER) && v2.is(CPREFER));
+            assert!(!v2.is(FORDER) && !v2.is(FPREFER));
+        }
+
+        let b = M::zeros((5, 5).f());
+
+        {
+            let v1 = b.slice(s![1.., ..]).layout();
+            let v2 = b.slice(s![.., 1..]).layout();
+
+            assert!(!v1.is(CORDER) && !v1.is(CPREFER));
+            assert!(!v1.is(FORDER) && v1.is(FPREFER));
+            assert!(!v2.is(CORDER) && !v2.is(CPREFER));
+            assert!(v2.is(FORDER) && v2.is(FPREFER));
+        }
+    }
+
+    #[test]
+    fn skip_layouts() {
+        let a = M::zeros((5, 5));
+        {
+            let v1 = a.slice(s![..;2, ..]).layout();
+            let v2 = a.slice(s![.., ..;2]).layout();
+
+            assert!(!v1.is(CORDER) && v1.is(CPREFER));
+            assert!(!v1.is(FORDER) && !v1.is(FPREFER));
+            assert!(!v2.is(CORDER) && !v2.is(CPREFER));
+            assert!(!v2.is(FORDER) && !v2.is(FPREFER));
+        }
+
+        let b = M::zeros((5, 5).f());
+        {
+            let v1 = b.slice(s![..;2, ..]).layout();
+            let v2 = b.slice(s![.., ..;2]).layout();
+
+            assert!(!v1.is(CORDER) && !v1.is(CPREFER));
+            assert!(!v1.is(FORDER) && !v1.is(FPREFER));
+            assert!(!v2.is(CORDER) && !v2.is(CPREFER));
+            assert!(!v2.is(FORDER) && v2.is(FPREFER));
+        }
+    }
+}

--- a/tests/format.rs
+++ b/tests/format.rs
@@ -62,13 +62,13 @@ fn debug_format() {
         "\
 [[0, 0, 0, 0],
  [0, 0, 0, 0],
- [0, 0, 0, 0]], shape=[3, 4], strides=[4, 1], layout=C (0x1), const ndim=2"
+ [0, 0, 0, 0]], shape=[3, 4], strides=[4, 1], layout=Cc (0x5), const ndim=2"
     );
     assert_eq!(
         format!("{:?}", a.into_dyn()),
         "\
 [[0, 0, 0, 0],
  [0, 0, 0, 0],
- [0, 0, 0, 0]], shape=[3, 4], strides=[4, 1], layout=C (0x1), dynamic ndim=2"
+ [0, 0, 0, 0]], shape=[3, 4], strides=[4, 1], layout=Cc (0x5), dynamic ndim=2"
     );
 }


### PR DESCRIPTION
For example, when we use `Zip::from(a).and(b)`; the Zip will examine the inputs and try to determine if they are all contiguous (and in the same way); it can now also determine what *tendency* the inputs have, to further guide which axis should be used for the innermost loop, even if not all the inputs are contiguous.

This helps for example with indexed Zip on f-order producers. The index producer has no bias in either direction, so all the other inputs will determine the layout preference.

The improved layout preference also affects parallelism, because in some cases we can better choose which axis to split along to preserve locality better.

The `Layout` type was improved to make this possible. It now has flags for C/F-contig and for C/F-preference. The new layout bits are visible in the array debug output.

Fixes #749 
