### PR TITLE
Update blas-src dep to 0.7.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ approx = { version = "0.4", optional = true , default-features = false }
 
 # Use via the `blas` crate feature!
 cblas-sys = { version = "0.1.4", optional = true, default-features = false }
-blas-src = { version = "0.6.1", optional = true, default-features = false }
+blas-src = { version = "0.7.0", optional = true, default-features = false }
 libc = { version = "0.2.82", optional = true }
 
 matrixmultiply = { version = "0.3.0", default-features = false}

--- a/README.rst
+++ b/README.rst
@@ -86,14 +86,14 @@ How to use with cargo
 
 How to enable blas integration. Depend on ``blas-src`` directly to pick a blas
 provider. Depend on the same ``blas-src`` version as ``ndarray`` does, for the
-selection to work.  A proposed configuration using system openblas is shown
+selection to work.  An example configuration using system openblas is shown
 below. Note that only end-user projects (not libraries) should select
 provider::
 
 
     [dependencies]
     ndarray = { version = "0.14.0", features = ["blas"] }
-    blas-src = { version = "0.6.1", default-features = false, features = ["openblas"] }
+    blas-src = { version = "0.7.0", default-features = false, features = ["openblas"] }
     openblas-src = { version = "0.9", default-features = false, features = ["cblas", "system"] }
 
 For official releases of ``ndarray``, the versions are:
@@ -101,10 +101,11 @@ For official releases of ``ndarray``, the versions are:
 =========== ============ ================
 ``ndarray`` ``blas-src`` ``openblas-src``
 =========== ============ ================
-0.14.0      0.6.1        0.9.0
-0.13.0      0.2.0        0.6.0
-0.12.\*     0.2.0        0.6.0
-0.11.\*     0.1.2        0.5.0
+0.15        0.7.0        0.9.0
+0.14        0.6.1        0.9.0
+0.13        0.2.0        0.6.0
+0.12        0.2.0        0.6.0
+0.11        0.1.2        0.5.0
 =========== ============ ================
 
 Recent Changes

--- a/blas-tests/Cargo.toml
+++ b/blas-tests/Cargo.toml
@@ -10,7 +10,7 @@ test = false
 [dev-dependencies]
 approx = "0.4"
 ndarray = { path = "../", features = ["approx", "blas"] }
-blas-src = { version = "0.6.1", default-features = false, features = ["openblas"] }
+blas-src = { version = "0.7.0", default-features = false, features = ["openblas"] }
 openblas-src = { version = "0.9.0", default-features = false, features = ["cblas", "system"] }
 defmac = "0.2"
 num-traits = "0.2"


### PR DESCRIPTION
Blas-src has already graduated to another major version, so we update this for the next ndarray.