### PR TITLE
implement multidimensional matrix multiply which supports blas and parallelization

### DIFF
--- a/src/dimension/mod.rs
+++ b/src/dimension/mod.rs
@@ -411,6 +411,25 @@ pub fn offset_from_ptr_to_memory<D: Dimension>(dim: &D, strides: &D) -> isize {
     offset
 }
 
+/// Return the index of the dimension from a specific distance from first index.
+///
+/// Panics if dis is greater than or equal to the count of dim elements.
+pub(crate) fn index_from_distance<D: Dimension>(dim: &D, dis: usize) -> D {
+    let mut dis = dis;
+    let mut index = D::zeros(dim.ndim());
+    let len = dim.ndim();
+    for i in 0..len {
+        let m = len - i -1;
+        index[m] = dis % dim[m];
+        dis = dis / dim[m];
+        if dis == 0 {
+            break;
+        }
+    }
+    assert!(dis == 0);
+    index
+}
+
 /// Modify dimension, stride and return data pointer offset
 ///
 /// **Panics** if stride is 0 or if any index is out of bounds.

--- a/src/iterators/lanes.rs
+++ b/src/iterators/lanes.rs
@@ -4,6 +4,7 @@ use super::LanesIter;
 use super::LanesIterMut;
 use crate::imp_prelude::*;
 use crate::{Layout, NdProducer};
