### PR TITLE
Stack and concatenate

### DIFF
--- a/src/doc/ndarray_for_numpy_users/mod.rs
+++ b/src/doc/ndarray_for_numpy_users/mod.rs
@@ -532,7 +532,8 @@
 //! ------|-----------|------
 //! `a[:] = 3.` | [`a.fill(3.)`][.fill()] | set all array elements to the same scalar value
 //! `a[:] = b` | [`a.assign(&b)`][.assign()] | copy the data from array `b` into array `a`
-//! `np.concatenate((a,b), axis=1)` | [`stack![Axis(1), a, b]`][stack!] or [`stack(Axis(1), &[a.view(), b.view()])`][stack()] | concatenate arrays `a` and `b` along axis 1
+//! `np.concatenate((a,b), axis=1)` | [`concatenate![Axis(1), a, b]`][concatenate!] or [`concatenate(Axis(1), &[a.view(), b.view()])`][concatenate()] | concatenate arrays `a` and `b` along axis 1
+//! `np.stack((a,b), axis=1)` | [`stack![Axis(1), a, b]`][stack!] or [`stack(Axis(1), vec![a.view(), b.view()])`][stack()] | stack arrays `a` and `b` along axis 1
 //! `a[:,np.newaxis]` or `np.expand_dims(a, axis=1)` | [`a.insert_axis(Axis(1))`][.insert_axis()] | create an array from `a`, inserting a new axis 1
 //! `a.transpose()` or `a.T` | [`a.t()`][.t()] or [`a.reversed_axes()`][.reversed_axes()] | transpose of array `a` (view for `.t()` or by-move for `.reversed_axes()`)
 //! `np.diag(a)` | [`a.diag()`][.diag()] | view the diagonal of `a`
@@ -640,6 +641,8 @@
 //! [.slice_move()]: ../../struct.ArrayBase.html#method.slice_move
 //! [.slice_mut()]: ../../struct.ArrayBase.html#method.slice_mut
 //! [.shape()]: ../../struct.ArrayBase.html#method.shape
+//! [concatenate!]: ../../macro.concatenate.html
+//! [concatenate()]: ../../fn.concatenate.html
 //! [stack!]: ../../macro.stack.html
 //! [stack()]: ../../fn.stack.html
 //! [.strides()]: ../../struct.ArrayBase.html#method.strides

--- a/src/doc/ndarray_for_numpy_users/mod.rs
+++ b/src/doc/ndarray_for_numpy_users/mod.rs
@@ -532,8 +532,8 @@
 //! ------|-----------|------
 //! `a[:] = 3.` | [`a.fill(3.)`][.fill()] | set all array elements to the same scalar value
 //! `a[:] = b` | [`a.assign(&b)`][.assign()] | copy the data from array `b` into array `a`
-//! `np.concatenate((a,b), axis=1)` | [`concatenate![Axis(1), a, b]`][concatenate!] or [`concatenate(Axis(1), &[a.view(), b.view()])`][concatenate()] | concatenate arrays `a` and `b` along axis 1
-//! `np.stack((a,b), axis=1)` | [`stack![Axis(1), a, b]`][stack!] or [`stack(Axis(1), vec![a.view(), b.view()])`][stack()] | stack arrays `a` and `b` along axis 1
+//! `np.concatenate((a,b), axis=1)` | [`stack![Axis(1), a, b]`][stack!] or [`stack(Axis(1), &[a.view(), b.view()])`][stack()] | concatenate arrays `a` and `b` along axis 1
+//! `np.stack((a,b), axis=1)` | [`stack_new_axis![Axis(1), a, b]`][stack_new_axis!] or [`stack_new_axis(Axis(1), vec![a.view(), b.view()])`][stack_new_axis()] | stack arrays `a` and `b` along axis 1
 //! `a[:,np.newaxis]` or `np.expand_dims(a, axis=1)` | [`a.insert_axis(Axis(1))`][.insert_axis()] | create an array from `a`, inserting a new axis 1
 //! `a.transpose()` or `a.T` | [`a.t()`][.t()] or [`a.reversed_axes()`][.reversed_axes()] | transpose of array `a` (view for `.t()` or by-move for `.reversed_axes()`)
 //! `np.diag(a)` | [`a.diag()`][.diag()] | view the diagonal of `a`
