### PR TITLE
Rename .visit() to .for_each()

### DIFF
--- a/src/doc/ndarray_for_numpy_users/mod.rs
+++ b/src/doc/ndarray_for_numpy_users/mod.rs
@@ -282,7 +282,7 @@
 //! Note that [`.mapv()`][.mapv()] has corresponding methods [`.map()`][.map()],
 //! [`.mapv_into()`][.mapv_into()], [`.map_inplace()`][.map_inplace()], and
 //! [`.mapv_inplace()`][.mapv_inplace()]. Also look at [`.fold()`][.fold()],
-//! [`.visit()`][.visit()], [`.fold_axis()`][.fold_axis()], and
+//! [`.for_each()`][.for_each()], [`.fold_axis()`][.fold_axis()], and
 //! [`.map_axis()`][.map_axis()].
 //!
 //! <table>
@@ -648,7 +648,7 @@
 //! [.sum_axis()]: ../../struct.ArrayBase.html#method.sum_axis
 //! [.t()]: ../../struct.ArrayBase.html#method.t
 //! [vec-* dot]: ../../struct.ArrayBase.html#method.dot
-//! [.visit()]: ../../struct.ArrayBase.html#method.visit
+//! [.for_each()]: ../../struct.ArrayBase.html#method.for_each
 //! [::zeros()]: ../../struct.ArrayBase.html#method.zeros
 //! [Zip]: ../../struct.Zip.html
 

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -2220,17 +2220,30 @@ where
         self.unordered_foreach_mut(move |x| *x = f(x.clone()));
     }
 
-    /// Visit each element in the array by calling `f` by reference
-    /// on each element.
+    /// Call `f` for each element in the array.
     ///
     /// Elements are visited in arbitrary order.
-    pub fn visit<'a, F>(&'a self, mut f: F)
+    pub fn for_each<'a, F>(&'a self, mut f: F)
     where
         F: FnMut(&'a A),
         A: 'a,
         S: Data,
     {
         self.fold((), move |(), elt| f(elt))
+    }
+
+    /// Visit each element in the array by calling `f` by reference
+    /// on each element.
+    ///
+    /// Elements are visited in arbitrary order.
+    #[deprecated(note="Renamed to .for_each()", since="0.15.0")]
+    pub fn visit<'a, F>(&'a self, f: F)
+    where
+        F: FnMut(&'a A),
+        A: 'a,
+        S: Data,
+    {
+        self.for_each(f)
     }
 
     /// Fold along an axis.

--- a/src/numeric/impl_numeric.rs
+++ b/src/numeric/impl_numeric.rs
@@ -168,7 +168,7 @@ where
         let mut mean = A::zero();
         let mut sum_sq = A::zero();
         let mut i = 0;
-        self.visit(|&x| {
+        self.for_each(|&x| {
             let count = A::from_usize(i + 1).expect("Converting index to `A` must not fail.");
             let delta = x - mean;
             mean = mean + delta / count;

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -925,7 +925,7 @@ fn zero_axes() {
     }
     a.map(|_| panic!());
     a.map_inplace(|_| panic!());
-    a.visit(|_| panic!());
+    a.for_each(|_| panic!());
     println!("{:?}", a);
     let b = arr2::<f32, _>(&[[], [], [], []]);
     println!("{:?}\n{:?}", b.shape(), b);


### PR DESCRIPTION
This is more consistent with `std::iter::Iterator` and `ndarray::Zip`.

See also #894, which is similar.

By the way, what do you think about renaming the existing (private) `.unordered_foreach_mut()` method to `.for_each_mut()` and making it public? (I'd also add an explicit lifetime parameter, like the one in `.visit()`, to make it more versatile.)