### PR TITLE
Error-check array shape before computing strides

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           profile: minimal
           toolchain: ${{ matrix.rust }}
-          taret: ${{ matrix.target }}
+          target: ${{ matrix.target }}
           override: true
       - name: Cache cargo plugins
         uses: actions/cache@v1

--- a/src/impl_views/constructors.rs
+++ b/src/impl_views/constructors.rs
@@ -53,12 +53,8 @@ where
 
     fn from_shape_impl(shape: StrideShape<D>, xs: &'a [A]) -> Result<Self, ShapeError> {
         let dim = shape.dim;
-        let strides = shape.strides;
-        if shape.custom {
-            dimension::can_index_slice(xs, &dim, &strides)?;
-        } else {
-            dimension::can_index_slice_not_custom::<A, _>(xs, &dim)?;
-        }
+        dimension::can_index_slice_with_strides(xs, &dim, &shape.strides)?;
+        let strides = shape.strides.strides_for_dim(&dim);
         unsafe { Ok(Self::new_(xs.as_ptr(), dim, strides)) }
     }
 
@@ -149,12 +145,8 @@ where
 
     fn from_shape_impl(shape: StrideShape<D>, xs: &'a mut [A]) -> Result<Self, ShapeError> {
         let dim = shape.dim;
-        let strides = shape.strides;
-        if shape.custom {
-            dimension::can_index_slice(xs, &dim, &strides)?;
-        } else {
-            dimension::can_index_slice_not_custom::<A, _>(xs, &dim)?;
-        }
+        dimension::can_index_slice_with_strides(xs, &dim, &shape.strides)?;
+        let strides = shape.strides.strides_for_dim(&dim);
         unsafe { Ok(Self::new_(xs.as_mut_ptr(), dim, strides)) }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,7 +138,7 @@ pub use crate::linalg_traits::{LinalgScalar, NdFloat};
 pub use crate::stacking::{concatenate, stack, stack_new_axis};
 
 pub use crate::impl_views::IndexLonger;
-pub use crate::shape_builder::ShapeBuilder;
+pub use crate::shape_builder::{Shape, StrideShape, ShapeBuilder};
 
 #[macro_use]
 mod macro_utils;
@@ -1595,24 +1595,8 @@ mod impl_raw_views;
 // Copy-on-write array methods
 mod impl_cow;
 
-/// A contiguous array shape of n dimensions.
-///
-/// Either c- or f- memory ordered (*c* a.k.a *row major* is the default).
-#[derive(Copy, Clone, Debug)]
-pub struct Shape<D> {
-    dim: D,
-    is_c: bool,
-}
-
-/// An array shape of n dimensions in c-order, f-order or custom strides.
-#[derive(Copy, Clone, Debug)]
-pub struct StrideShape<D> {
-    dim: D,
-    strides: D,
-    custom: bool,
-}
-
 /// Returns `true` if the pointer is aligned.
 pub(crate) fn is_aligned<T>(ptr: *const T) -> bool {
     (ptr as usize) % ::std::mem::align_of::<T>() == 0
 }
+

--- a/tests/array-construct.rs
+++ b/tests/array-construct.rs
@@ -148,6 +148,7 @@ fn test_from_fn_f3() {
 fn deny_wraparound_from_vec() {
     let five = vec![0; 5];
     let five_large = Array::from_shape_vec((3, 7, 29, 36760123, 823996703), five.clone());
+    println!("{:?}", five_large);
     assert!(five_large.is_err());
     let six = Array::from_shape_vec(6, five.clone());
     assert!(six.is_err());


### PR DESCRIPTION
Update representation (of StrideShape) to use enum { C, F, Custom(D) } so that we don't
try to compute a C or F stride set until after we have checked the
actual array shape.

This avoids overflow errors (that panic) in places where we expected to
return an error. It was visible as a test failure on 32-bit that long
went undetected because tests didn't run on such platforms before (but
the bug affected all platforms, given sufficiently large inputs).

Also move the Shape, StrideShape types into the shape builder module.
It all calls out for a nicer organization of types that makes
constructors easier to understand for users, but that's an issue for
another time - and it's a breaking change.

Fixes #852 