### PR TITLE
Fix CI by suppressing clippy::manual_non_exhaustive warning

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -5,6 +5,11 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
+
+// Clippy complains about not using #[non_exhaustive] attribute but the
+// attribute is not available in 1.37.0, which is MSRV of this library.
+#![allow(clippy::manual_non_exhaustive)]
+
 use super::Dimension;
 use std::error::Error;
 use std::fmt;


### PR DESCRIPTION
CI is failing since clippy raises a warning:

```
error: this seems like a manual implementation of the non-exhaustive pattern
  --> src/error.rs:37:1
   |
37 |   pub enum ErrorKind {
   |   ^-----------------
   |   |
   |  _help: add the attribute: `#[non_exhaustive] pub enum ErrorKind`
   | |
38 | |     /// incompatible shape
39 | |     IncompatibleShape = 1,
40 | |     /// incompatible memory layout
...  |
51 | |     __Incomplete,
52 | | }
   | |_^
   |
   = note: `-D clippy::manual-non-exhaustive` implied by `-D warnings`
help: remove this variant
  --> src/error.rs:51:5
   |
51 |     __Incomplete,
   |     ^^^^^^^^^^^^
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_non_exhaustive
```

https://travis-ci.org/github/rust-ndarray/ndarray/jobs/702749109

However, `#[non_exhaustive]` attribute is not available because Rust 1.37.0, which seems MSRV of this library, did not stabilize the attribute.

For now, I think `clippy::manual-non-exhaustive` should be suppressed until the attribute is available by bumping up MSRV.