### PR TITLE
Update to matrixmultiply 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,8 @@ cblas-sys = { version = "0.1.4", optional = true, default-features = false }
 blas-src = { version = "0.6.1", optional = true, default-features = false }
 libc = { version = "0.2.82", optional = true }
 
-matrixmultiply = { version = "0.2.0", default-features = false}
+matrixmultiply = { version = "0.3.0", default-features = false}
+
 serde = { version = "1.0", optional = true, default-features = false, features = ["alloc"] }
 rawpointer = { version = "0.2" }
 


### PR DESCRIPTION
This version supports multithreading with the threading flag. Maybe we should even have a forward of its threading
feature flag - unsure how interesting that is to others.