### PR TITLE
Small fixes in examples and docs

### DIFF
--- a/src/doc/ndarray_for_numpy_users/coord_transform.rs
+++ b/src/doc/ndarray_for_numpy_users/coord_transform.rs
@@ -49,8 +49,6 @@
 //! This is a direct translation to `ndarray`:
 //!
 //! ```
-//! extern crate ndarray;
-//!
 //! use ndarray::prelude::*;
 //!
 //! fn main() {
@@ -96,8 +94,6 @@
 //! this:
 //!
 //! ```
-//! extern crate ndarray;
-//!
 //! use ndarray::prelude::*;
 //!
 //! fn main() {

--- a/src/doc/ndarray_for_numpy_users/mod.rs
+++ b/src/doc/ndarray_for_numpy_users/mod.rs
@@ -177,8 +177,6 @@
 //! and `ndarray` like this:
 //!
 //! ```
-//! extern crate ndarray;
-//!
 //! use ndarray::prelude::*;
 //! #
 //! # fn main() {}

--- a/src/doc/ndarray_for_numpy_users/rk_step.rs
+++ b/src/doc/ndarray_for_numpy_users/rk_step.rs
@@ -71,8 +71,6 @@
 //! A direct translation to `ndarray` looks like this:
 //!
 //! ```
-//! extern crate ndarray;
-//!
 //! use ndarray::prelude::*;
 //!
 //! fn rk_step<F>(
@@ -129,8 +127,6 @@
 //!   some places, but that's not demonstrated in the example below.
 //!
 //! ```
-//! extern crate ndarray;
-//!
 //! use ndarray::prelude::*;
 //!
 //! fn rk_step<F>(

--- a/src/doc/ndarray_for_numpy_users/simple_math.rs
+++ b/src/doc/ndarray_for_numpy_users/simple_math.rs
@@ -51,8 +51,6 @@
 //! <td>
 //!
 //! ```
-//! extern crate ndarray;
-//!
 //! use ndarray::prelude::*;
 //!
 //! # fn main() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,8 +53,9 @@
 //! - Performance:
 //!   + Prefer higher order methods and arithmetic operations on arrays first,
 //!     then iteration, and as a last priority using indexed algorithms.
-//!   + The higher order functions like ``.map()``, ``.map_inplace()``,
-//!     ``.zip_mut_with()``, ``Zip`` and ``azip!()`` are the most efficient ways
+//!   + The higher order functions like [`.map()`](ArrayBase::map),
+//!     [`.map_inplace()`](ArrayBase::map_inplace), [`.zip_mut_with()`](ArrayBase::zip_mut_with),
+//!     [`Zip`] and [`azip!()`](azip) are the most efficient ways
 //!     to perform single traversal and lock step traversal respectively.
 //!   + Performance of an operation depends on the memory layout of the array
 //!     or array view. Especially if it's a binary operation, which
@@ -300,9 +301,10 @@ pub type Ixs = isize;
 /// Please see the documentation for the respective array view for an overview
 /// of methods specific to array views: [`ArrayView`], [`ArrayViewMut`].
 ///
-/// A view is created from an array using `.view()`, `.view_mut()`, using
-/// slicing (`.slice()`, `.slice_mut()`) or from one of the many iterators
-/// that yield array views.
+/// A view is created from an array using [`.view()`](ArrayBase::view),
+/// [`.view_mut()`](ArrayBase::view_mut), using
+/// slicing ([`.slice()`](ArrayBase::slice), [`.slice_mut()`](ArrayBase::slice_mut)) or from one of
+/// the many iterators that yield array views.
 ///
 /// You can also create an array view from a regular slice of data not
 /// allocated with `Array` — see array view methods or their `From` impls.

--- a/src/parallel/mod.rs
+++ b/src/parallel/mod.rs
@@ -39,8 +39,6 @@
 //! Compute the exponential of each element in an array, parallelized.
 //!
 //! ```
-//! extern crate ndarray;
-//!
 //! use ndarray::Array2;
 //! use ndarray::parallel::prelude::*;
 //!
@@ -61,8 +59,6 @@
 //! Use the parallel `.axis_iter()` to compute the sum of each row.
 //!
 //! ```
