### PR TITLE
Remove deprecated items `.all_close()` and `DataClone`, `ArrayView::into_slice`

### DIFF
--- a/src/aliases.rs
+++ b/src/aliases.rs
@@ -2,7 +2,6 @@
 //!
 
 use crate::dimension::Dim;
-#[allow(deprecated)]
 use crate::{ArcArray, Array, ArrayView, ArrayViewMut, Ix, IxDynImpl};
 
 /// Create a zero-dimensional index

--- a/src/data_traits.rs
+++ b/src/data_traits.rs
@@ -129,18 +129,6 @@ pub unsafe trait DataMut: Data + RawDataMut {
     }
 }
 
-/// Array representation trait.
-///
-/// An array representation that can be cloned and allows elements to be
-/// accessed with safe code.
-///
-/// ***Internal trait, see `Data`.***
-#[deprecated(note = "use `Data + RawDataClone` instead", since = "0.13.0")]
-pub trait DataClone: Data + RawDataClone {}
-
-#[allow(deprecated)]
-impl<T> DataClone for T where T: Data + RawDataClone {}
-
 unsafe impl<A> RawData for RawViewRepr<*const A> {
     type Elem = A;
     fn _data_slice(&self) -> Option<&[A]> {

--- a/src/impl_views/conversions.rs
+++ b/src/impl_views/conversions.rs
@@ -115,7 +115,7 @@ where
     /// Note that while this is similar to [`ArrayBase::as_slice_mut()`], this method tranfers the
     /// view's lifetime to the slice.
     pub fn into_slice(self) -> Option<&'a mut [A]> {
-        self.into_slice_().ok()
+        self.try_into_slice().ok()
     }
 }
 
@@ -173,7 +173,9 @@ where
         ElementsBaseMut::new(self)
     }
 
