### PR TITLE
Setup and tweak rayon, serde, blas features for no-std changes 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,16 +32,18 @@ num-integer = { version = "0.1.39", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 num-complex = { version = "0.3", default-features = false }
 
-rayon = { version = "1.0.3", optional = true }
+# Use via the `rayon` crate feature!
+rayon_ = { version = "1.0.3", optional = true, package = "rayon" }
 
 approx = { version = "0.4", optional = true , default-features = false }
 
 # Use via the `blas` crate feature!
 cblas-sys = { version = "0.1.4", optional = true, default-features = false }
 blas-src = { version = "0.6.1", optional = true, default-features = false }
+libc = { version = "0.2.82", optional = true }
 
 matrixmultiply = { version = "0.2.0", default-features = false}
-serde = { version = "1.0", optional = true }
+serde = { version = "1.0", optional = true, default-features = false, features = ["alloc"] }
 rawpointer = { version = "0.2" }
 
 [dev-dependencies]
@@ -55,7 +57,7 @@ default = ["std"]
 
 # Enable blas usage
 # See README for more instructions
-blas = ["cblas-sys", "blas-src"]
+blas = ["cblas-sys", "blas-src", "libc"]
 
 # Old name for the serde feature
 serde-1 = ["serde"]
@@ -68,6 +70,7 @@ test = ["test-blas-openblas-sys"]
 docs = ["approx", "serde", "rayon"]
 
 std = ["num-traits/std", "matrixmultiply/std"]
+rayon = ["rayon_", "std"]
 
 [profile.release]
 [profile.bench]

--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ your `Cargo.toml`.
 
 - ``std``
 
-  - Rust Standard Library
+  - Rust standard library (enabled by default)
 
   - This crate can be used without the standard library by disabling the
     default `std` feature. To do so, use this in your `Cargo.toml`:
@@ -63,20 +63,18 @@ your `Cargo.toml`.
 
 - ``serde``
 
-  - Optional, compatible with Rust stable
   - Enables serialization support for serde 1.x
 
 - ``rayon``
 
-  - Optional, compatible with Rust stable
   - Enables parallel iterators, parallelized methods and ``par_azip!``.
+  - Implies std
 
 - ``blas``
 
-  - Optional and experimental, compatible with Rust stable
   - Enable transparent BLAS support for matrix multiplication.
     Uses ``blas-src`` for pluggable backend, which needs to be configured
-    separately.
+    separately (see below).
 
 How to use with cargo
 ---------------------

--- a/serialization-tests/Cargo.toml
+++ b/serialization-tests/Cargo.toml
@@ -15,6 +15,7 @@ default = ["ron"]
 
 [dev-dependencies.serde]
 version = "1.0.100"
+default-features = false
 
 [dev-dependencies.serde_json]
 version = "1.0.40"

--- a/src/arrayformat.rs
+++ b/src/arrayformat.rs
@@ -9,8 +9,6 @@ use super::{ArrayBase, ArrayView, Axis, Data, Dimension, NdProducer};
 use crate::aliases::{Ix1, IxDyn};
 use std::fmt;
 use alloc::format;
-use alloc::string::String;
-use alloc::vec::Vec;
 
 /// Default threshold, below this element count, we don't ellipsize
 const ARRAY_MANY_ELEMENT_LIMIT: usize = 500;
@@ -290,6 +288,8 @@ where
 mod formatting_with_omit {
     use itertools::Itertools;
     use std::fmt;
+    use alloc::string::String;
+    use alloc::vec::Vec;
 
     use super::*;
     use crate::prelude::*;

--- a/src/impl_constructors.rs
+++ b/src/impl_constructors.rs
@@ -24,7 +24,9 @@ use crate::extension::nonnull::nonnull_from_vec_data;
 use crate::imp_prelude::*;
 use crate::indexes;
 use crate::indices;
-use crate::iterators::{to_vec, to_vec_mapped};
+#[cfg(feature = "std")]
+use crate::iterators::to_vec;
+use crate::iterators::to_vec_mapped;
 use crate::StrideShape;
 #[cfg(feature = "std")]
 use crate::{geomspace, linspace, logspace};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,27 +70,23 @@
 //! `Cargo.toml`.
 //!
 //! - `std`
-//!  - Rust Standard Library
+//!  - Rust standard library (enabled by default)
 //!  - This crate can be used without the standard library by disabling the
 //!    default `std` feature. To do so, use `default-features = false` in
 //!    your `Cargo.toml`.
 //!  - The `geomspace` `linspace` `logspace` `range` `std` `var` `var_axis`
-//!    and `std_axis` methods are only available when `std` is
-//!     enabled.
+//!    and `std_axis` methods are only available when `std` is enabled.
 //! - `serde`
-//!   - Optional, compatible with Rust stable
 //!   - Enables serialization support for serde 1.x
 //! - `rayon`
-//!   - Optional, compatible with Rust stable
 //!   - Enables parallel iterators, parallelized methods and [`par_azip!`].
+//!   - Implies std
 //! - `approx`
-//!   - Optional, compatible with Rust stable
 //!   - Enables implementations of traits from the [`approx`] crate.
 //! - `blas`
-//!   - Optional and experimental, compatible with Rust stable
 //!   - Enable transparent BLAS support for matrix multiplication.
 //!     Uses ``blas-src`` for pluggable backend, which needs to be configured
-//!     separately.
+//!     separately (see the README).
 //!
 //! ## Documentation
 //!
@@ -1593,6 +1589,8 @@ where
 }
 
 // parallel methods
+#[cfg(feature = "rayon")]
+extern crate rayon_ as rayon;
 #[cfg(feature = "rayon")]
 pub mod parallel;
 

--- a/src/linalg/impl_linalg.rs
+++ b/src/linalg/impl_linalg.rs
@@ -19,7 +19,7 @@ use std::cmp;
 #[cfg(feature = "blas")]
 use std::mem::swap;
 #[cfg(feature = "blas")]
-use std::os::raw::c_int;
+use libc::c_int;
 
 #[cfg(feature = "blas")]
 use cblas_sys as blas_sys;

--- a/src/linalg_traits.rs
+++ b/src/linalg_traits.rs
@@ -5,13 +5,19 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-use crate::ScalarOperand;
+
 #[cfg(feature = "std")]
 use num_traits::Float;
 use num_traits::{One, Zero};
+
+#[cfg(feature = "std")]
 use std::fmt;
 use std::ops::{Add, Div, Mul, Sub};
+#[cfg(feature = "std")]
 use std::ops::{AddAssign, DivAssign, MulAssign, RemAssign, SubAssign};
+
+#[cfg(feature = "std")]
+use crate::ScalarOperand;
 
 /// Elements that support linear algebra operations.
 ///

--- a/src/stacking.rs
+++ b/src/stacking.rs
@@ -5,7 +5,7 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-use alloc::vec::Vec;
+
 use crate::error::{from_kind, ErrorKind, ShapeError};
 use crate::imp_prelude::*;
 use crate::traversal_utils::assign_to;


### PR DESCRIPTION
rayon: implies std, because threads do.
serde: works fine without std.
blas: works fine without std if we use libc (libc is a new dependency
for this feature flag, but it's already used by blas transitively).

A slight hack is used for rayon (renaming the dependency) because we
need to use a feature flag to enable std in this crate too.