### PR TITLE
Fix sort-axis example, add test to confirm original error and resolution

### DIFF
--- a/scripts/all-tests.sh
+++ b/scripts/all-tests.sh
@@ -16,5 +16,6 @@ cargo test --manifest-path=ndarray-rand/Cargo.toml --no-default-features --verbo
 cargo test --manifest-path=ndarray-rand/Cargo.toml --features quickcheck --verbose
 cargo test --manifest-path=serialization-tests/Cargo.toml --verbose
 cargo test --manifest-path=blas-tests/Cargo.toml --verbose
+cargo test --examples
 CARGO_TARGET_DIR=target/ cargo test --manifest-path=numeric-tests/Cargo.toml --verbose
 ([ "$CHANNEL" != "nightly" ] || cargo bench --no-run --verbose --features "$FEATURES")


### PR DESCRIPTION
Noticed a sorting issue when using this example code in my application.  After building a couple tests and sharing with @bluss , he determined that the `perm_i` and `i` vars were swapped in the Zip comprehension.  Once fixed, a single test case was left which would have caught the original failure.