### PR TITLE
Fix Zip::indexed for the 0-dimensional case

### DIFF
--- a/src/zip/mod.rs
+++ b/src/zip/mod.rs
@@ -691,12 +691,14 @@ impl<P, D> Zip<P, D>
 where
     D: Dimension,
 {
-    fn apply_core<F, Acc>(&mut self, acc: Acc, function: F) -> FoldWhile<Acc>
+    fn apply_core<F, Acc>(&mut self, acc: Acc, mut function: F) -> FoldWhile<Acc>
     where
         F: FnMut(Acc, P::Item) -> FoldWhile<Acc>,
         P: ZippableTuple<Dim = D>,
     {
-        if self.layout.is(CORDER | FORDER) {
+        if self.dimension.ndim() == 0 {
+            function(acc, unsafe { self.parts.as_ref(self.parts.as_ptr()) })
+        } else if self.layout.is(CORDER | FORDER) {
             self.apply_core_contiguous(acc, function)
         } else {
             self.apply_core_strided(acc, function)

--- a/tests/azip.rs
+++ b/tests/azip.rs
@@ -304,6 +304,19 @@ fn test_clone() {
 }
 
 #[test]
+fn test_indices_0() {
+    let a1 = arr0(3);
+
+    let mut count = 0;
+    Zip::indexed(&a1).apply(|i, elt| {
+        count += 1;
+        assert_eq!(i, ());
+        assert_eq!(*elt, 3);
+    });
+    assert_eq!(count, 1);
+}
+
+#[test]
 fn test_indices_1() {
     let mut a1 = Array::default(12);
     for (i, elt) in a1.indexed_iter_mut() {


### PR DESCRIPTION
This commit fixes a panic for 0-dimensional, indexed `Zip` instances
which results from an out-of-bounds index in a call to
`IndexPtr::stride_offset` in `Zip::inner`. Basically, the "stride" for
`IndexPtr` is the axis to update, but for the 0-dimensional case,
there are no axes, so `IndexPtr::stride_offset` cannot be called
without panicking due to the `self.index[stride]` access.

The chosen solution is to add a special check to `Zip::apply_core` for
the 0-dimensional case. Another possible solution would be to modify
the loop of `Zip::inner` such that an offset would not be performed
for an index of zero.