### PR TITLE
replace Zip::apply with Zip::for_each in benches and docs

### DIFF
--- a/benches/bench1.rs
+++ b/benches/bench1.rs
@@ -255,7 +255,7 @@ fn add_2d_zip(bench: &mut test::Bencher) {
     let mut a = Array::<i32, _>::zeros((ADD2DSZ, ADD2DSZ));
     let b = Array::<i32, _>::zeros((ADD2DSZ, ADD2DSZ));
     bench.iter(|| {
-        Zip::from(&mut a).and(&b).apply(|a, &b| *a += b);
+        Zip::from(&mut a).and(&b).for_each(|a, &b| *a += b);
     });
 }
 
@@ -284,7 +284,7 @@ fn add_2d_alloc_zip_collect(bench: &mut test::Bencher) {
     let a = Array::<i32, _>::zeros((ADD2DSZ, ADD2DSZ));
     let b = Array::<i32, _>::zeros((ADD2DSZ, ADD2DSZ));
     bench.iter(|| {
-        Zip::from(&a).and(&b).apply_collect(|&x, &y| x + y)
+        Zip::from(&a).and(&b).map_collect(|&x, &y| x + y)
     });
 }
 
@@ -300,7 +300,7 @@ fn vec_string_collect(bench: &mut test::Bencher) {
 fn array_string_collect(bench: &mut test::Bencher) {
     let v = Array::from(vec![""; 10240]);
     bench.iter(|| {
-        Zip::from(&v).apply_collect(|s| s.to_owned())
+        Zip::from(&v).map_collect(|s| s.to_owned())
     });
 }
 
@@ -316,7 +316,7 @@ fn vec_f64_collect(bench: &mut test::Bencher) {
 fn array_f64_collect(bench: &mut test::Bencher) {
     let v = Array::from(vec![1.; 10240]);
     bench.iter(|| {
-        Zip::from(&v).apply_collect(|s| s + 1.)
+        Zip::from(&v).map_collect(|s| s + 1.)
     });
 }
 
@@ -350,7 +350,7 @@ fn add_2d_zip_cutout(bench: &mut test::Bencher) {
     let mut acut = a.slice_mut(s![1..-1, 1..-1]);
     let b = Array::<i32, _>::zeros((ADD2DSZ, ADD2DSZ));
     bench.iter(|| {
-        Zip::from(&mut acut).and(&b).apply(|a, &b| *a += b);
+        Zip::from(&mut acut).and(&b).for_each(|a, &b| *a += b);
     });
 }
 
@@ -363,7 +363,7 @@ fn add_2d_cutouts_by_4(bench: &mut test::Bencher) {
     bench.iter(|| {
         Zip::from(a.exact_chunks_mut(chunksz))
             .and(b.exact_chunks(chunksz))
-            .apply(|mut a, b| a += &b);
+            .for_each(|mut a, b| a += &b);
     });
 }
 
@@ -376,7 +376,7 @@ fn add_2d_cutouts_by_16(bench: &mut test::Bencher) {
     bench.iter(|| {
         Zip::from(a.exact_chunks_mut(chunksz))
             .and(b.exact_chunks(chunksz))
-            .apply(|mut a, b| a += &b);
+            .for_each(|mut a, b| a += &b);
     });
 }
 
@@ -389,7 +389,7 @@ fn add_2d_cutouts_by_32(bench: &mut test::Bencher) {
     bench.iter(|| {
         Zip::from(a.exact_chunks_mut(chunksz))
             .and(b.exact_chunks(chunksz))
-            .apply(|mut a, b| a += &b);
+            .for_each(|mut a, b| a += &b);
     });
 }
 
@@ -511,7 +511,7 @@ fn add_2d_zip_strided(bench: &mut test::Bencher) {
     let mut a = a.slice_mut(s![.., ..;2]);
     let b = Array::<i32, _>::zeros((ADD2DSZ, ADD2DSZ));
     bench.iter(|| {
-        Zip::from(&mut a).and(&b).apply(|a, &b| *a += b);
+        Zip::from(&mut a).and(&b).for_each(|a, &b| *a += b);
     });
 }
 
@@ -531,7 +531,7 @@ fn add_2d_zip_one_transposed(bench: &mut test::Bencher) {
     a.swap_axes(0, 1);
     let b = Array::<i32, _>::zeros((ADD2DSZ, ADD2DSZ));
     bench.iter(|| {
-        Zip::from(&mut a).and(&b).apply(|a, &b| *a += b);
+        Zip::from(&mut a).and(&b).for_each(|a, &b| *a += b);
     });
 }
 
@@ -553,7 +553,7 @@ fn add_2d_zip_both_transposed(bench: &mut test::Bencher) {
     let mut b = Array::<i32, _>::zeros((ADD2DSZ, ADD2DSZ));
     b.swap_axes(0, 1);
     bench.iter(|| {
-        Zip::from(&mut a).and(&b).apply(|a, &b| *a += b);
+        Zip::from(&mut a).and(&b).for_each(|a, &b| *a += b);
     });
 }
 

--- a/benches/iter.rs
+++ b/benches/iter.rs
@@ -249,7 +249,7 @@ fn indexed_zip_1d_ix1(bench: &mut Bencher) {
     }
 
     bench.iter(|| {
-        Zip::indexed(&a).apply(|i, &_elt| {
+        Zip::indexed(&a).for_each(|i, &_elt| {
             black_box(i);
             //assert!(a[i] == elt);
         });
@@ -278,7 +278,7 @@ fn indexed_zip_2d_ix2(bench: &mut Bencher) {
     }
 
     bench.iter(|| {
-        Zip::indexed(&a).apply(|i, &_elt| {
+        Zip::indexed(&a).for_each(|i, &_elt| {
             black_box(i);
             //assert!(a[i] == elt);
         });
@@ -308,7 +308,7 @@ fn indexed_zip_3d_ix3(bench: &mut Bencher) {
     }
 
     bench.iter(|| {
-        Zip::indexed(&a).apply(|i, &_elt| {
+        Zip::indexed(&a).for_each(|i, &_elt| {
             black_box(i);
             //assert!(a[i] == elt);
         });

--- a/benches/par_rayon.rs
+++ b/benches/par_rayon.rs
@@ -152,7 +152,7 @@ fn vec_string_collect(bench: &mut test::Bencher) {
 fn array_string_collect(bench: &mut test::Bencher) {
     let v = Array::from_elem((COLL_STRING_N, COLL_STRING_N), "");
     bench.iter(|| {
-        Zip::from(&v).par_apply_collect(|s| s.to_owned())
+        Zip::from(&v).par_map_collect(|s| s.to_owned())
     });
 }
 
@@ -168,7 +168,7 @@ fn vec_f64_collect(bench: &mut test::Bencher) {
 fn array_f64_collect(bench: &mut test::Bencher) {
     let v = Array::from_elem((COLL_F64_N, COLL_F64_N), 1.);
     bench.iter(|| {
-        Zip::from(&v).par_apply_collect(|s| s + 1.)
+        Zip::from(&v).par_map_collect(|s| s + 1.)
     });
 }
 

--- a/benches/zip.rs
+++ b/benches/zip.rs
@@ -10,7 +10,7 @@ pub fn zip_copy<'a, A, P, Q>(data: P, out: Q)
           Q: IntoNdProducer<Item = &'a mut A, Dim = P::Dim>,
           A: Copy + 'a
 {
-    Zip::from(data).and(out).apply(|&i, o| {
+    Zip::from(data).and(out).for_each(|&i, o| {
         *o = i;
     });
 }
@@ -25,14 +25,14 @@ pub fn zip_copy_split<'a, A, P, Q>(data: P, out: Q)
     let (z11, z12) = z1.split();
     let (z21, z22) = z2.split();
     let f = |&i: &A, o: &mut A| *o = i;
-    z11.apply(f);
-    z12.apply(f);
-    z21.apply(f);
-    z22.apply(f);
+    z11.for_each(f);
+    z12.for_each(f);
+    z21.for_each(f);
+    z22.for_each(f);
 }
 
 pub fn zip_indexed(data: &Array3<f32>, out: &mut Array3<f32>) {
-    Zip::indexed(data).and(out).apply(|idx, &i, o| {
+    Zip::indexed(data).and(out).for_each(|idx, &i, o| {
         let _ = black_box(idx);
         *o = i;
     });

--- a/src/impl_constructors.rs
+++ b/src/impl_constructors.rs
@@ -534,7 +534,7 @@ where
     ///           A: Clone + 'a
     /// {
     ///     Zip::from(from)
-    ///         .apply_assign_into(to, A::clone);
+    ///         .map_assign_into(to, A::clone);
     /// }
     ///
     /// # shift_by_two(&Array2::zeros((8, 8)));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -447,7 +447,7 @@ pub type Ixs = isize;
 ///
 /// Zip::from(a.rows())
 ///     .and(&mut b)
-///     .apply(|a_row, b_elt| {
+///     .for_each(|a_row, b_elt| {
 ///         *b_elt = a_row[a.ncols() - 1] - a_row[0];
 ///     });
 /// ```

--- a/src/parallel/mod.rs
+++ b/src/parallel/mod.rs
@@ -21,9 +21,9 @@
 //!
 //! - [`ArrayBase::par_map_inplace()`]
 //! - [`ArrayBase::par_mapv_inplace()`]
-//! - [`Zip::par_apply()`] (all arities)
-//! - [`Zip::par_apply_collect()`] (all arities)
-//! - [`Zip::par_apply_assign_into()`] (all arities)
+//! - [`Zip::par_for_each()`] (all arities)
+//! - [`Zip::par_map_collect()`] (all arities)
+//! - [`Zip::par_map_assign_into()`] (all arities)
 //!
 //! Note that you can use the parallel iterator for [Zip] to access all other
 //! rayon parallel iterator methods.
@@ -115,7 +115,7 @@
 //!     Zip::from(&mut c)
 //!         .and(&a)
 //!         .and(&b)
-//!         .par_apply(|c, &a, &b| {
+//!         .par_for_each(|c, &a, &b| {
 //!             *c += a - b;
 //!         });
 //! }

--- a/src/zip/mod.rs
+++ b/src/zip/mod.rs
@@ -571,9 +571,9 @@ impl<A, D: Dimension> NdProducer for RawArrayViewMut<A, D> {
 /// assert_eq!(totals, a.sum_axis(Axis(1)));
 ///
 ///
-/// // Example 3: Recreate Example 2 using apply_collect to make a new array
+/// // Example 3: Recreate Example 2 using map_collect to make a new array
 ///
-/// let mut totals2 = Zip::from(a.rows()).apply_collect(|row| row.sum());
+/// let mut totals2 = Zip::from(a.rows()).map_collect(|row| row.sum());
 ///
 /// // Check the result against the previous example.
 /// assert_eq!(totals, totals2);
@@ -722,7 +722,7 @@ where
         }
     }
 
-    /// The innermost loop of the Zip apply methods
+    /// The innermost loop of the Zip for_each methods
     ///
     /// Run the fold while operation on a stretch of elements with constant strides
     ///
@@ -1165,7 +1165,7 @@ macro_rules! map_impl {
                       $($p: NdProducer<Dim=D> ,)*
                       PLast: NdProducer<Dim = D, Item = *mut R, Ptr = *mut R, Stride = isize>,
             {
-                /// The inner workings of apply_collect and par_apply_collect
+                /// The inner workings of map_collect and par_map_collect
                 ///
                 /// Apply the function and collect the results into the output (last producer)
                 /// which should be a raw array view; a Partial that owns the written

--- a/tests/par_zip.rs
+++ b/tests/par_zip.rs
@@ -76,7 +76,7 @@ fn test_zip_index_4() {
 fn test_zip_collect() {
     use approx::assert_abs_diff_eq;
 
-    // test Zip::apply_collect and that it preserves c/f layout.
+    // test Zip::map_collect and that it preserves c/f layout.
 
     let b = Array::from_shape_fn((M, N), |(i, j)| 1. / (i + 2 * j + 1) as f32);
     let c = Array::from_shape_fn((M, N), |(i, j)| f32::ln((1 + i + j) as f32));


### PR DESCRIPTION
Work as a supplement to #894:
·Replace Zip::apply with Zip::for_each including other methods in benches so that they can function normally
·Update related calls and descriptions in the document