### PR TITLE
Combine common code / reduce codegen by factoring out common parts

### DIFF
--- a/src/iterators/mod.rs
+++ b/src/iterators/mod.rs
@@ -79,15 +79,18 @@ impl<A, D: Dimension> Iterator for Baseiter<A, D> {
         let ndim = self.dim.ndim();
         debug_assert_ne!(ndim, 0);
         let mut accum = init;
-        while let Some(mut index) = self.index.clone() {
+        while let Some(mut index) = self.index {
             let stride = self.strides.last_elem() as isize;
             let elem_index = index.last_elem();
             let len = self.dim.last_elem();
             let offset = D::stride_offset(&index, &self.strides);
             unsafe {
                 let row_ptr = self.ptr.offset(offset);
-                for i in 0..(len - elem_index) {
+                let mut i = 0;
+                let i_end = len - elem_index;
+                while i < i_end {
                     accum = g(accum, row_ptr.offset(i as isize * stride));
+                    i += 1;
                 }
             }
             index.set_last_elem(len - 1);

--- a/src/zip/mod.rs
+++ b/src/zip/mod.rs
@@ -781,7 +781,6 @@ where
 
             index_ = self.dimension.next_for(index);
         }
-        self.dimension[unroll_axis] = inner_len;
         FoldWhile::Continue(acc)
     }
 
@@ -812,7 +811,6 @@ where
                 }
             }
         }
-        self.dimension[unroll_axis] = inner_len;
         FoldWhile::Continue(acc)
     }
 

--- a/src/zip/mod.rs
+++ b/src/zip/mod.rs
@@ -723,7 +723,7 @@ where
         }
     }
 
-    fn apply_core_contiguous<F, Acc>(&mut self, mut acc: Acc, mut function: F) -> FoldWhile<Acc>
+    fn apply_core_contiguous<F, Acc>(&mut self, acc: Acc, mut function: F) -> FoldWhile<Acc>
     where
         F: FnMut(Acc, P::Item) -> FoldWhile<Acc>,
         P: ZippableTuple<Dim = D>,
@@ -732,14 +732,34 @@ where
         let size = self.dimension.size();
         let ptrs = self.parts.as_ptr();
         let inner_strides = self.parts.contiguous_stride();
-        for i in 0..size {
-            unsafe {
-                let ptr_i = ptrs.stride_offset(inner_strides, i);
-                acc = fold_while![function(acc, self.parts.as_ref(ptr_i))];
-            }
+        unsafe {
+            self.inner(acc, ptrs, inner_strides, size, &mut function)
+        }
+    }
+
+    /// The innermost loop of the Zip apply methods
+    ///
+    /// Run the fold while operation on a stretch of elements with constant strides
+    ///
+    /// `ptr`: base pointer for the first element in this stretch
+    /// `strides`: strides for the elements in this stretch
+    /// `len`: number of elements
+    /// `function`: closure
+    unsafe fn inner<F, Acc>(&self, mut acc: Acc, ptr: P::Ptr, strides: P::Stride,
+                            len: usize, function: &mut F) -> FoldWhile<Acc>
+    where
+        F: FnMut(Acc, P::Item) -> FoldWhile<Acc>,
+        P: ZippableTuple
+    {
+        let mut i = 0;
+        while i < len {
+            let p = ptr.stride_offset(strides, i);
+            acc = fold_while!(function(acc, self.parts.as_ref(p)));
+            i += 1;
         }
         FoldWhile::Continue(acc)
     }
+
 
     fn apply_core_strided<F, Acc>(&mut self, acc: Acc, function: F) -> FoldWhile<Acc>
     where
@@ -773,10 +793,7 @@ where
         while let Some(index) = index_ {
             unsafe {
                 let ptr = self.parts.uget_ptr(&index);
-                for i in 0..inner_len {
-                    let p = ptr.stride_offset(inner_strides, i);
-                    acc = fold_while!(function(acc, self.parts.as_ref(p)));
-                }
+                acc = fold_while![self.inner(acc, ptr, inner_strides, inner_len, &mut function)];
             }
 
             index_ = self.dimension.next_for(index);
@@ -800,10 +817,7 @@ where
             loop {
                 unsafe {
                     let ptr = self.parts.uget_ptr(&index);
-                    for i in 0..inner_len {
-                        let p = ptr.stride_offset(inner_strides, i);
-                        acc = fold_while!(function(acc, self.parts.as_ref(p)));
-                    }
+                    acc = fold_while![self.inner(acc, ptr, inner_strides, inner_len, &mut function)];
                 }
 
                 if !self.dimension.next_for_f(&mut index) {


### PR DESCRIPTION
The goal is to reduce the amount of code (as counted by cargo-llvm-lines) generated for our functions.

1. Make a few shape check functions less generic by dropping the dependency on the element type (and its size) as early as possible
2. Factor out the inner loop in the three main Zip apply_core_* methods
3. Small change to Baseiter::fold that also reduces the size of the loop