### PR TITLE
Bump to approx 0.4, num-complex 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ num-complex = { version = "0.3", default-features = false }
 
 rayon = { version = "1.0.3", optional = true }
 
-approx = { version = "0.3.2", optional = true }
+approx = { version = "0.4", optional = true }
 
 # Use via the `blas` crate feature!
 cblas-sys = { version = "0.1.4", optional = true, default-features = false }
@@ -47,7 +47,7 @@ rawpointer = { version = "0.2" }
 [dev-dependencies]
 defmac = "0.2"
 quickcheck = { version = "0.9", default-features = false }
-approx = "0.3.2"
+approx = "0.4"
 itertools = { version = "0.9.0", default-features = false, features = ["use_std"] }
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = [
   "bluss",
   "Jim Turner"
 ]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 readme = "README-crates.io.md"
 
 repository = "https://github.com/rust-ndarray/ndarray"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ test = true
 [dependencies]
 num-integer = "0.1.39"
 num-traits = "0.2"
-num-complex = "0.2"
+num-complex = { version = "0.3", default-features = false }
 
 rayon = { version = "1.0.3", optional = true }
 

--- a/blas-tests/Cargo.toml
+++ b/blas-tests/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 test = false
 
 [dev-dependencies]
-approx = "0.3.2"
+approx = "0.4"
 ndarray = { path = "../", features = ["approx", "blas"] }
 blas-src = { version = "0.6.1", default-features = false, features = ["openblas"] }
 openblas-src = { version = "0.9.0", default-features = false, features = ["cblas", "system"] }

--- a/numeric-tests/Cargo.toml
+++ b/numeric-tests/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["bluss"]
 publish = false
 
 [dependencies]
-approx = "0.3.2"
+approx = "0.4"
 ndarray = { path = "..", features = ["approx"] }
 ndarray-rand = { path = "../ndarray-rand/" }
 rand_distr = "0.2.1"

--- a/tests/complex.rs
+++ b/tests/complex.rs
@@ -10,7 +10,7 @@ fn c<T: Clone + Num>(re: T, im: T) -> Complex<T> {
 #[test]
 fn complex_mat_mul() {
     let a = arr2(&[[c(3., 4.), c(2., 0.)], [c(0., -2.), c(3., 0.)]]);
-    let b = (&a * c(3., 0.)).map(|c| 5. * c / c.norm());
+    let b = (&a * c(3., 0.)).map(|c| 5. * c / c.norm_sqr());
     println!("{:>8.2}", b);
     let e = Array::eye(2);
     let r = a.dot(&e);


### PR DESCRIPTION
Use num-complex without activating std (because ndarray does not need it
by itself) - this means we can't use norm in the test.