### PR TITLE
Treat warnings as errors in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ env:
   CARGO_TERM_COLOR: always
   HOST: x86_64-unknown-linux-gnu
   FEATURES: "test docs"
+  RUSTFLAGS: "-D warnings"
 
 jobs:
   tests:

--- a/benches/higher-order.rs
+++ b/benches/higher-order.rs
@@ -6,7 +6,6 @@
     clippy::many_single_char_names
 )]
 extern crate test;
-use std::iter::FromIterator;
 use test::black_box;
 use test::Bencher;
 

--- a/blas-tests/tests/oper.rs
+++ b/blas-tests/tests/oper.rs
@@ -8,7 +8,6 @@ use ndarray::linalg::general_mat_vec_mul;
 use ndarray::prelude::*;
 use ndarray::{Data, LinalgScalar};
 use ndarray::{Ix, Ixs, SliceInfo, SliceOrIndex};
-use std::iter::FromIterator;
 
 use approx::{assert_abs_diff_eq, assert_relative_eq};
 use defmac::defmac;

--- a/examples/life.rs
+++ b/examples/life.rs
@@ -6,7 +6,6 @@
 )]
 
 use ndarray::prelude::*;
-use std::iter::FromIterator;
 
 const INPUT: &[u8] = include_bytes!("life.txt");
 

