### PR TITLE
Implement IndexedParallelIterator for one-dimensional arrays

### DIFF
--- a/src/dimension/dimension_trait.rs
+++ b/src/dimension/dimension_trait.rs
@@ -540,6 +540,14 @@ impl Dimension for Dim<[Ix; 1]> {
     fn try_remove_axis(&self, axis: Axis) -> Self::Smaller {
         self.remove_axis(axis)
     }
+
+    fn from_dimension<D2: Dimension>(d: &D2) -> Option<Self> {
+        if 1 == d.ndim() {
+            Some(Ix1(d[0]))
+        } else {
+            None
+        }
+    }
     private_impl! {}
 }
 

--- a/src/parallel/mod.rs
+++ b/src/parallel/mod.rs
@@ -28,9 +28,12 @@
 //! Note that you can use the parallel iterator for [Zip] to access all other
 //! rayon parallel iterator methods.
 //!
-//! Only the axis iterators are indexed parallel iterators, the rest are all
-//! “unindexed”. Use ndarray’s [Zip] for lock step parallel iteration of
-//! multiple arrays or producers at a time.
+//! Only the axis iterators and one-dimensional array views make indexed parallel iterators, the
+//! rest are all “unindexed” in rayon terms.
+//!
+//! Ndarray’s [Zip] is specially made to handle lock step parallel iteration of multiple arrays or
+//! producers at a time, and it can handle multidimensional inputs efficiently, even with
+//! multidimensional indexing. [Zip] is always recommended over rayon `.zip()` for performance.
 //!
 //! # Examples
 //!


### PR DESCRIPTION
The rayon IndexedParallelIterator trait maps well to any one-dimensional indexed
sequence, and we can implement this trait as a special case (of the general
unindexed parallel iterator of an arbitrary array).

Implementing this is logical, it fits, but we still will recommend ndarray's `Zip`
for lock step iteration. The reason is performance. `Zip` will do it better.