### PR TITLE
Fix to_shared to avoid cloning when it is already ArcArray

### DIFF
--- a/src/data_traits.rs
+++ b/src/data_traits.rs
@@ -96,6 +96,15 @@ pub unsafe trait Data: RawData {
     where
         Self::Elem: Clone,
         D: Dimension;
+
+    fn to_share<D>(self_: &ArrayBase<Self, D>) -> ArrayBase<OwnedArcRepr<Self::Elem>, D>
+    where
+        Self::Elem: Clone,
+        D: Dimension,
+    {
+        // clone to shared
+        self_.to_owned().into_shared()
+    }
 }
 
 /// Array representation trait.
@@ -236,6 +245,20 @@ unsafe impl<A> Data for OwnedArcRepr<A> {
             ptr: self_.ptr,
             dim: self_.dim,
             strides: self_.strides,
+        }
+    }
+
+    fn to_share<D>(self_: &ArrayBase<Self, D>) -> ArrayBase<OwnedArcRepr<Self::Elem>, D>
+    where
+        Self::Elem: Clone,
+        D: Dimension,
+    {
+        // to shared using clone of OwnedArcRepr without clone of raw data.
+        ArrayBase {
+            data: self_.data.clone(),
+            ptr: self_.ptr,
+            dim: self_.dim.clone(),
+            strides: self_.strides.clone(),
         }
     }
 }

--- a/src/data_traits.rs
+++ b/src/data_traits.rs
@@ -97,7 +97,10 @@ pub unsafe trait Data: RawData {
         Self::Elem: Clone,
         D: Dimension;
 
-    fn to_share<D>(self_: &ArrayBase<Self, D>) -> ArrayBase<OwnedArcRepr<Self::Elem>, D>
+    /// Return a shared ownership (copy on write) array based on the existing one,
+    /// cloning elements if necessary.
+    #[doc(hidden)]
+    fn to_shared<D>(self_: &ArrayBase<Self, D>) -> ArrayBase<OwnedArcRepr<Self::Elem>, D>
     where
         Self::Elem: Clone,
         D: Dimension,
@@ -248,18 +251,13 @@ unsafe impl<A> Data for OwnedArcRepr<A> {
         }
     }
 
-    fn to_share<D>(self_: &ArrayBase<Self, D>) -> ArrayBase<OwnedArcRepr<Self::Elem>, D>
+    fn to_shared<D>(self_: &ArrayBase<Self, D>) -> ArrayBase<OwnedArcRepr<Self::Elem>, D>
     where
         Self::Elem: Clone,
         D: Dimension,
     {
         // to shared using clone of OwnedArcRepr without clone of raw data.
-        ArrayBase {
-            data: self_.data.clone(),
-            ptr: self_.ptr,
-            dim: self_.dim.clone(),
-            strides: self_.strides.clone(),
-        }
+        self_.clone()
     }
 }
 

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -221,7 +221,7 @@ where
         A: Clone,
         S: Data,
     {
-        S::to_share(self)
+        S::to_shared(self)
     }
 
     /// Turn the array into a uniquely owned array, cloning the array elements

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -214,14 +214,14 @@ where
         }
     }
 
-    /// Return a shared ownership (copy on write) array.
+    /// Return a shared ownership (copy on write) array, cloning the array
+    /// elements if necessary.
     pub fn to_shared(&self) -> ArcArray<A, D>
     where
         A: Clone,
         S: Data,
     {
-        // FIXME: Avoid copying if it’s already an ArcArray.
-        self.to_owned().into_shared()
+        S::to_share(self)
     }
 
     /// Turn the array into a uniquely owned array, cloning the array elements

--- a/src/linalg_traits.rs
+++ b/src/linalg_traits.rs
@@ -15,10 +15,8 @@ use std::fmt;
 use std::ops::{Add, Div, Mul, Sub};
 #[cfg(feature = "std")]
 use std::ops::{AddAssign, DivAssign, MulAssign, RemAssign, SubAssign};
-
 #[cfg(feature = "std")]
 use crate::ScalarOperand;
-
 /// Elements that support linear algebra operations.
 ///
 /// `'static` for type-based specialization, `Copy` so that they don't need move

--- a/src/linalg_traits.rs
+++ b/src/linalg_traits.rs
@@ -15,8 +15,10 @@ use std::fmt;
 use std::ops::{Add, Div, Mul, Sub};
 #[cfg(feature = "std")]
 use std::ops::{AddAssign, DivAssign, MulAssign, RemAssign, SubAssign};
+
 #[cfg(feature = "std")]
 use crate::ScalarOperand;
+
 /// Elements that support linear algebra operations.
 ///
 /// `'static` for type-based specialization, `Copy` so that they don't need move


### PR DESCRIPTION
From FIXME in to_shared. The current implementation simply calls to_owned().into_shared(), so cloning cannot be avoided when the array is already ArcArray. 
So use to_owned().shared() in a method of Data trait (just like into_owned()) and add a default implementation to it, which will not affect the existing structure. Then modify its implementation in OwnedArcRepr, which implements the Data trait, to avoid cloning when the array is already ArcArray.