### PR TITLE
Scalar + &array and &array + scalar performance improvements

### DIFF
--- a/benches/bench1.rs
+++ b/benches/bench1.rs
@@ -432,6 +432,22 @@ fn scalar_add_2(bench: &mut test::Bencher) {
 }
 
 #[bench]
+fn scalar_add_strided_1(bench: &mut test::Bencher) {
+    let a =
+        Array::from_shape_fn((64, 64 * 2), |(i, j)| (i * 64 + j) as f32).slice_move(s![.., ..;2]);
+    let n = 1.;
+    bench.iter(|| &a + n);
+}
+
+#[bench]
+fn scalar_add_strided_2(bench: &mut test::Bencher) {
+    let a =
+        Array::from_shape_fn((64, 64 * 2), |(i, j)| (i * 64 + j) as f32).slice_move(s![.., ..;2]);
+    let n = 1.;
+    bench.iter(|| n + &a);
+}
+
+#[bench]
 fn scalar_sub_1(bench: &mut test::Bencher) {
     let a = Array::<f32, _>::zeros((64, 64));
     let n = 1.;

--- a/src/impl_ops.rs
+++ b/src/impl_ops.rs
@@ -159,8 +159,8 @@ impl<'a, A, S, D, B> $trt<B> for &'a ArrayBase<S, D>
           B: ScalarOperand,
 {
     type Output = Array<A, D>;
-    fn $mth(self, x: B) -> Array<A, D> {
-        self.to_owned().$mth(x)
+    fn $mth(self, x: B) -> Self::Output {
+        self.map(move |elt| elt.clone() $operator x.clone())
     }
 }
     );
@@ -210,11 +210,11 @@ impl<'a, S, D> $trt<&'a ArrayBase<S, D>> for $scalar
           D: Dimension,
 {
     type Output = Array<$scalar, D>;
-    fn $mth(self, rhs: &ArrayBase<S, D>) -> Array<$scalar, D> {
+    fn $mth(self, rhs: &ArrayBase<S, D>) -> Self::Output {
         if_commutative!($commutative {
             rhs.$mth(self)
         } or {
-            self.$mth(rhs.to_owned())
+            rhs.map(move |elt| self.clone() $operator elt.clone())
         })
     }
 }


### PR DESCRIPTION
This incorporates the benchmark and performance improvements from #782 by @jturner314, without
the applicable types changes (since they run into some rustc bugs at the moment). Jim Turner is
the author of this, I've only edited the commits to the changes we can integrate now.

@jturner314 writes: 

* The new implementation avoids cloning the elements twice, and it
  avoids iterating over the elements twice. (The old implementation
  called `.to_owned()` followed by the arithmetic operation, while the
  new implementation clones the elements and performs the arithmetic
  operation in the same iteration.)

On my machine, this change improves the performance for both
contiguous and discontiguous arrays. (`scalar_add_1/2` go from ~530
ns/iter to ~380 ns/iter, and `scalar_add_strided_1/2` go from ~1540
ns/iter to ~1420 ns/iter.)