### PR TITLE
Rename Zip::apply to for_each including other apply methods

### DIFF
--- a/examples/sort-axis.rs
+++ b/examples/sort-axis.rs
@@ -112,7 +112,7 @@ where
                 let perm_i = perm.indices[i];
                 Zip::from(result.index_axis_mut(axis, perm_i))
                     .and(self.index_axis(axis, i))
-                    .apply(|to, from| {
+                    .for_each(|to, from| {
                         copy_nonoverlapping(from, to.as_mut_ptr(), 1);
                         moved_elements += 1;
                     });

--- a/examples/zip_many.rs
+++ b/examples/zip_many.rs
@@ -41,11 +41,11 @@ fn main() {
     // Let's imagine we split to parallelize
     {
         let (x, y) = Zip::indexed(&mut a).split();
-        x.apply(|(_, j), elt| {
+        x.for_each(|(_, j), elt| {
             *elt = elt.powi(j as i32);
         });
 
-        y.apply(|(_, j), elt| {
+        y.for_each(|(_, j), elt| {
             *elt = elt.powi(j as i32);
         });
     }

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -1985,7 +1985,7 @@ where
         let dim = self.raw_dim();
         Zip::from(LanesMut::new(self.view_mut(), Axis(n - 1)))
             .and(Lanes::new(rhs.broadcast_assume(dim), Axis(n - 1)))
-            .apply(move |s_row, r_row| Zip::from(s_row).and(r_row).apply(|a, b| f(a, b)));
+            .for_each(move |s_row, r_row| Zip::from(s_row).and(r_row).for_each(|a, b| f(a, b)));
     }
 
     fn zip_mut_with_elem<B, F>(&mut self, rhs_elem: &B, mut f: F)
@@ -2343,7 +2343,7 @@ where
         prev.slice_axis_inplace(axis, Slice::from(..-1));
         curr.slice_axis_inplace(axis, Slice::from(1..));
         // This implementation relies on `Zip` iterating along `axis` in order.
-        Zip::from(prev).and(curr).apply(|prev, curr| unsafe {
+        Zip::from(prev).and(curr).for_each(|prev, curr| unsafe {
             // These pointer dereferences and borrows are safe because:
             //
             // 1. They're pointers to elements in the array.

--- a/src/linalg/impl_linalg.rs
+++ b/src/linalg/impl_linalg.rs
@@ -679,11 +679,11 @@ unsafe fn general_mat_vec_mul_impl<A, S1, S2>(
 
         if beta.is_zero() {
             // when beta is zero, c may be uninitialized
-            Zip::from(a.outer_iter()).and(y).apply(|row, elt| {
+            Zip::from(a.outer_iter()).and(y).for_each(|row, elt| {
                 elt.write(row.dot(x) * alpha);
             });
         } else {
-            Zip::from(a.outer_iter()).and(y).apply(|row, elt| {
+            Zip::from(a.outer_iter()).and(y).for_each(|row, elt| {
                 *elt = *elt * beta + row.dot(x) * alpha;
             });
         }

--- a/src/parallel/impl_par_methods.rs
+++ b/src/parallel/impl_par_methods.rs
@@ -59,12 +59,25 @@ macro_rules! zip_impl {
                   D: Dimension,
                   $($p: NdProducer<Dim=D> ,)*
         {
+            /// The `par_for_each` method for `Zip`.
+            ///
+            /// This is a shorthand for using `.into_par_iter().for_each()` on
+            /// `Zip`.
+            ///
+            /// Requires crate feature `rayon`.
+            pub fn par_for_each<F>(self, function: F)
+                where F: Fn($($p::Item),*) + Sync + Send
+            {
+                self.into_par_iter().for_each(move |($($p,)*)| function($($p),*))
+            }
+
             /// The `par_apply` method for `Zip`.
             ///
             /// This is a shorthand for using `.into_par_iter().for_each()` on
             /// `Zip`.
             ///
             /// Requires crate feature `rayon`.
+            #[deprecated(note="Renamed to .par_for_each()", since="0.15.0")]
             pub fn par_apply<F>(self, function: F)
                 where F: Fn($($p::Item),*) + Sync + Send
             {
@@ -133,7 +146,7 @@ macro_rules! zip_impl {
                       Q::Output: Send,
             {
                 self.and(into)
-                    .par_apply(move |$($p, )* output_| {
+                    .par_for_each(move |$($p, )* output_| {
                         output_.assign_elem(f($($p ),*));
                     });
             }

--- a/src/parallel/impl_par_methods.rs
+++ b/src/parallel/impl_par_methods.rs
@@ -86,11 +86,11 @@ macro_rules! zip_impl {
 
             expand_if!(@bool [$notlast]
 
-            /// Apply and collect the results into a new array, which has the same size as the
+            /// Map and collect the results into a new array, which has the same size as the
             /// inputs.
             ///
             /// If all inputs are c- or f-order respectively, that is preserved in the output.
-            pub fn par_apply_collect<R>(self, f: impl Fn($($p::Item,)* ) -> R + Sync + Send)
+            pub fn par_map_collect<R>(self, f: impl Fn($($p::Item,)* ) -> R + Sync + Send)
                 -> Array<R, D>
                 where R: Send
             {
@@ -135,12 +135,24 @@ macro_rules! zip_impl {
                 }
             }
 
-            /// Apply and assign the results into the producer `into`, which should have the same
+            /// Map and collect the results into a new array, which has the same size as the
+            /// inputs.
+            ///
+            /// If all inputs are c- or f-order respectively, that is preserved in the output.
+            #[deprecated(note="Renamed to .par_map_collect()", since="0.15.0")]
+            pub fn par_apply_collect<R>(self, f: impl Fn($($p::Item,)* ) -> R + Sync + Send)
+                -> Array<R, D>
+                where R: Send
+            {
+                self.par_map_collect(f)
+            }
+
+            /// Map and assign the results into the producer `into`, which should have the same
             /// size as the other inputs.
             ///
             /// The producer should have assignable items as dictated by the `AssignElem` trait,
             /// for example `&mut R`.
-            pub fn par_apply_assign_into<R, Q>(self, into: Q, f: impl Fn($($p::Item,)* ) -> R + Sync + Send)
+            pub fn par_map_assign_into<R, Q>(self, into: Q, f: impl Fn($($p::Item,)* ) -> R + Sync + Send)
                 where Q: IntoNdProducer<Dim=D>,
                       Q::Item: AssignElem<R> + Send,
                       Q::Output: Send,
@@ -150,6 +162,21 @@ macro_rules! zip_impl {
                         output_.assign_elem(f($($p ),*));
                     });
             }
+
+            /// Apply and assign the results into the producer `into`, which should have the same
+            /// size as the other inputs.
+            ///
+            /// The producer should have assignable items as dictated by the `AssignElem` trait,
+            /// for example `&mut R`.
+            #[deprecated(note="Renamed to .par_map_assign_into()", since="0.15.0")]
+            pub fn par_apply_assign_into<R, Q>(self, into: Q, f: impl Fn($($p::Item,)* ) -> R + Sync + Send)
+                where Q: IntoNdProducer<Dim=D>,
+                      Q::Item: AssignElem<R> + Send,
+                      Q::Output: Send,
+            {
+                self.par_map_assign_into(into, f)
+            }
+
             );
         }
         )+

--- a/src/parallel/zipmacro.rs
+++ b/src/parallel/zipmacro.rs
@@ -24,7 +24,7 @@
 /// Is equivalent to:
 ///
 /// ```rust,ignore
-/// Zip::from(&mut a).and(&b).and(&c).par_apply(|a, &b, &c| {
+/// Zip::from(&mut a).and(&b).and(&c).par_for_each(|a, &b, &c| {
 ///     *a = b + c;
 /// });
 /// ```
@@ -54,6 +54,6 @@
 /// ```
 macro_rules! par_azip {
     ($($t:tt)*) => {
-        $crate::azip!(@build par_apply $($t)*)
+        $crate::azip!(@build par_for_each $($t)*)
     };
 }

--- a/src/traversal_utils.rs
+++ b/src/traversal_utils.rs
@@ -21,6 +21,6 @@ pub(crate) fn assign_to<'a, P1, P2, A>(from: P1, to: P2)
           A: Clone + 'a
 {
     Zip::from(from)
-        .apply_assign_into(to, A::clone);
+        .map_assign_into(to, A::clone);
 }
 

--- a/src/zip/mod.rs
+++ b/src/zip/mod.rs
@@ -1074,12 +1074,11 @@ macro_rules! map_impl {
                 }
             }
 
-            /// Apply and collect the results into a new array, which has the same size as the
+            /// Map and collect the results into a new array, which has the same size as the
             /// inputs.
             ///
             /// If all inputs are c- or f-order respectively, that is preserved in the output.
-            pub fn apply_collect<R>(self, f: impl FnMut($($p::Item,)* ) -> R) -> Array<R, D>
-            {
+            pub fn map_collect<R>(self, f: impl FnMut($($p::Item,)* ) -> R) -> Array<R, D> {
                 // Make uninit result
                 let mut output = self.uninitalized_for_current_layout::<R>();
 
@@ -1095,12 +1094,21 @@ macro_rules! map_impl {
                 }
             }
 
-            /// Apply and assign the results into the producer `into`, which should have the same
+            /// Map and collect the results into a new array, which has the same size as the
+            /// inputs.
+            ///
+            /// If all inputs are c- or f-order respectively, that is preserved in the output.
+            #[deprecated(note="Renamed to .map_collect()", since="0.15.0")]
+            pub fn apply_collect<R>(self, f: impl FnMut($($p::Item,)* ) -> R) -> Array<R, D> {
+                self.map_collect(f)
+            }
+
+            /// Map and assign the results into the producer `into`, which should have the same
             /// size as the other inputs.
             ///
             /// The producer should have assignable items as dictated by the `AssignElem` trait,
             /// for example `&mut R`.
-            pub fn apply_assign_into<R, Q>(self, into: Q, mut f: impl FnMut($($p::Item,)* ) -> R)
+            pub fn map_assign_into<R, Q>(self, into: Q, mut f: impl FnMut($($p::Item,)* ) -> R)
                 where Q: IntoNdProducer<Dim=D>,
                       Q::Item: AssignElem<R>
             {
@@ -1108,6 +1116,19 @@ macro_rules! map_impl {
                     .for_each(move |$($p, )* output_| {
                         output_.assign_elem(f($($p ),*));
                     });
+            }
+
+            /// Map and assign the results into the producer `into`, which should have the same
+            /// size as the other inputs.
+            ///
+            /// The producer should have assignable items as dictated by the `AssignElem` trait,
+            /// for example `&mut R`.
+            #[deprecated(note="Renamed to .map_assign_into()", since="0.15.0")]
+            pub fn apply_assign_into<R, Q>(self, into: Q, f: impl FnMut($($p::Item,)* ) -> R)
+                where Q: IntoNdProducer<Dim=D>,
+                      Q::Item: AssignElem<R>
+            {
+                self.map_assign_into(into, f)
             }
 
 

--- a/src/zip/zipmacro.rs
+++ b/src/zip/zipmacro.rs
@@ -12,7 +12,7 @@
 /// Is equivalent to:
 ///
 /// ```rust,ignore
-/// Zip::from(&mut a).and(&b).and(&c).apply(|a, &b, &c| {
+/// Zip::from(&mut a).and(&b).and(&c).for_each(|a, &b, &c| {
 ///     *a = b + c
 /// });
 /// ```
@@ -27,8 +27,8 @@
 ///
 /// The *expr* are expressions whose types must implement `IntoNdProducer`, the
 /// *pat* are the patterns of the parameters to the closure called by
-/// `Zip::apply`, and *body_expr* is the body of the closure called by
-/// `Zip::apply`. You can think of each *pat* `in` *expr* as being analogous to
+/// `Zip::for_each`, and *body_expr* is the body of the closure called by
+/// `Zip::for_each`. You can think of each *pat* `in` *expr* as being analogous to
 /// the `pat in expr` of a normal loop `for pat in expr { statements }`: a
 /// pattern, followed by `in`, followed by an expression that implements
 /// `IntoNdProducer` (analogous to `IntoIterator` for a `for` loop).
@@ -129,6 +129,6 @@ macro_rules! azip {
     // catch-all rule
     (@build $($t:tt)*) => { compile_error!("Invalid syntax in azip!()") };
     ($($t:tt)*) => {
-        $crate::azip!(@build apply $($t)*)
+        $crate::azip!(@build for_each $($t)*)
     };
 }

--- a/tests/array-construct.rs
+++ b/tests/array-construct.rs
@@ -231,12 +231,12 @@ fn maybe_uninit_1() {
         let mut a = Mat::maybe_uninit((10, 10));
         let v = a.raw_view_mut();
         Zip::from(v)
-            .apply(|ptr| *(*ptr).as_mut_ptr() = 1.);
+            .for_each(|ptr| *(*ptr).as_mut_ptr() = 1.);
 
         let u = a.raw_view_mut().assume_init();
 
         Zip::from(u)
-            .apply(|ptr| assert_eq!(*ptr, 1.));
+            .for_each(|ptr| assert_eq!(*ptr, 1.));
 
     }
 }

--- a/tests/azip.rs
+++ b/tests/azip.rs
@@ -243,7 +243,7 @@ fn test_broadcast() {
             .and_broadcast(&b)
             .and_broadcast(&d)
             .and_broadcast(&e);
-        z.apply(|x, &y, &z, &w| *x = y + z + w);
+        z.for_each(|x, &y, &z, &w| *x = y + z + w);
     }
     let sum = &b + &d + &e;
     assert_abs_diff_eq!(a, sum.broadcast((n, n)).unwrap(), epsilon = 1e-4);
@@ -293,11 +293,11 @@ fn test_clone() {
     let z = Zip::from(&a).and(a.exact_chunks((1, 1, 1)));
     let w = z.clone();
     let mut result = Vec::new();
-    z.apply(|x, y| {
+    z.for_each(|x, y| {
         result.push((x, y));
     });
     let mut i = 0;
-    w.apply(|x, y| {
+    w.for_each(|x, y| {
         assert_eq!(result[i], (x, y));
         i += 1;
     });
@@ -324,7 +324,7 @@ fn test_indices_1() {
     }
 
     let mut count = 0;
-    Zip::indexed(&a1).apply(|i, elt| {
+    Zip::indexed(&a1).for_each(|i, elt| {
         count += 1;
         assert_eq!(*elt, i);
     });
@@ -334,12 +334,12 @@ fn test_indices_1() {
     let len = a1.len();
     let (x, y) = Zip::indexed(&mut a1).split();
 
-    x.apply(|i, elt| {
+    x.for_each(|i, elt| {
         count += 1;
         assert_eq!(*elt, i);
     });
     assert_eq!(count, len / 2);
-    y.apply(|i, elt| {
+    y.for_each(|i, elt| {
         count += 1;
         assert_eq!(*elt, i);
     });
@@ -364,12 +364,12 @@ fn test_indices_2() {
     let len = a1.len();
     let (x, y) = Zip::indexed(&mut a1).split();
 
-    x.apply(|i, elt| {
+    x.for_each(|i, elt| {
         count += 1;
         assert_eq!(*elt, i);
     });
     assert_eq!(count, len / 2);
-    y.apply(|i, elt| {
+    y.for_each(|i, elt| {
         count += 1;
         assert_eq!(*elt, i);
     });
@@ -384,7 +384,7 @@ fn test_indices_3() {
     }
 
     let mut count = 0;
-    Zip::indexed(&a1).apply(|i, elt| {
+    Zip::indexed(&a1).for_each(|i, elt| {
         count += 1;
         assert_eq!(*elt, i);
     });
@@ -394,12 +394,12 @@ fn test_indices_3() {
     let len = a1.len();
     let (x, y) = Zip::indexed(&mut a1).split();
 
-    x.apply(|i, elt| {
+    x.for_each(|i, elt| {
         count += 1;
         assert_eq!(*elt, i);
     });
     assert_eq!(count, len / 2);
-    y.apply(|i, elt| {
+    y.for_each(|i, elt| {
         count += 1;
         assert_eq!(*elt, i);
     });
@@ -418,12 +418,12 @@ fn test_indices_split_1() {
             let mut seen = Vec::new();
 
             let mut ac = 0;
-            a.apply(|i, _| {
+            a.for_each(|i, _| {
                 ac += 1;
                 seen.push(i);
             });
             let mut bc = 0;
-            b.apply(|i, _| {
+            b.for_each(|i, _| {
                 bc += 1;
                 seen.push(i);
             });

--- a/tests/azip.rs
+++ b/tests/azip.rs
@@ -54,13 +54,13 @@ fn test_azip2_3() {
 fn test_zip_collect() {
     use approx::assert_abs_diff_eq;
 
-    // test Zip::apply_collect and that it preserves c/f layout.
+    // test Zip::map_collect and that it preserves c/f layout.
 
     let b = Array::from_shape_fn((5, 10), |(i, j)| 1. / (i + 2 * j + 1) as f32);
     let c = Array::from_shape_fn((5, 10), |(i, j)| f32::exp((i + j) as f32));
 
     {
-        let a = Zip::from(&b).and(&c).apply_collect(|x, y| x + y);
+        let a = Zip::from(&b).and(&c).map_collect(|x, y| x + y);
 
         assert_abs_diff_eq!(a, &b + &c, epsilon = 1e-6);
         assert_eq!(a.strides(), b.strides());
@@ -70,7 +70,7 @@ fn test_zip_collect() {
         let b = b.t();
         let c = c.t();
 
-        let a = Zip::from(&b).and(&c).apply_collect(|x, y| x + y);
+        let a = Zip::from(&b).and(&c).map_collect(|x, y| x + y);
 
         assert_abs_diff_eq!(a, &b + &c, epsilon = 1e-6);
         assert_eq!(a.strides(), b.strides());
@@ -86,7 +86,7 @@ fn test_zip_assign_into() {
     let b = Array::from_shape_fn((5, 10), |(i, j)| 1. / (i + 2 * j + 1) as f32);
     let c = Array::from_shape_fn((5, 10), |(i, j)| f32::exp((i + j) as f32));
 
-    Zip::from(&b).and(&c).apply_assign_into(&mut a, |x, y| x + y);
+    Zip::from(&b).and(&c).map_assign_into(&mut a, |x, y| x + y);
 
     assert_abs_diff_eq!(a, &b + &c, epsilon = 1e-6);
 }
@@ -101,7 +101,7 @@ fn test_zip_assign_into_cell() {
     let b = Array::from_shape_fn((5, 10), |(i, j)| 1. / (i + 2 * j + 1) as f32);
     let c = Array::from_shape_fn((5, 10), |(i, j)| f32::exp((i + j) as f32));
 
-    Zip::from(&b).and(&c).apply_assign_into(&a, |x, y| x + y);
+    Zip::from(&b).and(&c).map_assign_into(&a, |x, y| x + y);
     let a2 = a.mapv(|elt| elt.get());
 
     assert_abs_diff_eq!(a2, &b + &c, epsilon = 1e-6);
@@ -154,7 +154,7 @@ fn test_zip_collect_drop() {
         }
 
         let _result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
-            Zip::from(&a).and(&b).apply_collect(|&elt, _| {
+            Zip::from(&a).and(&b).map_collect(|&elt, _| {
                 if elt.0 > 3 && will_panic {
                     panic!();
                 }
@@ -308,7 +308,7 @@ fn test_indices_0() {
     let a1 = arr0(3);
 
     let mut count = 0;
-    Zip::indexed(&a1).apply(|i, elt| {
+    Zip::indexed(&a1).for_each(|i, elt| {
         count += 1;
         assert_eq!(i, ());
         assert_eq!(*elt, 3);

--- a/tests/iterators.rs
+++ b/tests/iterators.rs
@@ -308,7 +308,7 @@ fn axis_iter_zip() {
     let a = Array::from_iter(0..5);
     let iter = a.axis_iter(Axis(0));
     let mut b = Array::zeros(5);
-    Zip::from(&mut b).and(iter).apply(|b, a| *b = a[()]);
+    Zip::from(&mut b).and(iter).for_each(|b, a| *b = a[()]);
     assert_eq!(a, b);
 }
 
@@ -320,7 +320,7 @@ fn axis_iter_zip_partially_consumed() {
     while iter.next().is_some() {
         consumed += 1;
         let mut b = Array::zeros(a.len() - consumed);
-        Zip::from(&mut b).and(iter.clone()).apply(|b, a| *b = a[()]);
+        Zip::from(&mut b).and(iter.clone()).for_each(|b, a| *b = a[()]);
         assert_eq!(a.slice(s![consumed..]), b);
     }
 }
@@ -334,7 +334,7 @@ fn axis_iter_zip_partially_consumed_discontiguous() {
         consumed += 1;
         let mut b = Array::zeros((a.len() - consumed) * 2);
         b.slice_collapse(s![..;2]);
-        Zip::from(&mut b).and(iter.clone()).apply(|b, a| *b = a[()]);
+        Zip::from(&mut b).and(iter.clone()).for_each(|b, a| *b = a[()]);
         assert_eq!(a.slice(s![consumed..]), b);
     }
 }
@@ -487,7 +487,7 @@ fn axis_iter_mut_zip() {
     let mut cloned = orig.clone();
     let iter = cloned.axis_iter_mut(Axis(0));
     let mut b = Array::zeros(5);
-    Zip::from(&mut b).and(iter).apply(|b, mut a| {
+    Zip::from(&mut b).and(iter).for_each(|b, mut a| {
         a[()] += 1;
         *b = a[()];
     });
@@ -505,7 +505,7 @@ fn axis_iter_mut_zip_partially_consumed() {
             iter.next();
         }
         let mut b = Array::zeros(remaining);
-        Zip::from(&mut b).and(iter).apply(|b, a| *b = a[()]);
+        Zip::from(&mut b).and(iter).for_each(|b, a| *b = a[()]);
         assert_eq!(a.slice(s![consumed..]), b);
     }
 }
@@ -521,7 +521,7 @@ fn axis_iter_mut_zip_partially_consumed_discontiguous() {
         }
         let mut b = Array::zeros(remaining * 2);
         b.slice_collapse(s![..;2]);
-        Zip::from(&mut b).and(iter).apply(|b, a| *b = a[()]);
+        Zip::from(&mut b).and(iter).for_each(|b, a| *b = a[()]);
         assert_eq!(a.slice(s![consumed..]), b);
     }
 }

--- a/tests/par_zip.rs
+++ b/tests/par_zip.rs
@@ -11,14 +11,14 @@ const N: usize = 100;
 fn test_zip_1() {
     let mut a = Array2::<f64>::zeros((M, N));
 
-    Zip::from(&mut a).par_apply(|x| *x = x.exp());
+    Zip::from(&mut a).par_for_each(|x| *x = x.exp());
 }
 
 #[test]
 fn test_zip_index_1() {
     let mut a = Array2::default((10, 10));
 
-    Zip::indexed(&mut a).par_apply(|i, x| {
+    Zip::indexed(&mut a).par_for_each(|i, x| {
         *x = i;
     });
 
@@ -31,7 +31,7 @@ fn test_zip_index_1() {
 fn test_zip_index_2() {
     let mut a = Array2::default((M, N));
 
-    Zip::indexed(&mut a).par_apply(|i, x| {
+    Zip::indexed(&mut a).par_for_each(|i, x| {
         *x = i;
     });
 
@@ -44,7 +44,7 @@ fn test_zip_index_2() {
 fn test_zip_index_3() {
     let mut a = Array::default((1, 2, 1, 2, 3));
 
-    Zip::indexed(&mut a).par_apply(|i, x| {
+    Zip::indexed(&mut a).par_for_each(|i, x| {
         *x = i;
     });
 
@@ -58,7 +58,7 @@ fn test_zip_index_4() {
     let mut a = Array2::zeros((M, N));
     let mut b = Array2::zeros((M, N));
 
-    Zip::indexed(&mut a).and(&mut b).par_apply(|(i, j), x, y| {
+    Zip::indexed(&mut a).and(&mut b).par_for_each(|(i, j), x, y| {
         *x = i;
         *y = j;
     });

--- a/tests/par_zip.rs
+++ b/tests/par_zip.rs
@@ -82,7 +82,7 @@ fn test_zip_collect() {
     let c = Array::from_shape_fn((M, N), |(i, j)| f32::ln((1 + i + j) as f32));
 
     {
-        let a = Zip::from(&b).and(&c).par_apply_collect(|x, y| x + y);
+        let a = Zip::from(&b).and(&c).par_map_collect(|x, y| x + y);
 
         assert_abs_diff_eq!(a, &b + &c, epsilon = 1e-6);
         assert_eq!(a.strides(), b.strides());
@@ -92,7 +92,7 @@ fn test_zip_collect() {
         let b = b.t();
         let c = c.t();
 
-        let a = Zip::from(&b).and(&c).par_apply_collect(|x, y| x + y);
+        let a = Zip::from(&b).and(&c).par_map_collect(|x, y| x + y);
 
         assert_abs_diff_eq!(a, &b + &c, epsilon = 1e-6);
         assert_eq!(a.strides(), b.strides());
@@ -112,7 +112,7 @@ fn test_zip_small_collect() {
             let c = Array::from_shape_fn(dim, |(i, j)| f32::ln((1 + i + j) as f32));
 
             {
-                let a = Zip::from(&b).and(&c).par_apply_collect(|x, y| x + y);
+                let a = Zip::from(&b).and(&c).par_map_collect(|x, y| x + y);
 
                 assert_abs_diff_eq!(a, &b + &c, epsilon = 1e-6);
                 assert_eq!(a.strides(), b.strides());
@@ -130,7 +130,7 @@ fn test_zip_assign_into() {
     let b = Array::from_shape_fn((M, N), |(i, j)| 1. / (i + 2 * j + 1) as f32);
     let c = Array::from_shape_fn((M, N), |(i, j)| f32::ln((1 + i + j) as f32));
 
-    Zip::from(&b).and(&c).par_apply_assign_into(&mut a, |x, y| x + y);
+    Zip::from(&b).and(&c).par_map_assign_into(&mut a, |x, y| x + y);
 
     assert_abs_diff_eq!(a, &b + &c, epsilon = 1e-6);
 }

--- a/tests/raw_views.rs
+++ b/tests/raw_views.rs
@@ -14,7 +14,7 @@ fn raw_view_cast_cell() {
         let raw_cell_view = a.raw_view_mut().cast::<Cell<f32>>();
         let cell_view = unsafe { raw_cell_view.deref_into_view() };
 
-        Zip::from(cell_view).apply(|elt| elt.set(elt.get() + 1.));
+        Zip::from(cell_view).for_each(|elt| elt.set(elt.get() + 1.));
     }
     assert_eq!(a, answer);
 }

--- a/tests/views.rs
+++ b/tests/views.rs
@@ -10,7 +10,7 @@ fn cell_view() {
         let cv1 = a.cell_view();
         let cv2 = cv1;
 
-        Zip::from(cv1).and(cv2).apply(|a, b| a.set(b.get() + 1.));
+        Zip::from(cv1).and(cv2).for_each(|a, b| a.set(b.get() + 1.));
     }
     assert_eq!(a, answer);
 }

--- a/tests/windows.rs
+++ b/tests/windows.rs
@@ -104,7 +104,7 @@ fn test_window_zip() {
     for x in 1..4 {
         for y in 1..4 {
             for z in 1..4 {
-                Zip::indexed(a.windows((x, y, z))).apply(|(i, j, k), window| {
+                Zip::indexed(a.windows((x, y, z))).for_each(|(i, j, k), window| {
                     let x = x as isize;
                     let y = y as isize;
                     let z = z as isize;


### PR DESCRIPTION
As mentioned in #858. Use the name `Zip::for_each` which is more idiomatic than `apply`.

Renames the following and deprecates the old name:

- apply to for_each
- apply_collect to map_collect
- apply_collect_into to map_collect_into
- par_apply to par_for_each
- par_apply_collect to par_map_collect
- par_apply_collect_into to par_map_collect_into