--- a/src/data_traits.rs
+++ b/src/data_traits.rs
@@ -94,6 +94,7 @@ pub unsafe trait RawDataClone: RawData {
 pub unsafe trait Data: RawData {
     /// Converts the array to a uniquely owned array, cloning elements if necessary.
     #[doc(hidden)]
+    #[allow(clippy::wrong_self_convention)]
     fn into_owned<D>(self_: ArrayBase<Self, D>) -> ArrayBase<OwnedRepr<Self::Elem>, D>
     where
         Self::Elem: Clone,
@@ -102,6 +103,7 @@ pub unsafe trait Data: RawData {
     /// Return a shared ownership (copy on write) array based on the existing one,
     /// cloning elements if necessary.
     #[doc(hidden)]
+    #[allow(clippy::wrong_self_convention)]
     fn to_shared<D>(self_: &ArrayBase<Self, D>) -> ArrayBase<OwnedArcRepr<Self::Elem>, D>
     where
         Self::Elem: Clone,

--- a/src/dimension/dynindeximpl.rs
+++ b/src/dimension/dynindeximpl.rs
@@ -51,7 +51,7 @@ impl<T: Copy + Zero> IxDynRepr<T> {
     pub fn copy_from(x: &[T]) -> Self {
         if x.len() <= CAP {
             let mut arr = [T::zero(); CAP];
-            arr[..x.len()].copy_from_slice(&x[..]);
+            arr[..x.len()].copy_from_slice(x);
             IxDynRepr::Inline(x.len() as _, arr)
         } else {
             Self::from(x)

--- a/src/impl_constructors.rs
+++ b/src/impl_constructors.rs
@@ -73,6 +73,7 @@ where
     ///
     /// let array = Array::from_iter(0..10);
     /// ```
+    #[allow(clippy::should_implement_trait)]
     pub fn from_iter<I: IntoIterator<Item = A>>(iterable: I) -> Self {
         Self::from_vec(iterable.into_iter().collect())
     }

--- a/src/impl_internal_constructors.rs
+++ b/src/impl_internal_constructors.rs
@@ -25,8 +25,8 @@ where
     /// See ArrayView::from_shape_ptr for general pointer validity documentation.
     pub(crate) unsafe fn from_data_ptr(data: S, ptr: NonNull<A>) -> Self {
         let array = ArrayBase {
-            data: data,
-            ptr: ptr,
+            data,
+            ptr,
             dim: Ix1(0),
             strides: Ix1(1),
         };

--- a/src/linalg/impl_linalg.rs
+++ b/src/linalg/impl_linalg.rs
@@ -613,6 +613,7 @@ pub fn general_mat_vec_mul<A, S1, S2, S3>(
 ///
 /// The caller must ensure that the raw view is valid for writing.
 /// the destination may be uninitialized iff beta is zero.
+#[allow(clippy::collapsible_else_if)]
 unsafe fn general_mat_vec_mul_impl<A, S1, S2>(
     alpha: A,
     a: &ArrayBase<S1, Ix2>,

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -13,7 +13,6 @@ use ndarray::indices;
 use ndarray::prelude::*;
 use ndarray::{arr3, rcarr2};
 use ndarray::{Slice, SliceInfo, SliceOrIndex};
-use std::iter::FromIterator;
 
 macro_rules! assert_panics {
     ($body:expr) => {
@@ -1803,7 +1802,7 @@ fn test_contiguous() {
 #[test]
 fn test_contiguous_neg_strides() {
     let s = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13];
-    let mut a = ArrayView::from_shape((2, 3, 2).strides((1, 4, 2)), &s).unwrap();
+    let a = ArrayView::from_shape((2, 3, 2).strides((1, 4, 2)), &s).unwrap();
     assert_eq!(
         a,
         arr3(&[[[0, 2], [4, 6], [8, 10]], [[1, 3], [5, 7], [9, 11]]])

--- a/tests/azip.rs
+++ b/tests/azip.rs
@@ -8,7 +8,6 @@
 
 use ndarray::prelude::*;
 use ndarray::Zip;
-use std::iter::FromIterator;
 
 use itertools::{assert_equal, cloned};
 

--- a/tests/dimension.rs
+++ b/tests/dimension.rs
@@ -2,7 +2,7 @@
 
 use defmac::defmac;
 
-use ndarray::{arr2, ArcArray, Array, Axis, Dim, Dimension, IntoDimension, IxDyn, RemoveAxis};
+use ndarray::{arr2, ArcArray, Array, Axis, Dim, Dimension, IxDyn, RemoveAxis};
 
 use std::hash::{Hash, Hasher};
 
@@ -307,6 +307,7 @@ fn test_array_view() {
 #[cfg(feature = "std")]
 #[allow(clippy::cognitive_complexity)]
 fn test_all_ndindex() {
+    use ndarray::IntoDimension;
     macro_rules! ndindex {
     ($($i:expr),*) => {
         for &rev in &[false, true] {

--- a/tests/iterator_chunks.rs
+++ b/tests/iterator_chunks.rs
@@ -7,11 +7,11 @@
 )]
 
 use ndarray::prelude::*;
-use ndarray::NdProducer;
 
 #[test]
 #[cfg(feature = "std")]
 fn chunks() {
+    use ndarray::NdProducer;
     let a = <Array1<f32>>::linspace(1., 100., 10 * 10)
         .into_shape((10, 10))
         .unwrap();

--- a/tests/iterators.rs
+++ b/tests/iterators.rs
@@ -6,12 +6,9 @@
 )]
 
 use ndarray::prelude::*;
-use ndarray::Ix;
-use ndarray::{arr2, arr3, aview1, indices, s, Axis, Data, Dimension, Slice, Zip};
+use ndarray::{arr3, aview1, indices, s, Axis, Slice, Zip};
 
-use itertools::assert_equal;
-use itertools::{enumerate, rev};
-use std::iter::FromIterator;
+use itertools::{assert_equal, enumerate};
 
 macro_rules! assert_panics {
     ($body:expr) => {
@@ -37,7 +34,7 @@ fn double_ended() {
     assert_eq!(it.next(), Some(1.));
     assert_eq!(it.rev().last(), Some(2.));
     assert_equal(aview1(&[1, 2, 3]), &[1, 2, 3]);
-    assert_equal(rev(aview1(&[1, 2, 3])), rev(&[1, 2, 3]));
+    assert_equal(aview1(&[1, 2, 3]).into_iter().rev(), [1, 2, 3].iter().rev());
 }
 
 #[test]
@@ -63,7 +60,7 @@ fn iter_size_hint() {
 fn indexed() {
     let a = ArcArray::linspace(0., 7., 8);
     for (i, elt) in a.indexed_iter() {
-        assert_eq!(i, *elt as Ix);
+        assert_eq!(i, *elt as usize);
     }
     let a = a.reshape((2, 4, 1));
     let (mut i, mut j, k) = (0, 0, 0);
@@ -78,22 +75,24 @@ fn indexed() {
     }
 }
 
-fn assert_slice_correct<A, S, D>(v: &ArrayBase<S, D>)
-where
-    S: Data<Elem = A>,
-    D: Dimension,
-    A: PartialEq + std::fmt::Debug,
-{
-    let slc = v.as_slice();
-    assert!(slc.is_some());
-    let slc = slc.unwrap();
-    assert_eq!(v.len(), slc.len());
-    assert_equal(v.iter(), slc);
-}
-
 #[test]
 #[cfg(feature = "std")]
 fn as_slice() {
+    use ndarray::Data;
+
+    fn assert_slice_correct<A, S, D>(v: &ArrayBase<S, D>)
+    where
+        S: Data<Elem = A>,
+        D: Dimension,
+        A: PartialEq + std::fmt::Debug,
+    {
+        let slc = v.as_slice();
+        assert!(slc.is_some());
+        let slc = slc.unwrap();
+        assert_eq!(v.len(), slc.len());
+        assert_equal(v.iter(), slc);
+    }
+
     let a = ArcArray::linspace(0., 7., 8);
     let a = a.reshape((2, 4, 1));
 
@@ -544,9 +543,9 @@ fn axis_chunks_iter_corner_cases() {
     assert_equal(
         it,
         vec![
-            arr2(&[[7.], [6.], [5.]]),
-            arr2(&[[4.], [3.], [2.]]),
-            arr2(&[[1.], [0.]]),
+            array![[7.], [6.], [5.]],
+            array![[4.], [3.], [2.]],
+            array![[1.], [0.]],
         ],
     );
 

--- a/tests/ixdyn.rs
+++ b/tests/ixdyn.rs
@@ -9,7 +9,7 @@
 use ndarray::Array;
 use ndarray::IntoDimension;
 use ndarray::ShapeBuilder;
-use ndarray::{Ix0, Ix1, Ix2, Ix3, IxDyn};
+use ndarray::Ix3;
 
 #[test]
 fn test_ixdyn() {
@@ -157,6 +157,8 @@ fn test_0_add_broad() {
 #[test]
 #[cfg(feature = "std")]
 fn test_into_dimension() {
+    use ndarray::{Ix0, Ix1, Ix2, IxDyn};
+
     let a = Array::linspace(0., 41., 6 * 7).into_shape((6, 7)).unwrap();
     let a2 = a.clone().into_shape(IxDyn(&[6, 7])).unwrap();
     let b = a2.clone().into_dimensionality::<Ix2>().unwrap();

--- a/tests/numeric.rs
+++ b/tests/numeric.rs
@@ -40,7 +40,7 @@ fn test_mean_with_array_of_floats() {
 
 #[test]
 fn sum_mean() {
-    let a = arr2(&[[1., 2.], [3., 4.]]);
+    let a: Array2<f64> = arr2(&[[1., 2.], [3., 4.]]);
     assert_eq!(a.sum_axis(Axis(0)), arr1(&[4., 6.]));
     assert_eq!(a.sum_axis(Axis(1)), arr1(&[3., 7.]));
     assert_eq!(a.mean_axis(Axis(0)), Some(arr1(&[2., 3.])));

--- a/tests/oper.rs
+++ b/tests/oper.rs
@@ -11,11 +11,9 @@ use ndarray::{rcarr1, rcarr2};
 use ndarray::{Data, LinalgScalar};
 use ndarray::{Ix, Ixs};
 use num_traits::Zero;
-use std::iter::FromIterator;
 
 use approx::assert_abs_diff_eq;
 use defmac::defmac;
-use std::ops::Neg;
 
 fn test_oper(op: &str, a: &[f32], b: &[f32], c: &[f32]) {
     let aa = rcarr1(a);

--- a/tests/windows.rs
+++ b/tests/windows.rs
@@ -7,7 +7,6 @@
 
 use ndarray::prelude::*;
 use ndarray::Zip;
-use std::iter::FromIterator;
 
 // Edge Cases for Windows iterator:
 //


### PR DESCRIPTION
This helps avoid accidentally missing a warning.