+use crate::iterators::LanesIterCore;
 
 impl_ndproducer! {
     ['a, A, D: Dimension]
@@ -84,7 +85,9 @@ where
     type IntoIter = LanesIter<'a, A, D>;
     fn into_iter(self) -> Self::IntoIter {
         LanesIter {
-            iter: self.base.into_base_iter(),
+            iter: unsafe {
+                LanesIterCore::new(self.base.ptr.as_ptr(), self.base.dim, self.base.strides)
+            },
             inner_len: self.inner_len,
             inner_stride: self.inner_stride,
             life: PhantomData,
@@ -135,7 +138,9 @@ where
     type IntoIter = LanesIterMut<'a, A, D>;
     fn into_iter(self) -> Self::IntoIter {
         LanesIterMut {
-            iter: self.base.into_base_iter(),
+            iter: unsafe {
+                LanesIterCore::new(self.base.ptr.as_ptr(), self.base.dim, self.base.strides)
+            },
             inner_len: self.inner_len,
             inner_stride: self.inner_stride,
             life: PhantomData,

--- a/src/linalg/mod.rs
+++ b/src/linalg/mod.rs
@@ -11,5 +11,7 @@
 pub use self::impl_linalg::general_mat_mul;
 pub use self::impl_linalg::general_mat_vec_mul;
 pub use self::impl_linalg::Dot;
+#[cfg(feature = "rayon")]
+pub use self::impl_linalg::ParDot;
 
 mod impl_linalg;

--- a/src/parallel/mod.rs
+++ b/src/parallel/mod.rs
@@ -134,6 +134,8 @@ use crate::{
 use crate::iter::{
     AxisIter,
     AxisIterMut,
+    LanesIter,
+    LanesIterMut,
     AxisChunksIter,
     AxisChunksIterMut,
 };

--- a/src/parallel/par.rs
+++ b/src/parallel/par.rs
@@ -13,6 +13,8 @@ use crate::iter::AxisChunksIter;
 use crate::iter::AxisChunksIterMut;
 use crate::iter::AxisIter;
 use crate::iter::AxisIterMut;
+use crate::iter::LanesIter;
+use crate::iter::LanesIterMut;
 use crate::Dimension;
 use crate::{ArrayView, ArrayViewMut};
 use crate::split_at::SplitPreference;
@@ -115,6 +117,8 @@ macro_rules! par_iter_wrapper {
 
 par_iter_wrapper!(AxisIter, [Sync]);
 par_iter_wrapper!(AxisIterMut, [Send + Sync]);
+par_iter_wrapper!(LanesIter, [Sync]);
+par_iter_wrapper!(LanesIterMut, [Send + Sync]);
 par_iter_wrapper!(AxisChunksIter, [Sync]);
 par_iter_wrapper!(AxisChunksIterMut, [Send + Sync]);
 

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -14,6 +14,7 @@ use ndarray::prelude::*;
 use ndarray::{arr3, rcarr2};
 use ndarray::{Slice, SliceInfo, SliceOrIndex};
 use std::iter::FromIterator;
+use ndarray::linalg::Dot;
 
 macro_rules! assert_panics {
     ($body:expr) => {
@@ -69,6 +70,13 @@ fn test_muti_dot() {
     assert_eq!(c, Array4::from_shape_vec((2, 2, 2, 2), v).unwrap());
 
     let a = Array::range(0., 6., 1.).into_shape((2, 3)).unwrap();
+    let v =vec![1, 2, 1, 2, 1, 3, 2];
+    let b = Array::range(0., 24., 1.).into_shape(v.clone()).unwrap();
+    let c =a.dot(&b);
+    let v2 = vec![10.0, 13.0, 28.0, 31.0, 46.0, 49.0, 64.0, 67.0, 28.0, 40.0, 100.0, 112.0, 172.0, 184.0, 244.0, 256.0];
+    assert_eq!(c, Array::from_shape_vec(vec![2, 1, 2, 1, 2, 1, 2], v2).unwrap());
+
+    let a = Array::range(0., 6., 1.).into_shape(vec![2, 3]).unwrap();
     let v =vec![1, 2, 1, 2, 1, 3, 2];
     let b = Array::range(0., 24., 1.).into_shape(v.clone()).unwrap();
     let c =a.dot(&b);

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -54,6 +54,28 @@ fn test_matmul_arcarray() {
     }
 }
 
+#[test]
+#[cfg(feature = "std")]
+fn test_muti_dot() {
+    let a = Array::range(0., 3., 1.);
+    let b = Array::range(0., 12., 1.).into_shape((2, 3, 2)).unwrap();
+    let c =a.dot(&b);
+    assert_eq!(c, arr2(&[[10.0, 13.0], [28.0, 31.0]]));
+
+    let a = Array::range(0., 6., 1.).into_shape((2, 3)).unwrap();
+    let b = Array::range(0., 24., 1.).into_shape((2, 2, 3, 2)).unwrap();
+    let c =a.dot(&b);
+    let v = vec![10.0, 13.0, 28.0, 31.0, 46.0, 49.0, 64.0, 67.0, 28.0, 40.0, 100.0, 112.0, 172.0, 184.0, 244.0, 256.0];
+    assert_eq!(c, Array4::from_shape_vec((2, 2, 2, 2), v).unwrap());
+
+    let a = Array::range(0., 6., 1.).into_shape((2, 3)).unwrap();
+    let v =vec![1, 2, 1, 2, 1, 3, 2];
+    let b = Array::range(0., 24., 1.).into_shape(v.clone()).unwrap();
+    let c =a.dot(&b);
+    let v2 = vec![10.0, 13.0, 28.0, 31.0, 46.0, 49.0, 64.0, 67.0, 28.0, 40.0, 100.0, 112.0, 172.0, 184.0, 244.0, 256.0];
+    assert_eq!(c, Array::from_shape_vec(vec![2, 1, 2, 1, 2, 1, 2], v2).unwrap());
+}
+
 #[allow(unused)]
 fn arrayview_shrink_lifetime<'a, 'b: 'a>(view: ArrayView1<'b, f64>) -> ArrayView1<'a, f64> {
     view.reborrow()

--- a/tests/par_dot.rs
+++ b/tests/par_dot.rs
@@ -1,0 +1,31 @@
+#![cfg(feature = "rayon")]
+use ndarray::{Array, arr2, Array4};
+use ndarray::linalg::ParDot;
+
+#[test]
+fn test_muti_par_dot() {
+    let a = Array::range(0., 3., 1.);
+    let b = Array::range(0., 12., 1.).into_shape((2, 3, 2)).unwrap();
+    let c =a.par_dot(&b);
+    assert_eq!(c, arr2(&[[10.0, 13.0], [28.0, 31.0]]));
+
+    let a = Array::range(0., 6., 1.).into_shape((2, 3)).unwrap();
+    let b = Array::range(0., 24., 1.).into_shape((2, 2, 3, 2)).unwrap();
+    let c =a.par_dot(&b);
+    let v = vec![10.0, 13.0, 28.0, 31.0, 46.0, 49.0, 64.0, 67.0, 28.0, 40.0, 100.0, 112.0, 172.0, 184.0, 244.0, 256.0];
+    assert_eq!(c, Array4::from_shape_vec((2, 2, 2, 2), v).unwrap());
+
+    let a = Array::range(0., 6., 1.).into_shape((2, 3)).unwrap();
+    let v =vec![1, 2, 1, 2, 1, 3, 2];
+    let b = Array::range(0., 24., 1.).into_shape(v.clone()).unwrap();
+    let c =a.par_dot(&b);
+    let v2 = vec![10.0, 13.0, 28.0, 31.0, 46.0, 49.0, 64.0, 67.0, 28.0, 40.0, 100.0, 112.0, 172.0, 184.0, 244.0, 256.0];
+    assert_eq!(c, Array::from_shape_vec(vec![2, 1, 2, 1, 2, 1, 2], v2).unwrap());
+
+    let a = Array::range(0., 6., 1.).into_shape(vec![2, 3]).unwrap();
+    let v =vec![1, 2, 1, 2, 1, 3, 2];
+    let b = Array::range(0., 24., 1.).into_shape(v.clone()).unwrap();
+    let c =a.par_dot(&b);
+    let v2 = vec![10.0, 13.0, 28.0, 31.0, 46.0, 49.0, 64.0, 67.0, 28.0, 40.0, 100.0, 112.0, 172.0, 184.0, 244.0, 256.0];
+    assert_eq!(c, Array::from_shape_vec(vec![2, 1, 2, 1, 2, 1, 2], v2).unwrap());
+}


### PR DESCRIPTION
Fixes #16
Fixes #886 
Updates #678 
Refer to the implementation of [numpy.dot](https://github.com/numpy/numpy/blob/master/numpy/core/src/multiarray/multiarraymodule.c#L963-L1112)
The general rules are as follows:
If both a and b are 1-D arrays, it is inner product of vectors (without complex conjugation).
If both a and b are 2-D arrays, it is matrix multiplication, but using matmul or a @ b is preferred.
If either a or b is 0-D (scalar), it is equivalent to multiply and using numpy.multiply(a, b) or a * b is preferred.
If a is an N-D array and b is a 1-D array, it is a sum product over the last axis of a and b.
If a is an N-D array and b is an M-D array (where M>=2), it is a sum product over the last axis of a and the second-to-last axis of b:
`dot(a, b)[i,j,k,m] = sum(a[i,j,:] * b[k,:,m])`

I conducted a three-dimensional multiplication test on my linux-x86_64: 

        use ndarray::{Array, linalg::{Dot,ParDot}};
        extern crate openblas_src;
        fn main() {
            let a = Array::range(0., 96000., 1.).into_shape((40, 40, 60)).unwrap();
            let b = Array::range(0., 96000., 1.).into_shape((40, 60, 40)).unwrap();
        
            // without rayon
            let start=std::time::SystemTime::now();
            let c =a.dot(&b);
            let end=std::time::SystemTime::now();
            println!("{:?}",end.duration_since(start));
    
            // with rayon
            let start=std::time::SystemTime::now();
            let par_c =a.par_dot(&b);
            let end=std::time::SystemTime::now();
            println!("{:?}",end.duration_since(start));
    
            assert_eq!(c, par_c);
        }

and the test results are as follows:

        generic:                     20.288079241s
        with rayon:                  2.689783602s
        with openblas:               2.733138535s
        with rayon+openblas:         434.623734ms

The main modification is to implement the Dot trait for dimensions above two dimensions with the other dimentions in impl_linalg.rs. Panic when the shape does not match or the number of result elements overflows. 

Because multi-dimensional matrix multiplication will be converted into many vector inner product calculations(refers to [numpy.dot](https://github.com/numpy/numpy/blob/master/numpy/core/src/multiarray/multiarraymodule.c#L1080-L1090), I used lanes().into_iter() method to get the iterator that produces the required vectors. And use the dot_impl() method to calculate the vector inner product, so we can get the acceleration effect of blas.

        let v = self.lanes(Axis(l1-1))
            .into_iter()
            .map(|l1| { rhs.lanes(Axis(match_dim))
                .into_iter()
                .map(|l2| l2.dot_impl(&l1))
                .collect::<Vec<_>>()
            })
            .flatten()
            .collect::<Vec<_>>();

On the other hand, the process of calculating the inner product of vectors can be parallelized using rayon. 

        let v = self.lanes(Axis(l1-1))
            .into_iter()
            .into_par_iter()
            .map(|l1| { rhs.lanes(Axis(match_dim))
                .into_iter()
                .into_par_iter()
                .map(|l2| l2.dot_impl(&l1))
                .collect::<Vec<_>>()
            })
            .flatten()
            .collect::<Vec<_>>();

But since the internal iter of `LanesIter` is `Baseiter`, it cannot be converted into a parallel iterator simply by using `par_iter_wrapper!(LanesIter, [Sync])`.

        pub struct Baseiter<A, D> {
            ptr: *mut A,
            dim: D,
            strides: D,
            index: Option<D>,
        }

 So I created a new iterator named `LanesIterCore` instead of `Baseiter`. 

        pub struct LanesIterCore<A, D> {
            ptr: *mut A,
            dim: D,
            strides: D,
            dis: usize,
            end: usize,
        }

`LanesIterCore` uses `dis` and `end` parameters to replace the `index` in `Baseiter`. So it can simply implement the `ExactSizeIterator` `DoubleEndedIterator` and `split_at` required by a parallel iterator.

However its current method of obtaining dimension indexes is to use the newly added `index_from_distance()` method, which needs to use several divisions and remainder to calculate an dimension index 

        /// Return the index of the dimension from a specific distance from first index.
        ///
        /// Panics if dis is greater than or equal to the count of dim elements.
        pub(crate) fn index_from_distance<D: Dimension>(dim: &D, dis: usize) -> D {
            let mut dis = dis;
            let mut index = D::zeros(dim.ndim());
            let len = dim.ndim();
            for i in 0..len {
                let m = len - i -1;
                index[m] = dis % dim[m];
                dis = dis / dim[m];
                if dis == 0 {
                    break;
                }
            }
            assert!(dis == 0);
            index
        }

so will be much slower than `next_for()`. I have not thought of a better solution at present, but when the amount of data is large, this effect can be ignored. 

