### PR TITLE
Add for_each_mut method

### DIFF
--- a/src/dimension/mod.rs
+++ b/src/dimension/mod.rs
@@ -678,6 +678,36 @@ where
     }
 }
 
+/// Move the axis which has the smallest absolute stride and a length
+/// greater than one to be the last axis.
+pub fn move_min_stride_axis_to_last<D>(dim: &mut D, strides: &mut D)
+where
+    D: Dimension,
+{
+    debug_assert_eq!(dim.ndim(), strides.ndim());
+    match dim.ndim() {
+        0 | 1 => {}
+        2 => {
+            if dim[1] <= 1
+                || dim[0] > 1 && (strides[0] as isize).abs() < (strides[1] as isize).abs()
+            {
+                dim.slice_mut().swap(0, 1);
+                strides.slice_mut().swap(0, 1);
+            }
+        }
+        n => {
+            if let Some(min_stride_axis) = (0..n)
+                .filter(|&ax| dim[ax] > 1)
+                .min_by_key(|&ax| (strides[ax] as isize).abs())
+            {
+                let last = n - 1;
+                dim.slice_mut().swap(last, min_stride_axis);
+                strides.slice_mut().swap(last, min_stride_axis);
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::{

--- a/src/doc/ndarray_for_numpy_users/mod.rs
+++ b/src/doc/ndarray_for_numpy_users/mod.rs
@@ -282,8 +282,8 @@
 //! Note that [`.mapv()`][.mapv()] has corresponding methods [`.map()`][.map()],
 //! [`.mapv_into()`][.mapv_into()], [`.map_inplace()`][.map_inplace()], and
 //! [`.mapv_inplace()`][.mapv_inplace()]. Also look at [`.fold()`][.fold()],
-//! [`.for_each()`][.for_each()], [`.fold_axis()`][.fold_axis()], and
-//! [`.map_axis()`][.map_axis()].
+//! [`.for_each()`][.for_each()], [`.for_each_mut()`][.for_each_mut()],
+//! [`.fold_axis()`][.fold_axis()], and [`.map_axis()`][.map_axis()].
 //!
 //! <table>
 //! <tr><th>
@@ -649,6 +649,7 @@
 //! [.t()]: ../../struct.ArrayBase.html#method.t
 //! [vec-* dot]: ../../struct.ArrayBase.html#method.dot
 //! [.for_each()]: ../../struct.ArrayBase.html#method.for_each
+//! [.for_each_mut()]: ../../struct.ArrayBase.html#method.for_each_mut
 //! [::zeros()]: ../../struct.ArrayBase.html#method.zeros
 //! [Zip]: ../../struct.Zip.html
 

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -2253,7 +2253,7 @@ where
     /// Call `f` for each element in the array.
     ///
     /// Elements are visited in arbitrary order.
-    pub(crate) fn for_each_mut<F>(&mut self, mut f: F)
+    pub fn for_each_mut<F>(&mut self, mut f: F)
     where
         S: DataMut,
         F: FnMut(&mut A),

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -2233,12 +2233,14 @@ where
     /// Call `f` for each element in the array.
     ///
     /// Elements are visited in arbitrary order.
-    pub fn for_each_mut<F>(&mut self, f: F)
+    pub fn for_each_mut<'a, F>(&'a mut self, f: F)
     where
+        F: FnMut(&'a mut A),
+        A: 'a,
         S: DataMut,
-        F: FnMut(&mut A),
     {
-        if let Some(slc) = self.as_slice_memory_order_mut() {
+        if self.is_contiguous() {
+            let slc = self.as_slice_memory_order_mut().unwrap();
             slc.iter_mut().for_each(f);
         } else {
             let mut v = self.view_mut();

--- a/src/impl_ops.rs
+++ b/src/impl_ops.rs
@@ -141,7 +141,7 @@ impl<A, S, D, B> $trt<B> for ArrayBase<S, D>
 {
     type Output = ArrayBase<S, D>;
     fn $mth(mut self, x: B) -> ArrayBase<S, D> {
-        self.unordered_foreach_mut(move |elt| {
+        self.for_each_mut(move |elt| {
             *elt = elt.clone() $operator x.clone();
         });
         self
@@ -194,7 +194,7 @@ impl<S, D> $trt<ArrayBase<S, D>> for $scalar
             rhs.$mth(self)
         } or {{
             let mut rhs = rhs;
-            rhs.unordered_foreach_mut(move |elt| {
+            rhs.for_each_mut(move |elt| {
                 *elt = self $operator *elt;
             });
             rhs
@@ -299,7 +299,7 @@ mod arithmetic_ops {
         type Output = Self;
         /// Perform an elementwise negation of `self` and return the result.
         fn neg(mut self) -> Self {
-            self.unordered_foreach_mut(|elt| {
+            self.for_each_mut(|elt| {
                 *elt = -elt.clone();
             });
             self
@@ -329,7 +329,7 @@ mod arithmetic_ops {
         type Output = Self;
         /// Perform an elementwise unary not of `self` and return the result.
         fn not(mut self) -> Self {
-            self.unordered_foreach_mut(|elt| {
+            self.for_each_mut(|elt| {
                 *elt = !elt.clone();
             });
             self
@@ -386,7 +386,7 @@ mod assign_ops {
                 D: Dimension,
             {
                 fn $method(&mut self, rhs: A) {
-                    self.unordered_foreach_mut(move |elt| {
+                    self.for_each_mut(move |elt| {
                         elt.$method(rhs.clone());
                     });
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1544,22 +1544,6 @@ where
         self.strides.clone()
     }
 
-    /// Apply closure `f` to each element in the array, in whatever
-    /// order is the fastest to visit.
-    fn unordered_foreach_mut<F>(&mut self, mut f: F)
-    where
-        S: DataMut,
-        F: FnMut(&mut A),
-    {
-        if let Some(slc) = self.as_slice_memory_order_mut() {
-            slc.iter_mut().for_each(f);
-        } else {
-            for row in self.inner_rows_mut() {
-                row.into_iter_().fold((), |(), elt| f(elt));
-            }
-        }
-    }
-
     /// Remove array axis `axis` and return the result.
     fn try_remove_axis(self, axis: Axis) -> ArrayBase<S, D::Smaller> {
         let d = self.dim.try_remove_axis(axis);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,7 +143,7 @@ pub use crate::indexes::{indices, indices_of};
 pub use crate::slice::{Slice, SliceInfo, SliceNextDim, SliceOrIndex};
 
 use crate::iterators::Baseiter;
-use crate::iterators::{ElementsBase, ElementsBaseMut, Iter, IterMut, Lanes, LanesMut};
+use crate::iterators::{ElementsBase, ElementsBaseMut, Iter, IterMut, Lanes};
 
 pub use crate::arraytraits::AsArray;
 #[cfg(feature = "std")]
@@ -1560,15 +1560,6 @@ where
     fn inner_rows(&self) -> iterators::Lanes<'_, A, D::Smaller> {
         let n = self.ndim();
         Lanes::new(self.view(), Axis(n.saturating_sub(1)))
-    }
-
-    /// n-d generalization of rows, just like inner iter
-    fn inner_rows_mut(&mut self) -> iterators::LanesMut<'_, A, D::Smaller>
-    where
-        S: DataMut,
-    {
-        let n = self.ndim();
-        LanesMut::new(self.view_mut(), Axis(n.saturating_sub(1)))
     }
 }
 


### PR DESCRIPTION
This PR does the following:

- Rename the private `unordered_foreach_mut` method to `for_each_mut`.
- Make `for_each_mut` public.
- Unify some of the implementation of `fold` and `for_each_mut`.
- Lengthen the lifetimes of the `for_each_mut` element borrows to match `for_each`. Unfortunately, the compiler rejects the previous implementation due to the longer borrows, so a compromise involving two checks for contiguity is used to avoid the compilation error.