### PR TITLE
Add rustfmt check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,3 +76,18 @@ jobs:
           components: clippy
       - run: cargo clippy
 
+  format:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - stable
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+          components: rustfmt
+      - run: cargo fmt -- --check


### PR DESCRIPTION
`rustfmt` is very convenient when writing PRs, but when it's not enforced by CI, the formatting in the project inevitably diverges from the `rustfmt` style. So, when I run `rustfmt` to format a PR, lines unrelated to the changes in the PR are reformatted (since those lines don't follow the `rustfmt` style), and then I have to manually stage only the relevant lines and discard the irrelevant formatting changes. If `rustfmt` style is enforced by CI, then I can just run `rustfmt` before submitting a PR and not have to worry about discarding unrelated formatting changes (since there shouldn't be any).

This PR should fail CI right now. Once we've merged the large open PRs, we can run `cargo fmt` on the whole crate, rerun CI for this PR to make sure it passes, and then merge this PR.