@@ -641,10 +641,10 @@
 //! [.slice_move()]: ../../struct.ArrayBase.html#method.slice_move
 //! [.slice_mut()]: ../../struct.ArrayBase.html#method.slice_mut
 //! [.shape()]: ../../struct.ArrayBase.html#method.shape
-//! [concatenate!]: ../../macro.concatenate.html
-//! [concatenate()]: ../../fn.concatenate.html
 //! [stack!]: ../../macro.stack.html
 //! [stack()]: ../../fn.stack.html
+//! [stack_new_axis!]: ../../macro.stack_new_axis.html
+//! [stack_new_axis()]: ../../fn.stack_new_axis.html
 //! [.strides()]: ../../struct.ArrayBase.html#method.strides
 //! [.index_axis()]: ../../struct.ArrayBase.html#method.index_axis
 //! [.sum_axis()]: ../../struct.ArrayBase.html#method.sum_axis

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -28,7 +28,7 @@ use crate::iter::{
     IndexedIter, IndexedIterMut, Iter, IterMut, Lanes, LanesMut, Windows,
 };
 use crate::slice::MultiSlice;
-use crate::stacking::concatenate;
+use crate::stacking::stack;
 use crate::{NdIndex, Slice, SliceInfo, SliceOrIndex};
 
 /// # Methods For All Array Types
@@ -840,7 +840,7 @@ where
             dim.set_axis(axis, 0);
             unsafe { Array::from_shape_vec_unchecked(dim, vec![]) }
         } else {
-            concatenate(axis, &subs).unwrap()
+            stack(axis, &subs).unwrap()
         }
     }
 

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -28,7 +28,7 @@ use crate::iter::{
     IndexedIter, IndexedIterMut, Iter, IterMut, Lanes, LanesMut, Windows,
 };
 use crate::slice::MultiSlice;
-use crate::stacking::stack;
+use crate::stacking::concatenate;
 use crate::{NdIndex, Slice, SliceInfo, SliceOrIndex};
 
 /// # Methods For All Array Types