-//! extern crate ndarray;
-//!
 //! use ndarray::Array;
 //! use ndarray::Axis;
 //! use ndarray::parallel::prelude::*;
@@ -84,8 +80,6 @@
 //! Use the parallel `.axis_chunks_iter()` to process your data in chunks.
 //!
 //! ```
-//! extern crate ndarray;
-//!
 //! use ndarray::Array;
 //! use ndarray::Axis;
 //! use ndarray::parallel::prelude::*;
@@ -107,8 +101,6 @@
 //! Use zip for lock step function application across several arrays
 //!
 //! ```
-//! extern crate ndarray;
-//!
 //! use ndarray::Array3;
 //! use ndarray::Zip;
 //!

--- a/src/parallel/mod.rs
+++ b/src/parallel/mod.rs
@@ -10,11 +10,11 @@
 //! The following types implement parallel iterators, accessed using these
 //! methods:
 //!
-//! - [`Array`], [`ArcArray`]: `.par_iter()` and `.par_iter_mut()`
-//! - [`ArrayView`](ArrayView): `.into_par_iter()`
-//! - [`ArrayViewMut`](ArrayViewMut): `.into_par_iter()`
-//! - [`AxisIter`](iter::AxisIter), [`AxisIterMut`](iter::AxisIterMut): `.into_par_iter()`
-//! - [`AxisChunksIter`](iter::AxisChunksIter), [`AxisChunksIterMut`](iter::AxisChunksIterMut): `.into_par_iter()`
+//! - [`Array`], [`ArcArray`] `.par_iter()` and `.par_iter_mut()`
+//! - [`ArrayView`] `.into_par_iter()`
+//! - [`ArrayViewMut`] `.into_par_iter()`
+//! - [`AxisIter`], [`AxisIterMut`] `.into_par_iter()`
+//! - [`AxisChunksIter`], [`AxisChunksIterMut`] `.into_par_iter()`
 //! - [`Zip`] `.into_par_iter()`
 //!
 //! The following other parallelized methods exist:
@@ -120,6 +120,23 @@
 //!         });
 //! }
 //! ```
+
+#[allow(unused_imports)] // used by rustdoc links
+use crate::{
+    ArrayBase,
+    Array,
+    ArcArray,
+    ArrayView,
+    ArrayViewMut,
+    Zip,
+};
+#[allow(unused_imports)] // used by rustdoc links
+use crate::iter::{
+    AxisIter,
+    AxisIterMut,
+    AxisChunksIter,
+    AxisChunksIterMut,
+};
 
 /// Into- traits for creating parallelized iterators and/or using [`par_azip!`]
 pub mod prelude {

--- a/src/parallel/zipmacro.rs
+++ b/src/parallel/zipmacro.rs
@@ -34,8 +34,6 @@
 /// ## Examples
 ///
 /// ```rust
-/// extern crate ndarray;
-///
 /// use ndarray::Array2;
 /// use ndarray::parallel::par_azip;
 ///

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -496,8 +496,6 @@ impl_slicenextdim_larger!((), Slice);
 /// # Example
 ///
 /// ```
-/// extern crate ndarray;
-///
 /// use ndarray::{s, Array2, ArrayView2};
 ///
 /// fn laplacian(v: &ArrayView2<f32>) -> Array2<f32> {
@@ -528,8 +526,6 @@ impl_slicenextdim_larger!((), Slice);
 /// For example,
 ///
 /// ```
-/// # extern crate ndarray;
-/// #
 /// # use ndarray::prelude::*;
 /// #
 /// # fn main() {

--- a/src/stacking.rs
+++ b/src/stacking.rs
@@ -86,8 +86,6 @@ where
 /// ***Panics*** if the `stack` function would return an error.
 ///
 /// ```
-/// extern crate ndarray;
-///
 /// use ndarray::{arr2, stack, Axis};
 ///
 /// # fn main() {

--- a/src/zip/zipmacro.rs
+++ b/src/zip/zipmacro.rs
@@ -38,8 +38,6 @@
 /// ## Examples
 ///
 /// ```rust
-/// extern crate ndarray;
-///
 /// use ndarray::{azip, Array1, Array2, Axis};
 ///
 /// type M = Array2<f32>;


### PR DESCRIPTION
- Remove `extern crate` in examples, not needed in current Rust edition
- Fix and add more rustdoc links