### PR TITLE
Document NdProducer::raw_dim

### DIFF
--- a/src/zip/ndproducer.rs
+++ b/src/zip/ndproducer.rs
@@ -72,7 +72,7 @@ pub trait NdProducer {
 
     #[doc(hidden)]
     fn layout(&self) -> Layout;
-    #[doc(hidden)]
+    /// Return the shape of the producer.
     fn raw_dim(&self) -> Self::Dim;
     #[doc(hidden)]
     fn equal_dim(&self, dim: &Self::Dim) -> bool {


### PR DESCRIPTION
This is useful because, otherwise, users have to manually calculate the shape of the producer to e.g. allocate an array of the correct shape to zip with it.