### PR TITLE
Place NdFloat and num-traits/std behind a new "std" feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ test = true
 
 [dependencies]
 num-integer = "0.1.39"
-num-traits = "0.2"
+num-traits = { version = "0.2", default-features = false }
 num-complex = { version = "0.3", default-features = false }
 
 rayon = { version = "1.0.3", optional = true }
@@ -51,6 +51,7 @@ approx = "0.4"
 itertools = { version = "0.9.0", default-features = false, features = ["use_std"] }
 
 [features]
+default = ["std"]
 # Enable blas usage
 # See README for more instructions
 blas = ["cblas-sys", "blas-src"]
@@ -64,6 +65,8 @@ test = ["test-blas-openblas-sys"]
 
 # This feature is used for docs
 docs = ["approx", "serde", "rayon"]
+
+std = ["num-traits/std"]
 
 [profile.release]
 [profile.bench]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 #![allow(
     clippy::many_single_char_names,
     clippy::deref_addrof,
-    clippy::unreadable_literal,
+    clippy::unreadable_literal
 )]
 
 //! The `ndarray` crate provides an *n*-dimensional container for general elements
@@ -106,7 +106,7 @@
 //!
 //! If you are looking to generate random arrays instead, check out [`ndarray-rand`](https://crates.io/crates/ndarray-rand).
 //!
-//! For conversion between `ndarray`, [`nalgebra`](https://crates.io/crates/nalgebra) and 
+//! For conversion between `ndarray`, [`nalgebra`](https://crates.io/crates/nalgebra) and
 //! [`image`](https://crates.io/crates/image) check out [`nshare`](https://crates.io/crates/nshare).
 
 #[cfg(feature = "blas")]
@@ -133,12 +133,14 @@ use crate::iterators::Baseiter;
 use crate::iterators::{ElementsBase, ElementsBaseMut, Iter, IterMut, Lanes, LanesMut};
 
 pub use crate::arraytraits::AsArray;
-pub use crate::linalg_traits::{LinalgScalar, NdFloat};
+#[cfg(feature = "std")]
+pub use crate::linalg_traits::NdFloat;
+pub use crate::linalg_traits::LinalgScalar; 
 
 pub use crate::stacking::{concatenate, stack, stack_new_axis};
 
 pub use crate::impl_views::IndexLonger;
-pub use crate::shape_builder::{Shape, StrideShape, ShapeBuilder};
+pub use crate::shape_builder::{Shape, ShapeBuilder, StrideShape};
 
 #[macro_use]
 mod macro_utils;
@@ -147,16 +149,16 @@ mod private;
 mod aliases;
 #[macro_use]
 mod itertools;
+mod argument_traits;
 #[cfg(feature = "approx")]
 mod array_approx;
 #[cfg(feature = "serde")]
 mod array_serde;
 mod arrayformat;
 mod arraytraits;
-mod argument_traits;
 pub use crate::argument_traits::AssignElem;
-mod data_traits;
 mod data_repr;
+mod data_traits;
 
 pub use crate::aliases::*;
 
@@ -1599,4 +1601,3 @@ mod impl_cow;
 pub(crate) fn is_aligned<T>(ptr: *const T) -> bool {
     (ptr as usize) % ::std::mem::align_of::<T>() == 0
 }
-

--- a/src/linalg_traits.rs
+++ b/src/linalg_traits.rs
@@ -6,7 +6,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 use crate::ScalarOperand;
-use num_traits::{Float, One, Zero};
+#[cfg(feature = "std")]
+use num_traits::Float;
+use num_traits::{One, Zero};
 use std::fmt;
 use std::ops::{Add, Div, Mul, Sub};
 use std::ops::{AddAssign, DivAssign, MulAssign, RemAssign, SubAssign};
@@ -47,6 +49,7 @@ impl<T> LinalgScalar for T where
 /// operations (`ScalarOperand`).
 ///
 /// This trait can only be implemented by `f32` and `f64`.
+#[cfg(feature = "std")]
 pub trait NdFloat:
     Float
     + AddAssign
@@ -65,5 +68,8 @@ pub trait NdFloat:
 {
 }
 
+#[cfg(feature = "std")]
 impl NdFloat for f32 {}
+#[cfg(feature = "std")]
 impl NdFloat for f64 {}
+

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -51,4 +51,8 @@ pub use crate::{array, azip, s};
 pub use crate::ShapeBuilder;
 
 #[doc(no_inline)]
-pub use crate::{AsArray, NdFloat};
+pub use crate::AsArray;
+
+#[doc(no_inline)]
+#[cfg(feature = "std")]
+pub use crate::NdFloat;

--- a/tests/oper.rs
+++ b/tests/oper.rs
@@ -10,6 +10,7 @@ use ndarray::prelude::*;
 use ndarray::{rcarr1, rcarr2};
 use ndarray::{Data, LinalgScalar};
 use ndarray::{Ix, Ixs};
+use num_traits::Zero;
 use std::iter::FromIterator;
 
 use approx::assert_abs_diff_eq;
@@ -33,10 +34,9 @@ fn test_oper(op: &str, a: &[f32], b: &[f32], c: &[f32]) {
     test_oper_arr::<f32, _>(op, aa.clone(), bb.clone(), cc.clone());
 }
 
-fn test_oper_arr<A, D>(op: &str, mut aa: ArcArray<A, D>, bb: ArcArray<A, D>, cc: ArcArray<A, D>)
+
+fn test_oper_arr<A, D>(op: &str, mut aa: ArcArray<f32, D>, bb: ArcArray<f32, D>, cc: ArcArray<f32, D>)
 where
-    A: NdFloat,
-    for<'a> &'a A: Neg<Output = A>,
     D: Dimension,
 {
     match op {
@@ -147,17 +147,16 @@ fn scalar_operations() {
     }
 }
 
-fn reference_dot<'a, A, V1, V2>(a: V1, b: V2) -> A
+fn reference_dot<'a, V1, V2>(a: V1, b: V2) -> f32
 where
-    A: NdFloat,
-    V1: AsArray<'a, A>,
-    V2: AsArray<'a, A>,
+    V1: AsArray<'a, f32>,
+    V2: AsArray<'a, f32>,
 {
     let a = a.into();
     let b = b.into();
     a.iter()
         .zip(b.iter())
-        .fold(A::zero(), |acc, (&x, &y)| acc + x * y)
+        .fold(f32::zero(), |acc, (&x, &y)| acc + x * y)
 }
 
 #[test]


### PR DESCRIPTION
This PR adds a new default feature "std" and when present this activates the "std" feature in num-traits and includes the `NdFloat` trait defined in ndarray. This is part of the tasks required in order to provide a `no_std + alloc` version of ndarray for issue #708 

This is (an unavoidable) breaking change for any users that set `default-features = false`, other ndarray users will be unaffected.