### PR TITLE
Fix constructors when strides are negative

### DIFF
--- a/src/impl_raw_views.rs
+++ b/src/impl_raw_views.rs
@@ -1,7 +1,7 @@
 use std::mem;
 use std::ptr::NonNull;
 
-use crate::dimension::{self, stride_offset};
+use crate::dimension::{self, stride_offset, offset_from_ptr_to_memory};
 use crate::extension::nonnull::nonnull_debug_checked_from_ptr;
 use crate::imp_prelude::*;
 use crate::is_aligned;
@@ -85,7 +85,7 @@ where
             }
         }
         let strides = shape.strides.strides_for_dim(&dim);
-        RawArrayView::new_(ptr, dim, strides)
+        RawArrayView::new_(ptr.offset(-offset_from_ptr_to_memory(&dim, &strides)), dim, strides)
     }
 
     /// Converts to a read-only view of the array.
@@ -231,7 +231,7 @@ where
             }
         }
         let strides = shape.strides.strides_for_dim(&dim);
-        RawArrayViewMut::new_(ptr, dim, strides)
+        RawArrayViewMut::new_(ptr.offset(-offset_from_ptr_to_memory(&dim, &strides)), dim, strides)
     }
 
     /// Converts to a non-mutable `RawArrayView`.

--- a/src/impl_views/constructors.rs
+++ b/src/impl_views/constructors.rs
@@ -13,6 +13,7 @@ use crate::error::ShapeError;
 use crate::extension::nonnull::nonnull_debug_checked_from_ptr;
 use crate::imp_prelude::*;
 use crate::{is_aligned, StrideShape};
+use crate::dimension::offset_from_ptr_to_memory;
 
 /// Methods for read-only array views.
 impl<'a, A, D> ArrayView<'a, A, D>
@@ -55,7 +56,7 @@ where
         let dim = shape.dim;
         dimension::can_index_slice_with_strides(xs, &dim, &shape.strides)?;
         let strides = shape.strides.strides_for_dim(&dim);
-        unsafe { Ok(Self::new_(xs.as_ptr(), dim, strides)) }
+        unsafe { Ok(Self::new_(xs.as_ptr().offset(-offset_from_ptr_to_memory(&dim, &strides)), dim, strides)) }
     }
 
     /// Create an `ArrayView<A, D>` from shape information and a raw pointer to
@@ -152,7 +153,7 @@ where
         let dim = shape.dim;
         dimension::can_index_slice_with_strides(xs, &dim, &shape.strides)?;
         let strides = shape.strides.strides_for_dim(&dim);
-        unsafe { Ok(Self::new_(xs.as_mut_ptr(), dim, strides)) }
+        unsafe { Ok(Self::new_(xs.as_mut_ptr().offset(-offset_from_ptr_to_memory(&dim, &strides)), dim, strides)) }
     }
 
     /// Create an `ArrayViewMut<A, D>` from shape information and a


### PR DESCRIPTION
Some follow-up work for #885, but also some preparation work for #842.
Although we currently do not support the use of negative strides to build arrays, there may be users who write like this:

    let s = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13];
    let mut a= Array::from_shape_vec((2, 3, 2).strides(((-1isize as usize), 4, 2)),s[0..12].to_vec()).unwrap();
    println!("{:?}", a);

Bacuase of #885, this is just all right:

    [[[1, 3],
      [5, 7],
      [9, 11]],
    
     [[0, 2],
      [4, 6],
      [8, 10]]], shape=[2, 3, 2], strides=[-1, 4, 2], layout=Custom (0x0), const ndim=3

But if someone write like this:

    let s = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13];
    let mut a = ArrayView::from_shape((2, 3, 2).strides(((-1isize as usize), 4, 2)), &s).unwrap();
    println!("{:?}", a);

This will cause unpredictable consequences:

    [[[0, 2],
      [4, 6],
      [8, 10]],
    
     [[-622357902, 1],
      [3, 5],
      [7, 9]]], shape=[2, 3, 2], strides=[-1, 4, 2], layout=Custom (0x0), const ndim=3

The source of constructors with negative strides is the StrideShape trait, so I traversed the code and made corrections where StrideShape was used.