-    pub(crate) fn into_slice_(self) -> Result<&'a mut [A], Self> {
+    /// Return the array’s data as a slice, if it is contiguous and in standard order.
+    /// Otherwise return self in the Err branch of the result.
+    pub(crate) fn try_into_slice(self) -> Result<&'a mut [A], Self> {
         if self.is_standard_layout() {
             unsafe { Ok(slice::from_raw_parts_mut(self.ptr.as_ptr(), self.len())) }
         } else {

--- a/src/impl_views/conversions.rs
+++ b/src/impl_views/conversions.rs
@@ -31,18 +31,9 @@ where
 
     /// Return the array’s data as a slice, if it is contiguous and in standard order.
     /// Return `None` otherwise.
-    #[deprecated(note = "`into_slice` has been renamed to `to_slice`", since = "0.13.0")]
-    #[allow(clippy::wrong_self_convention)]
-    pub fn into_slice(&self) -> Option<&'a [A]> {
-        if self.is_standard_layout() {
-            unsafe { Some(slice::from_raw_parts(self.ptr.as_ptr(), self.len())) }
-        } else {
-            None
-        }
-    }
-
-    /// Return the array’s data as a slice, if it is contiguous and in standard order.
-    /// Return `None` otherwise.
+    ///
+    /// Note that while the method is similar to [`ArrayBase::as_slice()`], this method tranfers
+    /// the view's lifetime to the slice, so it is a bit more powerful.
     pub fn to_slice(&self) -> Option<&'a [A]> {
         if self.is_standard_layout() {
             unsafe { Some(slice::from_raw_parts(self.ptr.as_ptr(), self.len())) }
@@ -120,6 +111,9 @@ where
 {
     /// Return the array’s data as a slice, if it is contiguous and in standard order.
     /// Return `None` otherwise.
+    ///
+    /// Note that while this is similar to [`ArrayBase::as_slice_mut()`], this method tranfers the
+    /// view's lifetime to the slice.
     pub fn into_slice(self) -> Option<&'a mut [A]> {
         self.into_slice_().ok()
     }

--- a/src/iterators/mod.rs
+++ b/src/iterators/mod.rs
@@ -294,7 +294,7 @@ where
 {
     pub(crate) fn new(self_: ArrayViewMut<'a, A, D>) -> Self {
         IterMut {
-            inner: match self_.into_slice_() {
+            inner: match self_.try_into_slice() {
                 Ok(x) => ElementsRepr::Slice(x.iter_mut()),
                 Err(self_) => ElementsRepr::Counted(self_.into_elements_base()),
             },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,7 +162,6 @@ mod data_traits;
 
 pub use crate::aliases::*;
 
-#[allow(deprecated)]
 pub use crate::data_traits::{
     Data, DataMut, DataOwned, DataShared, RawData, RawDataClone, RawDataMut,
     RawDataSubst,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,7 +164,7 @@ pub use crate::aliases::*;
 
 #[allow(deprecated)]
 pub use crate::data_traits::{
-    Data, DataClone, DataMut, DataOwned, DataShared, RawData, RawDataClone, RawDataMut,
+    Data, DataMut, DataOwned, DataShared, RawData, RawDataClone, RawDataMut,
     RawDataSubst,
 };
 

--- a/src/numeric/impl_numeric.rs
+++ b/src/numeric/impl_numeric.rs
@@ -13,8 +13,6 @@ use crate::imp_prelude::*;
 use crate::itertools::enumerate;
 use crate::numeric_util;
 
-use crate::{FoldWhile, Zip};
-
 /// # Numerical Methods for Arrays
 impl<A, S, D> ArrayBase<S, D>
 where
@@ -303,33 +301,5 @@ where
         D: RemoveAxis,
     {
         self.var_axis(axis, ddof).mapv_into(|x| x.sqrt())
-    }
-
-    /// Return `true` if the arrays' elementwise differences are all within
-    /// the given absolute tolerance, `false` otherwise.
-    ///
-    /// If their shapes disagree, `rhs` is broadcast to the shape of `self`.
-    ///
-    /// **Panics** if broadcasting to the same shape isn’t possible.
-    #[deprecated(
-        note = "Use `abs_diff_eq` - it requires the `approx` crate feature",
-        since = "0.13.0"
-    )]
-    pub fn all_close<S2, E>(&self, rhs: &ArrayBase<S2, E>, tol: A) -> bool
-    where
-        A: Float,
-        S2: Data<Elem = A>,
-        E: Dimension,
-    {
-        !Zip::from(self)
-            .and(rhs.broadcast_unwrap(self.raw_dim()))
-            .fold_while((), |_, x, y| {
-                if (*x - *y).abs() <= tol {
-                    FoldWhile::Continue(())
-                } else {
-                    FoldWhile::Done(())
-                }
-            })
-            .is_done()
     }
 }

--- a/src/numeric/impl_numeric.rs
+++ b/src/numeric/impl_numeric.rs
@@ -48,6 +48,17 @@ where
         sum
     }
 
+    /// Return the sum of all elements in the array.
+    ///
+    /// *This method has been renamed to `.sum()`*
+    #[deprecated(note="renamed to `sum`", since="0.15.0")]
+    pub fn scalar_sum(&self) -> A
+    where
+        A: Clone + Add<Output = A> + num_traits::Zero,
+    {
+        self.sum()
+    }
+
     /// Returns the [arithmetic mean] x̅ of all elements in the array:
     ///
     /// ```text
@@ -73,18 +84,6 @@ where
                 .expect("Converting number of elements to `A` must not fail.");
             Some(self.sum() / n_elements)
         }
-    }
-
-    /// Return the sum of all elements in the array.
-    ///
-    /// *This method has been renamed to `.sum()` and will be deprecated in the
-    /// next version.*
-    // #[deprecated(note="renamed to `sum`", since="0.13")]
-    pub fn scalar_sum(&self) -> A
-    where
-        A: Clone + Add<Output = A> + num_traits::Zero,
-    {
-        self.sum()
     }
 
     /// Return the product of all elements in the array.

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -17,7 +17,6 @@
 //! ```
 
 #[doc(no_inline)]
-#[allow(deprecated)]
 pub use crate::{
     ArcArray, Array, ArrayBase, ArrayView, ArrayViewMut, CowArray, RawArrayView, RawArrayViewMut,
 };

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -1787,17 +1787,6 @@ fn test_contiguous() {
 }
 
 #[test]
-#[allow(deprecated)]
-fn test_all_close() {
-    let c = arr3(&[
-        [[1., 2., 3.], [1.5, 1.5, 3.]],
-        [[1., 2., 3.], [1., 2.5, 3.]],
-    ]);
-    assert!(c.all_close(&aview1(&[1., 2., 3.]), 1.));
-    assert!(!c.all_close(&aview1(&[1., 2., 3.]), 0.1));
-}
-
-#[test]
 fn test_swap() {
     let mut a = arr2(&[[1, 2, 3], [4, 5, 6], [7, 8, 9]]);
     let b = a.clone();


### PR DESCRIPTION
- Remove deprecated `.all_close()` - use approx feature and methods like  `.abs_diff_eq` instead
- Mark `.scalar_sum()` as deprecated - use `.sum()` instead
- Remove deprecated `DataClone` - use `Data + RawDataClone` instead
- Remove deprecated `ArrayView::into_slice` - use `to_slice()` instead.

Fixes #863 

### `ArrayView::into_slice` vs `to_slice`

Looking closely at this one, I'd want to use the name `into_slice`.
The "into" semantic is for preserving the lifetime from the input
to the output - and for setting it more apart from the general `ArrayBase::as_slice`.

However, both names `into-slice` and `to-slice` have pros and cons
and in the interest of reducing churn, the already deprecated method
loses in the tiebreaker IMO, and so `into_slice` is removed because
clippy said so.

Previously in #646