### PR TITLE
Fix clippy lints

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -5,6 +5,6 @@
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
     if cfg!(feature = "test-blas-openblas-sys") {
-        println!("cargo:rustc-link-lib={}=openblas", "dylib");
+        println!("cargo:rustc-link-lib=dylib=openblas");
     }
 }

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+single-char-binding-names-threshold = 1000

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,6 @@
     clippy::many_single_char_names,
     clippy::deref_addrof,
     clippy::unreadable_literal,
-    clippy::many_single_char_names
 )]
 
 //! The `ndarray` crate provides an *n*-dimensional container for general elements


### PR DESCRIPTION
The clippy.toml setting is a workaround for the currently broken single
char variable lint (a fix is pending in clippy).