### PR TITLE
Add clippy lints as annotations to PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,5 +74,8 @@ jobs:
           toolchain: ${{ matrix.rust }}
           override: true
           components: clippy
-      - run: cargo clippy
+      - uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --all-features
 


### PR DESCRIPTION
This makes CI annotate PRs with clippy lints. See https://github.com/actions-rs/clippy-check for details.

Huh, it doesn't look like it worked. When I run `clippy` locally, there are at least a few warnings.