@@ -840,7 +840,7 @@ where
             dim.set_axis(axis, 0);
             unsafe { Array::from_shape_vec_unchecked(dim, vec![]) }
         } else {
-            stack(axis, &subs).unwrap()
+            concatenate(axis, &subs).unwrap()
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,7 +131,7 @@ use crate::iterators::{ElementsBase, ElementsBaseMut, Iter, IterMut, Lanes, Lane
 
 pub use crate::arraytraits::AsArray;
 pub use crate::linalg_traits::{LinalgScalar, NdFloat};
-pub use crate::stacking::stack;
+pub use crate::stacking::{concatenate, stack};
 
 pub use crate::impl_views::IndexLonger;
 pub use crate::shape_builder::ShapeBuilder;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,7 +131,7 @@ use crate::iterators::{ElementsBase, ElementsBaseMut, Iter, IterMut, Lanes, Lane
 
 pub use crate::arraytraits::AsArray;
 pub use crate::linalg_traits::{LinalgScalar, NdFloat};
-pub use crate::stacking::{concatenate, stack};
+pub use crate::stacking::{stack, stack_new_axis};
 
 pub use crate::impl_views::IndexLonger;
 pub use crate::shape_builder::ShapeBuilder;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,6 +131,8 @@ use crate::iterators::{ElementsBase, ElementsBaseMut, Iter, IterMut, Lanes, Lane
 
 pub use crate::arraytraits::AsArray;
 pub use crate::linalg_traits::{LinalgScalar, NdFloat};
+
+#[allow(deprecated)]
 pub use crate::stacking::{concatenate, stack, stack_new_axis};
 
 pub use crate::impl_views::IndexLonger;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,7 +131,7 @@ use crate::iterators::{ElementsBase, ElementsBaseMut, Iter, IterMut, Lanes, Lane
 
 pub use crate::arraytraits::AsArray;
 pub use crate::linalg_traits::{LinalgScalar, NdFloat};
-pub use crate::stacking::{stack, stack_new_axis};
+pub use crate::stacking::{concatenate, stack, stack_new_axis};
 
 pub use crate::impl_views::IndexLonger;
 pub use crate::shape_builder::ShapeBuilder;

--- a/src/stacking.rs
+++ b/src/stacking.rs
@@ -30,7 +30,7 @@ use crate::imp_prelude::*;
 /// );
 /// ```
 #[deprecated(
-    since = "0.13.1",
+    since = "0.13.2",
     note = "Please use the `concatenate` function instead"
 )]
 pub fn stack<A, D>(axis: Axis, arrays: &[ArrayView<A, D>]) -> Result<Array<A, D>, ShapeError>
@@ -106,9 +106,33 @@ where
     stack(axis, arrays)
 }
 
+/// Stack arrays along the new axis.
+///
+/// ***Errors*** if the arrays have mismatching shapes.
+/// ***Errors*** if `arrays` is empty, if `axis` is out of bounds,
+/// if the result is larger than is possible to represent.
+///
+/// ```
+/// extern crate ndarray;
+///
+/// use ndarray::{arr2, arr3, stack_new_axis, Axis};
+///
+/// # fn main() {
+///
+/// let a = arr2(&[[2., 2.],
+///                [3., 3.]]);
+/// assert!(
+///     stack_new_axis(Axis(0), &[a.view(), a.view()])
+///     == Ok(arr3(&[[[2., 2.],
+///                   [3., 3.]],
+///                  [[2., 2.],
+///                   [3., 3.]]]))
+/// );
+/// # }
+/// ```
 pub fn stack_new_axis<A, D>(
     axis: Axis,
-    arrays: Vec<ArrayView<A, D>>,
+    arrays: &[ArrayView<A, D>],
 ) -> Result<Array<A, D::Larger>, ShapeError>
 where
     A: Copy,
@@ -176,6 +200,10 @@ where
 /// );
 /// # }
 /// ```
+#[deprecated(
+    since = "0.13.2",
+    note = "Please use the `concatenate!` macro instead"
+)]
 #[macro_export]
 macro_rules! stack {
     ($axis:expr, $( $array:expr ),+ ) => {
@@ -247,6 +275,6 @@ macro_rules! concatenate {
 #[macro_export]
 macro_rules! stack_new_axis {
     ($axis:expr, $( $array:expr ),+ ) => {
-        $crate::stack_new_axis($axis, vec![ $($crate::ArrayView::from(&$array) ),* ]).unwrap()
+        $crate::stack_new_axis($axis, &[ $($crate::ArrayView::from(&$array) ),* ]).unwrap()
     }
 }

--- a/src/stacking.rs
+++ b/src/stacking.rs
@@ -29,10 +29,7 @@ use crate::imp_prelude::*;
 ///                  [3., 3.]]))
 /// );
 /// ```
-pub fn concatenate<A, D>(
-    axis: Axis,
-    arrays: &[ArrayView<A, D>],
-) -> Result<Array<A, D>, ShapeError>
+pub fn concatenate<A, D>(axis: Axis, arrays: &[ArrayView<A, D>]) -> Result<Array<A, D>, ShapeError>
 where
     A: Copy,
     D: RemoveAxis,
@@ -90,8 +87,8 @@ where
             return Err(from_kind(ErrorKind::OutOfBounds));
         }
     }
-    let arrays: Vec<ArrayView<A, D::Larger>> = arrays.into_iter()
-        .map(|a| a.insert_axis(axis)).collect();
+    let arrays: Vec<ArrayView<A, D::Larger>> =
+        arrays.into_iter().map(|a| a.insert_axis(axis)).collect();
     concatenate(axis, &arrays)
 }
 

--- a/src/stacking.rs
+++ b/src/stacking.rs
@@ -107,7 +107,8 @@ where
     }
     let mut res = Array::from_shape_vec(res_dim, v)?;
 
-    res.axis_iter_mut(axis).zip(arrays.into_iter())
+    res.axis_iter_mut(axis)
+        .zip(arrays.into_iter())
         .for_each(|(mut assign_view, array)| {
             assign_view.assign(&array);
         });

--- a/src/stacking.rs
+++ b/src/stacking.rs
@@ -30,7 +30,7 @@ use crate::imp_prelude::*;
 /// );
 /// ```
 #[deprecated(
