### PR TITLE
Add back Array::from_vec and Array::from_iter

### DIFF
--- a/src/arraytraits.rs
+++ b/src/arraytraits.rs
@@ -7,7 +7,6 @@
 // except according to those terms.
 
 use std::hash;
-use std::isize;
 use std::iter::FromIterator;
 use std::iter::IntoIterator;
 use std::mem;
@@ -135,13 +134,7 @@ where
     /// let array = Array::from(vec![1., 2., 3., 4.]);
     /// ```
     fn from(v: Vec<A>) -> Self {
-        if mem::size_of::<A>() == 0 {
-            assert!(
-                v.len() <= isize::MAX as usize,
-                "Length must fit in `isize`.",
-            );
-        }
-        unsafe { Self::from_shape_vec_unchecked(v.len() as Ix, v) }
+        Self::from_vec(v)
     }
 }
 
@@ -165,7 +158,7 @@ where
     where
         I: IntoIterator<Item = A>,
     {
-        Self::from(iterable.into_iter().collect::<Vec<A>>())
+        Self::from_iter(iterable)
     }
 }
 

--- a/src/impl_constructors.rs
+++ b/src/impl_constructors.rs
@@ -14,6 +14,7 @@
 #[cfg(feature = "std")]
 use num_traits::Float;
 use num_traits::{One, Zero};
+use std::mem;
 use std::mem::MaybeUninit;
 use alloc::vec;
 use alloc::vec::Vec;
@@ -51,11 +52,29 @@ where
     /// ```rust
     /// use ndarray::Array;
     ///
-    /// let array = Array::from(vec![1., 2., 3., 4.]);
+    /// let array = Array::from_vec(vec![1., 2., 3., 4.]);
     /// ```
-    #[deprecated(note = "use standard `from`", since = "0.13.0")]
     pub fn from_vec(v: Vec<A>) -> Self {
-        Self::from(v)
+        if mem::size_of::<A>() == 0 {
+            assert!(
+                v.len() <= isize::MAX as usize,
+                "Length must fit in `isize`.",
+            );
+        }
+        unsafe { Self::from_shape_vec_unchecked(v.len() as Ix, v) }
+    }
+
+    /// Create a one-dimensional array from an iterator or iterable.
+    ///
+    /// **Panics** if the length is greater than `isize::MAX`.
+    ///
+    /// ```rust
+    /// use ndarray::Array;
+    ///
+    /// let array = Array::from_iter(0..10);
+    /// ```
+    pub fn from_iter<I: IntoIterator<Item = A>>(iterable: I) -> Self {
+        Self::from_vec(iterable.into_iter().collect())
     }
 
     /// Create a one-dimensional array with `n` evenly spaced elements from


### PR DESCRIPTION
Inherent methods are always available, easier to use and have high
visibility in docs. These important user interfaces are undeprecated and
added back respectively.

- Undeprecate `ArrayBase::from_vec` (it has the same effect as the `From<Vec<_>>` impl)
- Add back `ArrayBase::from_iter` (it has the same effect as the `FromIterator` impl)


`FromIterator` is not even in the prelude, and I really miss having `from_iter` available.