### PR TITLE
Improve .assume_init() and use Array::maybe_uninit instead of Array::uninitialized

### DIFF
--- a/benches/bench1.rs
+++ b/benches/bench1.rs
@@ -9,6 +9,8 @@
 
 extern crate test;
 
+use std::mem::MaybeUninit;
+
 use ndarray::ShapeBuilder;
 use ndarray::{arr0, arr1, arr2, azip, s};
 use ndarray::{Array, Array1, Array2, Axis, Ix, Zip};
@@ -269,9 +271,9 @@ fn add_2d_alloc_zip_uninit(bench: &mut test::Bencher) {
     let a = Array::<i32, _>::zeros((ADD2DSZ, ADD2DSZ));
     let b = Array::<i32, _>::zeros((ADD2DSZ, ADD2DSZ));
     bench.iter(|| unsafe {
-        let mut c = Array::uninitialized(a.dim());
-        azip!((&a in &a, &b in &b, c in c.raw_view_mut())
-            std::ptr::write(c, a + b)
+        let mut c = Array::<MaybeUninit<i32>, _>::maybe_uninit(a.dim());
+        azip!((&a in &a, &b in &b, c in c.raw_view_mut().cast::<i32>())
+            c.write(a + b)
         );
         c
     });

--- a/src/data_repr.rs
+++ b/src/data_repr.rs
@@ -10,7 +10,11 @@ use crate::extension::nonnull;
 /// *Don’t use this type directly—use the type alias
 /// [`Array`](type.Array.html) for the array type!*
 // Like a Vec, but with non-unique ownership semantics
+//
+// repr(C) to make it transmutable OwnedRepr<A> -> OwnedRepr<B> if
+// transmutable A -> B.
 #[derive(Debug)]
+#[repr(C)]
 pub struct OwnedRepr<A> {
     ptr: NonNull<A>,
     len: usize,
@@ -48,6 +52,23 @@ impl<A> OwnedRepr<A> {
 
     pub(crate) fn as_nonnull_mut(&mut self) -> NonNull<A> {
         self.ptr
+    }
+
+    /// Cast self into equivalent repr of other element type
+    ///
+    /// ## Safety
+    ///
+    /// Caller must ensure the two types have the same representation.
+    /// **Panics** if sizes don't match (which is not a sufficient check).
+    pub(crate) unsafe fn data_subst<B>(self) -> OwnedRepr<B> {
+        // necessary but not sufficient check
+        assert_eq!(mem::size_of::<A>(), mem::size_of::<B>());
+        let self_ = ManuallyDrop::new(self);
+        OwnedRepr {
+            ptr: self_.ptr.cast::<B>(),
+            len: self_.len,
+            capacity: self_.capacity,
+        }
     }
 
     fn take_as_vec(&mut self) -> Vec<A> {

--- a/src/data_traits.rs
+++ b/src/data_traits.rs
@@ -526,28 +526,60 @@ unsafe impl<'a, A> DataMut for CowRepr<'a, A> where A: Clone {}
 pub trait RawDataSubst<A>: RawData {
     /// The resulting array storage of the same kind but substituted element type
     type Output: RawData<Elem = A>;
+
+    /// Unsafely translate the data representation from one element
+    /// representation to another.
+    ///
+    /// ## Safety
+    ///
+    /// Caller must ensure the two types have the same representation.
+    unsafe fn data_subst(self) -> Self::Output;
 }
 
 impl<A, B> RawDataSubst<B> for OwnedRepr<A> {
     type Output = OwnedRepr<B>;
+
+    unsafe fn data_subst(self) -> Self::Output {
+        self.data_subst()
+    }
 }
 
 impl<A, B> RawDataSubst<B> for OwnedArcRepr<A> {
     type Output = OwnedArcRepr<B>;
+
+    unsafe fn data_subst(self) -> Self::Output {
+        OwnedArcRepr(Arc::from_raw(Arc::into_raw(self.0) as *const OwnedRepr<B>))
+    }
 }
 
 impl<A, B> RawDataSubst<B> for RawViewRepr<*const A> {
     type Output = RawViewRepr<*const B>;
+
+    unsafe fn data_subst(self) -> Self::Output {
+        RawViewRepr::new()
+    }
 }
 
 impl<A, B> RawDataSubst<B> for RawViewRepr<*mut A> {
     type Output = RawViewRepr<*mut B>;
+
+    unsafe fn data_subst(self) -> Self::Output {
+        RawViewRepr::new()
+    }
 }
 
 impl<'a, A: 'a, B: 'a> RawDataSubst<B> for ViewRepr<&'a A> {
     type Output = ViewRepr<&'a B>;
+
+    unsafe fn data_subst(self) -> Self::Output {
+        ViewRepr::new()
+    }
 }
 
 impl<'a, A: 'a, B: 'a> RawDataSubst<B> for ViewRepr<&'a mut A> {
     type Output = ViewRepr<&'a mut B>;
+
+    unsafe fn data_subst(self) -> Self::Output {
+        ViewRepr::new()
+    }
 }

--- a/src/doc/ndarray_for_numpy_users/mod.rs
+++ b/src/doc/ndarray_for_numpy_users/mod.rs
@@ -647,7 +647,6 @@
 //! [.index_axis()]: ../../struct.ArrayBase.html#method.index_axis
 //! [.sum_axis()]: ../../struct.ArrayBase.html#method.sum_axis
 //! [.t()]: ../../struct.ArrayBase.html#method.t
-//! [::uninitialized()]: ../../struct.ArrayBase.html#method.uninitialized
 //! [vec-* dot]: ../../struct.ArrayBase.html#method.dot
 //! [.visit()]: ../../struct.ArrayBase.html#method.visit
 //! [::zeros()]: ../../struct.ArrayBase.html#method.zeros

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2014-2016 bluss and ndarray developers.
+// Copyright 2014-2020 bluss and ndarray developers.
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
@@ -187,6 +187,7 @@ mod shape_builder;
 mod slice;
 mod split_at;
 mod stacking;
+mod traversal_utils;
 #[macro_use]
 mod zip;
 

--- a/src/stacking.rs
+++ b/src/stacking.rs
@@ -1,4 +1,4 @@
-// Copyright 2014-2016 bluss and ndarray developers.
+// Copyright 2014-2020 bluss and ndarray developers.
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
@@ -8,6 +8,7 @@
 
 use crate::error::{from_kind, ErrorKind, ShapeError};
 use crate::imp_prelude::*;
+use crate::traversal_utils::assign_to;
 
 /// Stack arrays along the new axis.
 ///
@@ -88,25 +89,23 @@ where
     let stacked_dim = arrays.iter().fold(0, |acc, a| acc + a.len_of(axis));
     res_dim.set_axis(axis, stacked_dim);
 
-    // we can safely use uninitialized values here because they are Copy
-    // and we will only ever write to them
-    let size = res_dim.size();
-    let mut v = Vec::with_capacity(size);
-    unsafe {
-        v.set_len(size);
-    }
-    let mut res = Array::from_shape_vec(res_dim, v)?;
+    // we can safely use uninitialized values here because we will
+    // overwrite every one of them.
+    let mut res = Array::maybe_uninit(res_dim);
 
     {
         let mut assign_view = res.view_mut();
         for array in arrays {
             let len = array.len_of(axis);
-            let (mut front, rest) = assign_view.split_at(axis, len);
-            front.assign(array);
+            let (front, rest) = assign_view.split_at(axis, len);
+            assign_to(array, front);
             assign_view = rest;
         }
+        debug_assert_eq!(assign_view.len(), 0);
     }
-    Ok(res)
+    unsafe {
+        Ok(res.assume_init())
+    }
 }
 
 /// Stack arrays along the new axis.
@@ -158,22 +157,24 @@ where
 
     res_dim.set_axis(axis, arrays.len());
 
-    // we can safely use uninitialized values here because they are Copy
-    // and we will only ever write to them
-    let size = res_dim.size();
-    let mut v = Vec::with_capacity(size);
-    unsafe {
-        v.set_len(size);
-    }
-    let mut res = Array::from_shape_vec(res_dim, v)?;
+    // we can safely use uninitialized values here because we will
+    // overwrite every one of them.
+    let mut res = Array::maybe_uninit(res_dim);
 
     res.axis_iter_mut(axis)
         .zip(arrays.iter())
-        .for_each(|(mut assign_view, array)| {
-            assign_view.assign(&array);
+        .for_each(|(assign_view, array)| {
+            // assign_view is D::Larger::Smaller which is usually == D
+            // (but if D is Ix6, we have IxD != Ix6 here; differing types
+            // but same number of axes).
+            let assign_view = assign_view.into_dimensionality::<D>()
+                .expect("same-dimensionality cast");
+            assign_to(array, assign_view);
         });
 
-    Ok(res)
+    unsafe {
+        Ok(res.assume_init())
+    }
 }
 
 /// Stack arrays along the new axis.

--- a/src/traversal_utils.rs
+++ b/src/traversal_utils.rs
@@ -1,0 +1,26 @@
+// Copyright 2020 bluss and ndarray developers.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use crate::{
+    IntoNdProducer,
+    AssignElem,
+    Zip,
+};
+
+/// Assign values from producer P1 to producer P2
+/// P1 and P2 must be of the same shape and dimension
+pub(crate) fn assign_to<'a, P1, P2, A>(from: P1, to: P2)
+    where P1: IntoNdProducer<Item = &'a A>,
+          P2: IntoNdProducer<Dim = P1::Dim>,
+          P2::Item: AssignElem<A>,
+          A: Clone + 'a
+{
+    Zip::from(from)
+        .apply_assign_into(to, A::clone);
+}
+


### PR DESCRIPTION
Improve `.assume_init()` so that we can see that it is on sound ground (and not transmuting wildly).

Then the remaining internal uses of `Array::uninitialized` are removed and replaced with `Array::maybe_uninit`.

Fixes part of #796
Prerequisite of #804

This pull request demonstrates two different ways of working with `maybe_uninit`. In concatenate and stack,
we can see how we're using the more "Rust-level" approach of using regular array traversal and interacting with
elements of type `MaybeUninit<A>` (by just assigning to them, but still).

In the implementation of `dot` and the benchmark, we instead use raw array views - `RawArrayViewMut`,
cast the raw view from element type `MaybeUninit<A>` to `A`, and handle the resulting raw view and
raw pointers carefully. We have some power in the ndarray abstractions because we can use `Zip`
to traverse raw views just like regular arrays.