-    since = "0.13.0",
+    since = "0.13.1",
     note = "Please use the `concatenate` function instead"
 )]
 pub fn stack<A, D>(axis: Axis, arrays: &[ArrayView<A, D>]) -> Result<Array<A, D>, ShapeError>
@@ -97,6 +97,7 @@ where
 ///                  [3., 3.]]))
 /// );
 /// ```
+#[allow(deprecated)]
 pub fn concatenate<A, D>(axis: Axis, arrays: &[ArrayView<A, D>]) -> Result<Array<A, D>, ShapeError>
 where
     A: Copy,

--- a/tests/stacking.rs
+++ b/tests/stacking.rs
@@ -52,16 +52,16 @@ fn concatenating() {
 #[test]
 fn stacking() {
     let a = arr2(&[[2., 2.], [3., 3.]]);
-    let b = ndarray::stack_new_axis(Axis(0), vec![a.view(), a.view()]).unwrap();
+    let b = ndarray::stack_new_axis(Axis(0), &[a.view(), a.view()]).unwrap();
     assert_eq!(b, arr3(&[[[2., 2.], [3., 3.]], [[2., 2.], [3., 3.]]]));
 
     let c = arr2(&[[3., 2., 3.], [2., 3., 2.]]);
-    let res = ndarray::stack_new_axis(Axis(1), vec![a.view(), c.view()]);
+    let res = ndarray::stack_new_axis(Axis(1), &[a.view(), c.view()]);
     assert_eq!(res.unwrap_err().kind(), ErrorKind::IncompatibleShape);
 
-    let res = ndarray::stack_new_axis(Axis(3), vec![a.view(), a.view()]);
+    let res = ndarray::stack_new_axis(Axis(3), &[a.view(), a.view()]);
     assert_eq!(res.unwrap_err().kind(), ErrorKind::OutOfBounds);
 
-    let res: Result<Array2<f64>, _> = ndarray::stack_new_axis::<_, Ix1>(Axis(0), vec![]);
+    let res: Result<Array2<f64>, _> = ndarray::stack_new_axis::<_, Ix1>(Axis(0), &[]);
     assert_eq!(res.unwrap_err().kind(), ErrorKind::Unsupported);
 }

--- a/tests/stacking.rs
+++ b/tests/stacking.rs
@@ -1,4 +1,4 @@
-use ndarray::{arr2, arr3, aview1, stack, Array2, Axis, ErrorKind, Ix1};
+use ndarray::{arr2, arr3, aview1, concatenate, stack, Array2, Axis, ErrorKind, Ix1};
 
 #[test]
 fn concatenating() {
@@ -22,6 +22,28 @@ fn concatenating() {
     assert_eq!(res.unwrap_err().kind(), ErrorKind::OutOfBounds);
 
     let res: Result<Array2<f64>, _> = ndarray::stack(Axis(0), &[]);
+    assert_eq!(res.unwrap_err().kind(), ErrorKind::Unsupported);
+
+    let a = arr2(&[[2., 2.], [3., 3.]]);
+    let b = ndarray::concatenate(Axis(0), &[a.view(), a.view()]).unwrap();
+    assert_eq!(b, arr2(&[[2., 2.], [3., 3.], [2., 2.], [3., 3.]]));
+
+    let c = concatenate![Axis(0), a, b];
+    assert_eq!(
+        c,
+        arr2(&[[2., 2.], [3., 3.], [2., 2.], [3., 3.], [2., 2.], [3., 3.]])
+    );
+
+    let d = concatenate![Axis(0), a.row(0), &[9., 9.]];
+    assert_eq!(d, aview1(&[2., 2., 9., 9.]));
+
+    let res = ndarray::concatenate(Axis(1), &[a.view(), c.view()]);
+    assert_eq!(res.unwrap_err().kind(), ErrorKind::IncompatibleShape);
+
+    let res = ndarray::concatenate(Axis(2), &[a.view(), c.view()]);
+    assert_eq!(res.unwrap_err().kind(), ErrorKind::OutOfBounds);
+
+    let res: Result<Array2<f64>, _> = ndarray::concatenate(Axis(0), &[]);
     assert_eq!(res.unwrap_err().kind(), ErrorKind::Unsupported);
 }
 

--- a/tests/stacking.rs
+++ b/tests/stacking.rs
@@ -1,26 +1,43 @@
-use ndarray::{arr2, aview1, stack, Array2, Axis, ErrorKind};
+use ndarray::{arr2, arr3, aview1, concatenate, Array2, Axis, ErrorKind, Ix1};
 
 #[test]
-fn stacking() {
+fn concatenating() {
     let a = arr2(&[[2., 2.], [3., 3.]]);
-    let b = ndarray::stack(Axis(0), &[a.view(), a.view()]).unwrap();
+    let b = ndarray::concatenate(Axis(0), &[a.view(), a.view()]).unwrap();
     assert_eq!(b, arr2(&[[2., 2.], [3., 3.], [2., 2.], [3., 3.]]));
 
-    let c = stack![Axis(0), a, b];
+    let c = concatenate![Axis(0), a, b];
     assert_eq!(
         c,
         arr2(&[[2., 2.], [3., 3.], [2., 2.], [3., 3.], [2., 2.], [3., 3.]])
     );
 
-    let d = stack![Axis(0), a.row(0), &[9., 9.]];
+    let d = concatenate![Axis(0), a.row(0), &[9., 9.]];
     assert_eq!(d, aview1(&[2., 2., 9., 9.]));
 
-    let res = ndarray::stack(Axis(1), &[a.view(), c.view()]);
+    let res = ndarray::concatenate(Axis(1), &[a.view(), c.view()]);
     assert_eq!(res.unwrap_err().kind(), ErrorKind::IncompatibleShape);
 
-    let res = ndarray::stack(Axis(2), &[a.view(), c.view()]);
+    let res = ndarray::concatenate(Axis(2), &[a.view(), c.view()]);
     assert_eq!(res.unwrap_err().kind(), ErrorKind::OutOfBounds);
 
-    let res: Result<Array2<f64>, _> = ndarray::stack(Axis(0), &[]);
+    let res: Result<Array2<f64>, _> = ndarray::concatenate(Axis(0), &[]);
+    assert_eq!(res.unwrap_err().kind(), ErrorKind::Unsupported);
+}
+
+#[test]
+fn stacking() {
+    let a = arr2(&[[2., 2.], [3., 3.]]);
+    let b = ndarray::stack(Axis(0), vec![a.view(), a.view()]).unwrap();
+    assert_eq!(b, arr3(&[[[2., 2.], [3., 3.]], [[2., 2.], [3., 3.]]]));
+
+    let c = arr2(&[[3., 2., 3.], [2., 3., 2.]]);
+    let res = ndarray::stack(Axis(1), vec![a.view(), c.view()]);
+    assert_eq!(res.unwrap_err().kind(), ErrorKind::IncompatibleShape);
+
+    let res = ndarray::stack(Axis(3), vec![a.view(), a.view()]);
+    assert_eq!(res.unwrap_err().kind(), ErrorKind::OutOfBounds);
+
+    let res: Result<Array2<f64>, _> = ndarray::stack::<_, Ix1>(Axis(0), vec![]);
     assert_eq!(res.unwrap_err().kind(), ErrorKind::Unsupported);
 }

--- a/tests/stacking.rs
+++ b/tests/stacking.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use ndarray::{arr2, arr3, aview1, concatenate, stack, Array2, Axis, ErrorKind, Ix1};
 
 #[test]

--- a/tests/stacking.rs
+++ b/tests/stacking.rs
@@ -1,43 +1,43 @@
-use ndarray::{arr2, arr3, aview1, concatenate, Array2, Axis, ErrorKind, Ix1};
+use ndarray::{arr2, arr3, aview1, stack, Array2, Axis, ErrorKind, Ix1};
 
 #[test]
 fn concatenating() {
     let a = arr2(&[[2., 2.], [3., 3.]]);
-    let b = ndarray::concatenate(Axis(0), &[a.view(), a.view()]).unwrap();
+    let b = ndarray::stack(Axis(0), &[a.view(), a.view()]).unwrap();
     assert_eq!(b, arr2(&[[2., 2.], [3., 3.], [2., 2.], [3., 3.]]));
 
-    let c = concatenate![Axis(0), a, b];
+    let c = stack![Axis(0), a, b];
     assert_eq!(
         c,
         arr2(&[[2., 2.], [3., 3.], [2., 2.], [3., 3.], [2., 2.], [3., 3.]])
     );
 
-    let d = concatenate![Axis(0), a.row(0), &[9., 9.]];
+    let d = stack![Axis(0), a.row(0), &[9., 9.]];
     assert_eq!(d, aview1(&[2., 2., 9., 9.]));
 
-    let res = ndarray::concatenate(Axis(1), &[a.view(), c.view()]);
+    let res = ndarray::stack(Axis(1), &[a.view(), c.view()]);
     assert_eq!(res.unwrap_err().kind(), ErrorKind::IncompatibleShape);
 
-    let res = ndarray::concatenate(Axis(2), &[a.view(), c.view()]);
+    let res = ndarray::stack(Axis(2), &[a.view(), c.view()]);
     assert_eq!(res.unwrap_err().kind(), ErrorKind::OutOfBounds);
 
-    let res: Result<Array2<f64>, _> = ndarray::concatenate(Axis(0), &[]);
+    let res: Result<Array2<f64>, _> = ndarray::stack(Axis(0), &[]);
     assert_eq!(res.unwrap_err().kind(), ErrorKind::Unsupported);
 }
 
 #[test]
 fn stacking() {
     let a = arr2(&[[2., 2.], [3., 3.]]);
-    let b = ndarray::stack(Axis(0), vec![a.view(), a.view()]).unwrap();
+    let b = ndarray::stack_new_axis(Axis(0), vec![a.view(), a.view()]).unwrap();
     assert_eq!(b, arr3(&[[[2., 2.], [3., 3.]], [[2., 2.], [3., 3.]]]));
 
     let c = arr2(&[[3., 2., 3.], [2., 3., 2.]]);
-    let res = ndarray::stack(Axis(1), vec![a.view(), c.view()]);
+    let res = ndarray::stack_new_axis(Axis(1), vec![a.view(), c.view()]);
     assert_eq!(res.unwrap_err().kind(), ErrorKind::IncompatibleShape);
 
-    let res = ndarray::stack(Axis(3), vec![a.view(), a.view()]);
+    let res = ndarray::stack_new_axis(Axis(3), vec![a.view(), a.view()]);
     assert_eq!(res.unwrap_err().kind(), ErrorKind::OutOfBounds);
 
-    let res: Result<Array2<f64>, _> = ndarray::stack::<_, Ix1>(Axis(0), vec![]);
+    let res: Result<Array2<f64>, _> = ndarray::stack_new_axis::<_, Ix1>(Axis(0), vec![]);
     assert_eq!(res.unwrap_err().kind(), ErrorKind::Unsupported);
 }


### PR DESCRIPTION
Issue: https://github.com/rust-ndarray/ndarray/issues/667

Continuation of https://github.com/rust-ndarray/ndarray/pull/735 with the commit history being cleaned up.

Changes:
 - added `concatenate` proxy function to `stack` function, `concatenate!` proxy macro to `stack!` macro
 - deprecated `stack` function and `stack!` macro since `0.13.2`
 - added `stack_new_axis` function and `stack_new_axis!` macro to mimic the behavior of `np.stack` function from numpy

In 0.14.0 we should probably rename `stack_new_axis` to `stack` and drop old `stack` function, same about macro.

##### concatenate
```rust
use ndarray::{arr2, Axis, concatenate};

let a = arr2(&[[2., 2.], [3., 3.]]);
assert!(
     concatenate(Axis(0), &[a.view(), a.view()])
     == Ok(arr2(&[[2., 2.], [3., 3.], [2., 2.], [3., 3.]]))
);
```

##### stack_new_axis
```rust
use ndarray::{arr2, arr3, stack_new_axis, Axis};

let a = arr2(&[[2., 2.],
               [3., 3.]]);
assert!(
    stack_new_axis![Axis(0), a, a]
    == arr3(&[[[2., 2.],
               [3., 3.]],
              [[2., 2.],
               [3., 3.]]])
);
```