### PR TITLE
Add docs to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -85,12 +85,28 @@ jobs:
       - run: cargo careful test -Zcareful-sanitizer --features="$FEATURES"
       - run: cargo careful test -Zcareful-sanitizer -p ndarray-rand
 
+  docs:
+    if: ${{ github.event_name == 'merge_group' }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - stable
+    name: docs/${{ matrix.rust }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+      - run: cargo doc
+
   conclusion:
     needs:
       - clippy
       - tests
       - cross_test
       - cargo-careful
+      - docs
     if: always()
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This is primarily to detect broken intra-doc links, which `cargo doc` warns about.

This should be rebased off of `master` once #924 is merged to make sure the existing warnings (when the `docs` feature is not enabled) are treated as errors. Then, we can change the command to `cargo doc --features=docs` to resolve the warnings.

Edit: It looks like this is blocked on rust-lang/rust#79816 in order for `-D warnings` to apply to rustdoc.