### PR TITLE
Add fast case (no-op case) for into_dimensionality and into_dyn

### DIFF
--- a/benches/bench1.rs
+++ b/benches/bench1.rs
@@ -14,6 +14,7 @@ use std::mem::MaybeUninit;
 use ndarray::ShapeBuilder;
 use ndarray::{arr0, arr1, arr2, azip, s};
 use ndarray::{Array, Array1, Array2, Axis, Ix, Zip};
+use ndarray::{Ix1, Ix2, Ix3, Ix5, IxDyn};
 
 use test::black_box;
 
@@ -940,4 +941,60 @@ fn sum_axis0(bench: &mut test::Bencher) {
 fn sum_axis1(bench: &mut test::Bencher) {
     let a = range_mat(MEAN_SUM_N, MEAN_SUM_N);
     bench.iter(|| a.sum_axis(Axis(1)));
+}
+
+#[bench]
+fn into_dimensionality_ix1_ok(bench: &mut test::Bencher) {
+    let a = Array::<f32, _>::zeros(Ix1(10));
+    let a = a.view();
+    bench.iter(|| a.into_dimensionality::<Ix1>());
+}
+
+#[bench]
+fn into_dimensionality_ix3_ok(bench: &mut test::Bencher) {
+    let a = Array::<f32, _>::zeros(Ix3(10, 10, 10));
+    let a = a.view();
+    bench.iter(|| a.into_dimensionality::<Ix3>());
+}
+
+#[bench]
+fn into_dimensionality_ix3_err(bench: &mut test::Bencher) {
+    let a = Array::<f32, _>::zeros(Ix3(10, 10, 10));
+    let a = a.view();
+    bench.iter(|| a.into_dimensionality::<Ix2>());
+}
+
+#[bench]
+fn into_dimensionality_dyn_to_ix3(bench: &mut test::Bencher) {
+    let a = Array::<f32, _>::zeros(IxDyn(&[10, 10, 10]));
+    let a = a.view();
+    bench.iter(|| a.clone().into_dimensionality::<Ix3>());
+}
+
+#[bench]
+fn into_dimensionality_dyn_to_dyn(bench: &mut test::Bencher) {
+    let a = Array::<f32, _>::zeros(IxDyn(&[10, 10, 10]));
+    let a = a.view();
+    bench.iter(|| a.clone().into_dimensionality::<IxDyn>());
+}
+
+#[bench]
+fn into_dyn_ix3(bench: &mut test::Bencher) {
+    let a = Array::<f32, _>::zeros(Ix3(10, 10, 10));
+    let a = a.view();
+    bench.iter(|| a.into_dyn());
+}
+
+#[bench]
+fn into_dyn_ix5(bench: &mut test::Bencher) {
+    let a = Array::<f32, _>::zeros(Ix5(2, 2, 2, 2, 2));
+    let a = a.view();
+    bench.iter(|| a.into_dyn());
+}
+
+#[bench]
+fn into_dyn_dyn(bench: &mut test::Bencher) {
+    let a = Array::<f32, _>::zeros(IxDyn(&[10, 10, 10]));
+    let a = a.view();
+    bench.iter(|| a.clone().into_dyn());
 }

--- a/src/dimension/dimension_trait.rs
+++ b/src/dimension/dimension_trait.rs
@@ -929,6 +929,11 @@ impl Dimension for IxDyn {
     fn from_dimension<D2: Dimension>(d: &D2) -> Option<Self> {
         Some(IxDyn(d.slice()))
     }
+
+    fn into_dyn(self) -> IxDyn {
+        self
+    }
+
     private_impl! {}
 }
 


### PR DESCRIPTION
This adds a no-cloning or no-allocation case for `IxDyn` to `IxDyn` in this method; there is no change to other conversions - they were already good, benchmarks show.

`into_dyn` was improved for the dyn -> dyn case by just adding a missing special case `IxDyn::into_dyn` method.

Fixes #905 