### PR TITLE
append, append_row, append_column: methods for appending an array or single rows and columns

### DIFF
--- a/benches/append.rs
+++ b/benches/append.rs
@@ -1,0 +1,24 @@
+#![feature(test)]
+
+extern crate test;
+use test::Bencher;
+
+use ndarray::prelude::*;
+
+#[bench]
+fn select_axis0(bench: &mut Bencher) {
+    let a = Array::<f32, _>::zeros((256, 256));
+    let selectable = vec![0, 1, 2, 0, 1, 3, 0, 4, 16, 32, 128, 147, 149, 220, 221, 255, 221, 0, 1];
+    bench.iter(|| {
+        a.select(Axis(0), &selectable)
+    });
+}
+
+#[bench]
+fn select_axis1(bench: &mut Bencher) {
+    let a = Array::<f32, _>::zeros((256, 256));
+    let selectable = vec![0, 1, 2, 0, 1, 3, 0, 4, 16, 32, 128, 147, 149, 220, 221, 255, 221, 0, 1];
+    bench.iter(|| {
+        a.select(Axis(1), &selectable)
+    });
+}

--- a/benches/append.rs
+++ b/benches/append.rs
@@ -22,3 +22,14 @@ fn select_axis1(bench: &mut Bencher) {
         a.select(Axis(1), &selectable)
     });
 }
+
+#[bench]
+fn select_1d(bench: &mut Bencher) {
+    let a = Array::<f32, _>::zeros(1024);
+    let mut selectable = (0..a.len()).step_by(17).collect::<Vec<_>>();
+    selectable.extend(selectable.clone().iter().rev());
+
+    bench.iter(|| {
+        a.select(Axis(0), &selectable)
+    });
+}

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -873,7 +873,7 @@ where
     /// ```
     pub fn select(&self, axis: Axis, indices: &[Ix]) -> Array<A, D>
     where
-        A: Copy,
+        A: Clone,
         S: Data,
         D: RemoveAxis,
     {

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -877,16 +877,35 @@ where
         S: Data,
         D: RemoveAxis,
     {
-        let mut subs = vec![self.view(); indices.len()];
-        for (&i, sub) in zip(indices, &mut subs[..]) {
-            sub.collapse_axis(axis, i);
-        }
-        if subs.is_empty() {
-            let mut dim = self.raw_dim();
-            dim.set_axis(axis, 0);
-            unsafe { Array::from_shape_vec_unchecked(dim, vec![]) }
+        if self.ndim() == 1 {
+            // using .len_of(axis) means that we check if `axis` is in bounds too.
+            let axis_len = self.len_of(axis);
+            // bounds check the indices first
+            if let Some(max_index) = indices.iter().cloned().max() {
+                if max_index >= axis_len {
+                    panic!("ndarray: index {} is out of bounds in array of len {}",
+                           max_index, self.len_of(axis));
+                }
+            } // else: indices empty is ok
+            let view = self.view().into_dimensionality::<Ix1>().unwrap();
+            Array::from_iter(indices.iter().map(move |&index| {
+                // Safety: bounds checked indexes
+                unsafe {
+                    view.uget(index).clone()
+                }
+            })).into_dimensionality::<D>().unwrap()
         } else {
-            concatenate(axis, &subs).unwrap()
+            let mut subs = vec![self.view(); indices.len()];
+            for (&i, sub) in zip(indices, &mut subs[..]) {
+                sub.collapse_axis(axis, i);
+            }
+            if subs.is_empty() {
+                let mut dim = self.raw_dim();
+                dim.set_axis(axis, 0);
+                unsafe { Array::from_shape_vec_unchecked(dim, vec![]) }
+            } else {
+                concatenate(axis, &subs).unwrap()
+            }
         }
     }
 

--- a/src/impl_owned_array.rs
+++ b/src/impl_owned_array.rs
@@ -480,9 +480,11 @@ impl<A, D> Array<A, D>
         } else if current_axis_len == 1 {
             // This is the outermost/longest stride axis; so we find the max across the other axes
             let new_stride = self.axes().fold(1, |acc, ax| {
-                if ax.axis == axis { acc } else {
-                    let this_ax = ax.len as isize * ax.stride;
-                    if this_ax.abs() > acc { this_ax } else { acc }
+                if ax.axis == axis || ax.len <= 1 {
+                    acc
+                } else {
+                    let this_ax = ax.len as isize * ax.stride.abs();
+                    if this_ax > acc { this_ax } else { acc }
                 }
             });
             let mut strides = self.strides.clone();

--- a/src/impl_owned_array.rs
+++ b/src/impl_owned_array.rs
@@ -201,14 +201,20 @@ impl<A, D> Array<A, D>
         }
 
         let len_to_append = array.len();
-        if len_to_append == 0 {
-            return Ok(());
-        }
 
         let array_shape = array.raw_dim();
         let mut res_dim = self.raw_dim();
         res_dim[axis.index()] += array_shape[axis.index()];
         let new_len = dimension::size_of_shape_checked(&res_dim)?;
+
+        if len_to_append == 0 {
+            // There are no elements to append and shapes are compatible:
+            // either the dimension increment is zero, or there is an existing
+            // zero in another axis in self.
+            debug_assert_eq!(self.len(), new_len);
+            self.dim = res_dim;
+            return Ok(());
+        }
 
         let self_is_empty = self.is_empty();
 

--- a/src/impl_owned_array.rs
+++ b/src/impl_owned_array.rs
@@ -2,6 +2,8 @@
 use alloc::vec::Vec;
 use std::mem::MaybeUninit;
 
+use rawpointer::PointerExt;
+
 use crate::imp_prelude::*;
 
 use crate::dimension;
@@ -332,15 +334,18 @@ impl<A, D> Array<A, D>
     /// - If the array is empty (the axis or any other has length 0) or if `axis`
     ///   has length 1, then the array can always be appended.
     ///
-    /// ***Errors*** with a layout error if the array is not in standard order or
-    /// if it has holes, even exterior holes (from slicing). <br>
-    /// ***Errors*** with shape error if the length of the input row does not match
-    /// the length of the rows in the array. <br>
+    /// ***Errors*** with shape error if the shape of self does not match the array-to-append;
+    /// all axes *except* the axis along which it being appended matter for this check.
     ///
-    /// The memory layout of the `self` array matters, since it determines in which direction the
-    /// array can easily grow. Notice that an empty array is compatible both ways. The amortized
-    /// average complexity of the append is O(m) where *m* is the number of elements in the
-    /// array-to-append (equivalent to how `Vec::extend` works).
+    /// The memory layout of the `self` array matters for ensuring that the append is efficient.
+    /// Appending automatically changes memory layout of the array so that it is appended to
+    /// along the "growing axis".
+    ///
+    /// Ensure appending is efficient by for example starting from an empty array and/or always
+    /// appending to an array along the same axis.
+    ///
+    /// The amortized average complexity of the append, when appending along its growing axis, is
+    /// O(*m*) where *m* is the length of the row.
     ///
     /// The memory layout of the argument `array` does not matter.
     ///
@@ -404,8 +409,11 @@ impl<A, D> Array<A, D>
         // array must be empty or have `axis` as the outermost (longest stride) axis
         if !self_is_empty && current_axis_len > 1 {
             // `axis` must be max stride axis or equal to its stride
-            let max_stride_axis = self.axes().max_by_key(|ax| ax.stride).unwrap();
-            if max_stride_axis.axis != axis && max_stride_axis.stride > self.stride_of(axis) {
+            let max_axis = self.axes().max_by_key(|ax| ax.stride.abs()).unwrap();
+            if max_axis.axis != axis && max_axis.stride.abs() > self.stride_of(axis) {
+                incompatible_layout = true;
+            }
+            if self.stride_of(axis) < 0 {
                 incompatible_layout = true;
             }
         }
@@ -442,7 +450,8 @@ impl<A, D> Array<A, D>
             // This is the outermost/longest stride axis; so we find the max across the other axes
             let new_stride = self.axes().fold(1, |acc, ax| {
                 if ax.axis == axis { acc } else {
-                    Ord::max(acc, ax.len as isize * ax.stride)
+                    let this_ax = ax.len as isize * ax.stride;
+                    if this_ax.abs() > acc { this_ax } else { acc }
                 }
             });
             let mut strides = self.strides.clone();
@@ -454,37 +463,18 @@ impl<A, D> Array<A, D>
 
         unsafe {
             // grow backing storage and update head ptr
-            debug_assert_eq!(self.data.as_ptr(), self.as_ptr());
-            self.ptr = self.data.reserve(len_to_append); // because we are standard order
-
-            // copy elements from view to the array now
-            //
-            // make a raw view with the new row
-            // safe because the data was "full"
-            let tail_ptr = self.data.as_end_nonnull();
-            let mut tail_view = RawArrayViewMut::new(tail_ptr, array_shape, strides.clone());
-
-            struct SetLenOnDrop<'a, A: 'a> {
-                len: usize,
-                data: &'a mut OwnedRepr<A>,
-            }
-
-            let mut length_guard = SetLenOnDrop {
-                len: self.data.len(),
-                data: &mut self.data,
+            let data_to_array_offset = if std::mem::size_of::<A>() != 0 {
+                self.as_ptr().offset_from(self.data.as_ptr())
+            } else {
+                0
             };
+            debug_assert!(data_to_array_offset >= 0);
+            self.ptr = self.data.reserve(len_to_append).offset(data_to_array_offset);
 
-            impl<A> Drop for SetLenOnDrop<'_, A> {
-                fn drop(&mut self) {
-                    unsafe {
-                        self.data.set_len(self.len);
-                    }
-                }
-            }
-
+            // clone elements from view to the array now
+            //
             // To be robust for panics and drop the right elements, we want
-            // to fill the tail in-order, so that we can drop the right elements on
-            // panic.
+            // to fill the tail in memory order, so that we can drop the right elements on panic.
             //
             // We have: Zip::from(tail_view).and(array)
             // Transform tail_view into standard order by inverting and moving its axes.
@@ -495,23 +485,56 @@ impl<A, D> Array<A, D>
             // doesn't have drop. However, in the interest of code coverage, all elements
             // use this code initially.
 
-            if tail_view.ndim() > 1 {
-                for i in 0..tail_view.ndim() {
-                    if tail_view.stride_of(Axis(i)) < 0 {
-                        tail_view.invert_axis(Axis(i));
+            // Invert axes in tail_view by inverting strides
+            let mut tail_strides = strides.clone();
+            if tail_strides.ndim() > 1 {
+                for i in 0..tail_strides.ndim() {
+                    let s = tail_strides[i] as isize;
+                    if s < 0 {
+                        tail_strides.set_axis(Axis(i), -s as usize);
                         array.invert_axis(Axis(i));
                     }
                 }
-                sort_axes_to_standard_order_tandem(&mut tail_view, &mut array);
+            }
+
+            // With > 0 strides, the current end of data is the correct base pointer for tail_view
+            let tail_ptr = self.data.as_end_nonnull();
+            let mut tail_view = RawArrayViewMut::new(tail_ptr, array_shape, tail_strides);
+
+            if tail_view.ndim() > 1 {
+                sort_axes_in_default_order_tandem(&mut tail_view, &mut array);
+                debug_assert!(tail_view.is_standard_layout(),
+                              "not std layout dim: {:?}, strides: {:?}",
+                              tail_view.shape(), tail_view.strides());
             } 
+
+            // Keep track of currently filled lenght of `self.data` and update it
+            // on scope exit (panic or loop finish).
+            struct SetLenOnDrop<'a, A: 'a> {
+                len: usize,
+                data: &'a mut OwnedRepr<A>,
+            }
+
+            impl<A> Drop for SetLenOnDrop<'_, A> {
+                fn drop(&mut self) {
+                    unsafe {
+                        self.data.set_len(self.len);
+                    }
+                }
+            }
+
+            let mut data_length_guard = SetLenOnDrop {
+                len: self.data.len(),
+                data: &mut self.data,
+            };
+
             Zip::from(tail_view).and(array)
                 .debug_assert_c_order()
                 .for_each(|to, from| {
                     to.write(from.clone());
-                    length_guard.len += 1;
+                    data_length_guard.len += 1;
                 });
-
-            drop(length_guard);
+            drop(data_length_guard);
 
             // update array dimension
             self.strides = strides;
@@ -520,6 +543,7 @@ impl<A, D> Array<A, D>
         // multiple assertions after pointer & dimension update
         debug_assert_eq!(self.data.len(), self.len());
         debug_assert_eq!(self.len(), new_len);
+        debug_assert!(self.pointer_is_inbounds());
 
         Ok(())
     }
@@ -537,20 +561,6 @@ where
         return;
     }
     sort_axes1_impl(&mut a.dim, &mut a.strides);
-}
-
-fn sort_axes_to_standard_order_tandem<S, S2, D>(a: &mut ArrayBase<S, D>, b: &mut ArrayBase<S2, D>)
-where
-    S: RawData,
-    S2: RawData,
-    D: Dimension,
-{
-    if a.ndim() <= 1 {
-        return;
-    }
-    sort_axes_impl(&mut a.dim, &mut a.strides, &mut b.dim, &mut b.strides);
-    debug_assert!(a.is_standard_layout(), "not std layout dim: {:?}, strides: {:?}",
-                  a.shape(), a.strides());
 }
 
 fn sort_axes1_impl<D>(adim: &mut D, astrides: &mut D)
@@ -579,7 +589,23 @@ where
 }
 
 
-fn sort_axes_impl<D>(adim: &mut D, astrides: &mut D, bdim: &mut D, bstrides: &mut D)
+/// Sort axes to standard order, i.e Axis(0) has biggest stride and Axis(n - 1) least stride
+///
+/// Axes in a and b are sorted by the strides of `a`, and `a`'s axes should have stride >= 0 before
+/// calling this method.
+fn sort_axes_in_default_order_tandem<S, S2, D>(a: &mut ArrayBase<S, D>, b: &mut ArrayBase<S2, D>)
+where
+    S: RawData,
+    S2: RawData,
+    D: Dimension,
+{
+    if a.ndim() <= 1 {
+        return;
+    }
+    sort_axes2_impl(&mut a.dim, &mut a.strides, &mut b.dim, &mut b.strides);
+}
+
+fn sort_axes2_impl<D>(adim: &mut D, astrides: &mut D, bdim: &mut D, bstrides: &mut D)
 where
     D: Dimension,
 {

--- a/src/impl_owned_array.rs
+++ b/src/impl_owned_array.rs
@@ -255,10 +255,6 @@ impl<A, D> Array<A, D>
             debug_assert!(data_ptr <= array_memory_head_ptr);
             debug_assert!(array_memory_head_ptr <= data_end_ptr);
 
-            // iter is a raw pointer iterator traversing self_ in its standard order
-            let mut iter = Baseiter::new(self_.ptr.as_ptr(), self_.dim, self_.strides);
-            let mut dropped_elements = 0;
-
             // The idea is simply this: the iterator will yield the elements of self_ in
             // increasing address order.
             //
@@ -267,6 +263,25 @@ impl<A, D> Array<A, D>
             //
             // We have to drop elements in the range from `data_ptr` until (not including)
             // `data_end_ptr`, except those that are produced by `iter`.
+
+            // As an optimization, the innermost axis is removed if it has stride 1, because
+            // we then have a long stretch of contiguous elements we can skip as one.
+            let inner_lane_len;
+            if self_.ndim() > 1 && self_.strides.last_elem() == 1 {
+                self_.dim.slice_mut().rotate_right(1);
+                self_.strides.slice_mut().rotate_right(1);
+                inner_lane_len = self_.dim[0];
+                self_.dim[0] = 1;
+                self_.strides[0] = 1;
+            } else {
+                inner_lane_len = 1;
+            }
+
+            // iter is a raw pointer iterator traversing the array in memory order now with the
+            // sorted axes.
+            let mut iter = Baseiter::new(self_.ptr.as_ptr(), self_.dim, self_.strides);
+            let mut dropped_elements = 0;
+
             let mut last_ptr = data_ptr;
 
             while let Some(elem_ptr) = iter.next() {
@@ -278,8 +293,8 @@ impl<A, D> Array<A, D>
                     last_ptr = last_ptr.add(1);
                     dropped_elements += 1;
                 }
-                // Next interval will continue one past the current element
-                last_ptr = elem_ptr.add(1);
+                // Next interval will continue one past the current lane
+                last_ptr = elem_ptr.add(inner_lane_len);
             }
 
             while last_ptr < data_end_ptr {

--- a/src/impl_owned_array.rs
+++ b/src/impl_owned_array.rs
@@ -438,12 +438,19 @@ impl<A, D> Array<A, D>
         // array must be empty or have `axis` as the outermost (longest stride) axis
         if !self_is_empty && current_axis_len > 1 {
             // `axis` must be max stride axis or equal to its stride
-            let max_axis = self.axes().max_by_key(|ax| ax.stride.abs()).unwrap();
-            if max_axis.axis != axis && max_axis.stride.abs() > self.stride_of(axis) {
+            let axis_stride = self.stride_of(axis);
+            if axis_stride < 0 {
                 incompatible_layout = true;
-            }
-            if self.stride_of(axis) < 0 {
-                incompatible_layout = true;
+            } else {
+                for ax in self.axes() {
+                    if ax.axis == axis {
+                        continue;
+                    }
+                    if ax.len > 1 && ax.stride.abs() > axis_stride {
+                        incompatible_layout = true;
+                        break;
+                    }
+                }
             }
         }
 

--- a/src/impl_owned_array.rs
+++ b/src/impl_owned_array.rs
@@ -540,7 +540,10 @@ impl<A, D> Array<A, D>
                 data: &mut self.data,
             };
 
-            Zip::from(tail_view).and(array)
+
+            // Safety: tail_view is constructed to have the same shape as array
+            Zip::from(tail_view)
+                .and_unchecked(array)
                 .debug_assert_c_order()
                 .for_each(|to, from| {
                     to.write(from.clone());

--- a/src/impl_owned_array.rs
+++ b/src/impl_owned_array.rs
@@ -537,7 +537,9 @@ impl<A, D> Array<A, D>
             } 
 
             // Keep track of currently filled length of `self.data` and update it
-            // on scope exit (panic or loop finish).
+            // on scope exit (panic or loop finish). This "indirect" way to
+            // write the length is used to help the compiler, the len store to self.data may
+            // otherwise be mistaken to alias with other stores in the loop.
             struct SetLenOnDrop<'a, A: 'a> {
                 len: usize,
                 data: &'a mut OwnedRepr<A>,

--- a/src/impl_owned_array.rs
+++ b/src/impl_owned_array.rs
@@ -1,6 +1,11 @@
 
 use alloc::vec::Vec;
+
 use crate::imp_prelude::*;
+use crate::dimension;
+use crate::error::{ErrorKind, ShapeError};
+use crate::OwnedRepr;
+use crate::Zip;
 
 /// Methods specific to `Array0`.
 ///
@@ -59,3 +64,142 @@ where
         self.data.into_vec()
     }
 }
+
+/// Methods specific to `Array2`.
+///
+/// ***See also all methods for [`ArrayBase`]***
+///
+/// [`ArrayBase`]: struct.ArrayBase.html
+impl<A> Array<A, Ix2> {
+    /// Append a row to an array with row major memory layout.
+    ///
+    /// ***Errors*** with a layout error if the array is not in standard order or
+    /// if it has holes, even exterior holes (from slicing). <br>
+    /// ***Errors*** with shape error if the length of the input row does not match
+    /// the length of the rows in the array. <br>
+    ///
+    /// The memory layout matters, since it determines in which direction the array can easily
+    /// grow. Notice that an empty array is compatible both ways. The amortized average
+    /// complexity of the append is O(m) where *m* is the length of the row.
+    ///
+    /// ```rust
+    /// use ndarray::{Array, ArrayView, array};
+    ///
+    /// // create an empty array and append
+    /// let mut a = Array::zeros((0, 4));
+    /// a.try_append_row(ArrayView::from(&[ 1.,  2.,  3.,  4.])).unwrap();
+    /// a.try_append_row(ArrayView::from(&[-1., -2., -3., -4.])).unwrap();
+    ///
+    /// assert_eq!(
+    ///     a,
+    ///     array![[ 1.,  2.,  3.,  4.],
+    ///            [-1., -2., -3., -4.]]);
+    /// ```
+    pub fn try_append_row(&mut self, row: ArrayView<A, Ix1>) -> Result<(), ShapeError>
+    where
+        A: Clone,
+    {
+        let row_len = row.len();
+        if row_len != self.len_of(Axis(1)) {
+            return Err(ShapeError::from_kind(ErrorKind::IncompatibleShape));
+        }
+        let mut res_dim = self.raw_dim();
+        res_dim[0] += 1;
+        let new_len = dimension::size_of_shape_checked(&res_dim)?;
+
+        // array must be c-contiguous and be "full" (have no exterior holes)
+        if !self.is_standard_layout() || self.len() != self.data.len() {
+            return Err(ShapeError::from_kind(ErrorKind::IncompatibleLayout));
+        }
+
+        unsafe {
+            // grow backing storage and update head ptr
+            debug_assert_eq!(self.data.as_ptr(), self.as_ptr());
+            self.ptr = self.data.reserve(row_len);  // because we are standard order
+
+            // recompute strides - if the array was previously empty, it could have
+            // zeros in strides.
+            let strides = res_dim.default_strides();
+
+            // copy elements from view to the array now
+            //
+            // make a raw view with the new row
+            // safe because the data was "full"
+            let tail_ptr = self.data.as_end_nonnull();
+            let tail_view = RawArrayViewMut::new(tail_ptr, Ix1(row_len), Ix1(1));
+
+            struct SetLenOnDrop<'a, A: 'a> {
+                len: usize,
+                data: &'a mut OwnedRepr<A>,
+            }
+
+            let mut length_guard = SetLenOnDrop {
+                len: self.data.len(),
+                data: &mut self.data,
+            };
+
+            impl<A> Drop for SetLenOnDrop<'_, A> {
+                fn drop(&mut self) {
+                    unsafe {
+                        self.data.set_len(self.len);
+                    }
+                }
+            }
+
+            // assign the new elements
+            Zip::from(tail_view).and(row)
+                .for_each(|to, from| {
+                    to.write(from.clone());
+                    length_guard.len += 1;
+                });
+
+            drop(length_guard);
+
+            // update array dimension
+            self.strides = strides;
+            self.dim[0] += 1;
+
+        }
+        // multiple assertions after pointer & dimension update
+        debug_assert_eq!(self.data.len(), self.len());
+        debug_assert_eq!(self.len(), new_len);
+        debug_assert!(self.is_standard_layout());
+
+        Ok(())
+    }
+
+    /// Append a column to an array with column major memory layout.
+    ///
+    /// ***Errors*** with a layout error if the array is not in column major order or
+    /// if it has holes, even exterior holes (from slicing). <br>
+    /// ***Errors*** with shape error if the length of the input column does not match
+    /// the length of the columns in the array.<br>
+    ///
+    /// The memory layout matters, since it determines in which direction the array can easily
+    /// grow. Notice that an empty array is compatible both ways. The amortized average
+    /// complexity of the append is O(m) where *m* is the length of the column.
+    ///
+    /// ```rust
+    /// use ndarray::{Array, ArrayView, array};
+    ///
+    /// // create an empty array and append
+    /// let mut a = Array::zeros((2, 0));
+    /// a.try_append_column(ArrayView::from(&[1., 2.])).unwrap();
+    /// a.try_append_column(ArrayView::from(&[-1., -2.])).unwrap();
+    ///
+    /// assert_eq!(
+    ///     a,
+    ///     array![[1., -1.],
+    ///            [2., -2.]]);
+    /// ```
+    pub fn try_append_column(&mut self, column: ArrayView<A, Ix1>) -> Result<(), ShapeError>
+    where
+        A: Clone,
+    {
+        self.swap_axes(0, 1);
+        let ret = self.try_append_row(column);
+        self.swap_axes(0, 1);
+        ret
+    }
+}
+

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -58,6 +58,7 @@ impl Layout {
 
     /// A simple "score" method which scores positive for preferring C-order, negative for F-order
     /// Subject to change when we can describe other layouts
+    #[inline]
     pub(crate) fn tendency(self) -> i32 {
         (self.is(CORDER) as i32 - self.is(FORDER) as i32) +
         (self.is(CPREFER) as i32 - self.is(FPREFER) as i32)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@
     clippy::deref_addrof,
     clippy::unreadable_literal,
     clippy::manual_map, // is not an error
+    clippy::while_let_on_iterator, // is not an error
 )]
 #![cfg_attr(not(feature = "std"), no_std)]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -235,8 +235,8 @@ pub type Ixs = isize;
 
 /// An *n*-dimensional array.
 ///
-/// The array is a general container of elements. It cannot grow or shrink, but
-/// can be sliced into subsets of its data.
+/// The array is a general container of elements. It cannot grow or shrink (with some exceptions),
+/// but can be sliced into subsets of its data.
 /// The array supports arithmetic operations by applying them elementwise.
 ///
 /// In *n*-dimensional we include for example 1-dimensional rows or columns,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@
     clippy::unreadable_literal,
     clippy::manual_map, // is not an error
     clippy::while_let_on_iterator, // is not an error
+    clippy::from_iter_instead_of_collect, // using from_iter is good style
 )]
 #![cfg_attr(not(feature = "std"), no_std)]
 

--- a/src/stacking.rs
+++ b/src/stacking.rs
@@ -94,7 +94,7 @@ where
     let new_len = dimension::size_of_shape_checked(&res_dim)?;
 
     // start with empty array with precomputed capacity
-    // try_append_array's handling of empty arrays makes sure `axis` is ok for appending
+    // append's handling of empty arrays makes sure `axis` is ok for appending
     res_dim.set_axis(axis, 0);
     let mut res = unsafe {
         // Safety: dimension is size 0 and vec is empty
@@ -102,7 +102,7 @@ where
     };
 
     for array in arrays {
-        res.try_append_array(axis, array.clone())?;
+        res.append(axis, array.clone())?;
     }
     debug_assert_eq!(res.len_of(axis), stacked_dim);
     Ok(res)
@@ -161,7 +161,7 @@ where
     let new_len = dimension::size_of_shape_checked(&res_dim)?;
 
     // start with empty array with precomputed capacity
-    // try_append_array's handling of empty arrays makes sure `axis` is ok for appending
+    // append's handling of empty arrays makes sure `axis` is ok for appending
     res_dim.set_axis(axis, 0);
     let mut res = unsafe {
         // Safety: dimension is size 0 and vec is empty
@@ -169,7 +169,7 @@ where
     };
 
     for array in arrays {
-        res.try_append_array(axis, array.clone().insert_axis(axis))?;
+        res.append(axis, array.clone().insert_axis(axis))?;
     }
 
     debug_assert_eq!(res.len_of(axis), arrays.len());

--- a/src/zip/mod.rs
+++ b/src/zip/mod.rs
@@ -673,6 +673,13 @@ macro_rules! map_impl {
                 self.build_and(part)
             }
 
+            #[allow(unused)]
+            #[inline]
+            pub(crate) fn debug_assert_c_order(self) -> Self {
+                debug_assert!(self.layout.is(CORDER) || self.layout_tendency >= 0);
+                self
+            }
+
             fn build_and<P>(self, part: P) -> Zip<($($p,)* P, ), D>
                 where P: NdProducer<Dim=D>,
             {

--- a/src/zip/mod.rs
+++ b/src/zip/mod.rs
@@ -240,22 +240,25 @@ where
     }
 }
 
+#[inline]
+fn zip_dimension_check<D, P>(dimension: &D, part: &P)
+where
+    D: Dimension,
+    P: NdProducer<Dim = D>,
+{
+    ndassert!(
+        part.equal_dim(&dimension),
+        "Zip: Producer dimension mismatch, expected: {:?}, got: {:?}",
+        dimension,
+        part.raw_dim()
+    );
+}
+
+
 impl<Parts, D> Zip<Parts, D>
 where
     D: Dimension,
 {
-    fn check<P>(&self, part: &P)
-    where
-        P: NdProducer<Dim = D>,
-    {
-        ndassert!(
-            part.equal_dim(&self.dimension),
-            "Zip: Producer dimension mismatch, expected: {:?}, got: {:?}",
-            self.dimension,
-            part.raw_dim()
-        );
-    }
-
     /// Return a the number of element tuples in the Zip
     pub fn size(&self) -> usize {
         self.dimension.size()
@@ -652,7 +655,7 @@ macro_rules! map_impl {
                 where P: IntoNdProducer<Dim=D>,
             {
                 let part = p.into_producer();
-                self.check(&part);
+                zip_dimension_check(&self.dimension, &part);
                 self.build_and(part)
             }
 

--- a/src/zip/mod.rs
+++ b/src/zip/mod.rs
@@ -679,6 +679,26 @@ macro_rules! map_impl {
                 self.build_and(part)
             }
 
+            /// Include the producer `p` in the Zip.
+            ///
+            /// ## Safety
+            ///
+            /// The caller must ensure that the producer's shape is equal to the Zip's shape.
+            /// Uses assertions when debug assertions are enabled.
+            #[allow(unused)]
+            pub(crate) unsafe fn and_unchecked<P>(self, p: P) -> Zip<($($p,)* P::Output, ), D>
+                where P: IntoNdProducer<Dim=D>,
+            {
+                #[cfg(debug_assertions)]
+                {
+                    self.and(p)
+                }
+                #[cfg(not(debug_assertions))]
+                {
+                    self.build_and(p.into_producer())
+                }
+            }
+
             /// Include the producer `p` in the Zip, broadcasting if needed.
             ///
             /// If their shapes disagree, `rhs` is broadcast to the shape of `self`.

--- a/tests/append.rs
+++ b/tests/append.rs
@@ -146,3 +146,52 @@ fn append_array_3d() {
                 [83, 84],
                 [87, 88]]]);
 }
+
+#[test]
+fn test_append_2d() {
+    // create an empty array and append
+    let mut a = Array::zeros((0, 4));
+    let ones = ArrayView::from(&[1.; 12]).into_shape((3, 4)).unwrap();
+    let zeros = ArrayView::from(&[0.; 8]).into_shape((2, 4)).unwrap();
+    a.try_append_array(Axis(0), ones).unwrap();
+    a.try_append_array(Axis(0), zeros).unwrap();
+    a.try_append_array(Axis(0), ones).unwrap();
+    println!("{:?}", a);
+    assert_eq!(a.shape(), &[8, 4]);
+    for (i, row) in a.rows().into_iter().enumerate() {
+        let ones = i < 3 || i >= 5;
+        assert!(row.iter().all(|&x| x == ones as i32 as f64), "failed on lane {}", i);
+    }
+
+    let mut a = Array::zeros((0, 4));
+    a = a.reversed_axes();
+    let ones = ones.reversed_axes();
+    let zeros = zeros.reversed_axes();
+    a.try_append_array(Axis(1), ones).unwrap();
+    a.try_append_array(Axis(1), zeros).unwrap();
+    a.try_append_array(Axis(1), ones).unwrap();
+    println!("{:?}", a);
+    assert_eq!(a.shape(), &[4, 8]);
+
+    for (i, row) in a.columns().into_iter().enumerate() {
+        let ones = i < 3 || i >= 5;
+        assert!(row.iter().all(|&x| x == ones as i32 as f64), "failed on lane {}", i);
+    }
+}
+
+#[test]
+fn test_append_middle_axis() {
+    // ensure we can append to Axis(1) by letting it become outermost
+    let mut a = Array::<i32, _>::zeros((3, 0, 2));
+    a.try_append_array(Axis(1), Array::from_iter(0..12).into_shape((3, 2, 2)).unwrap().view()).unwrap();
+    println!("{:?}", a);
+    a.try_append_array(Axis(1), Array::from_iter(12..24).into_shape((3, 2, 2)).unwrap().view()).unwrap();
+    println!("{:?}", a);
+
+    // ensure we can append to Axis(1) by letting it become outermost
+    let mut a = Array::<i32, _>::zeros((3, 1, 2));
+    a.try_append_array(Axis(1), Array::from_iter(0..12).into_shape((3, 2, 2)).unwrap().view()).unwrap();
+    println!("{:?}", a);
+    a.try_append_array(Axis(1), Array::from_iter(12..24).into_shape((3, 2, 2)).unwrap().view()).unwrap();
+    println!("{:?}", a);
+}

--- a/tests/append.rs
+++ b/tests/append.rs
@@ -82,3 +82,26 @@ fn append_column() {
         array![[0., 1., 2., 3.],
                [4., 5., 6., 7.]]);
 }
+
+#[test]
+fn append_array1() {
+    let mut a = Array::zeros((0, 4));
+    a.try_append_array(Axis(0), aview2(&[[0., 1., 2., 3.]])).unwrap();
+    println!("{:?}", a);
+    a.try_append_array(Axis(0), aview2(&[[4., 5., 6., 7.]])).unwrap();
+    println!("{:?}", a);
+    //a.try_append_column(aview1(&[4., 5., 6., 7.])).unwrap();
+    //assert_eq!(a.shape(), &[4, 2]);
+
+    assert_eq!(a,
+        array![[0., 1., 2., 3.],
+               [4., 5., 6., 7.]]);
+
+    a.try_append_array(Axis(0), aview2(&[[5., 5., 4., 4.], [3., 3., 2., 2.]])).unwrap();
+    println!("{:?}", a);
+    assert_eq!(a,
+        array![[0., 1., 2., 3.],
+               [4., 5., 6., 7.],
+               [5., 5., 4., 4.],
+               [3., 3., 2., 2.]]);
+}

--- a/tests/append.rs
+++ b/tests/append.rs
@@ -31,11 +31,19 @@ fn append_row_wrong_layout() {
     a.append_row(aview1(&[4., 5., 6., 7.])).unwrap();
     assert_eq!(a.shape(), &[2, 4]);
 
-    //assert_eq!(a.append_column(aview1(&[1., 2.])), Err(ShapeError::from_kind(ErrorKind::IncompatibleLayout)));
-
     assert_eq!(a,
         array![[0., 1., 2., 3.],
                [4., 5., 6., 7.]]);
+    assert_eq!(a.strides(), &[4, 1]);
+
+    // Changing the memory layout to fit the next append
+    let mut a2 = a.clone();
+    a2.append_column(aview1(&[1., 2.])).unwrap();
+    assert_eq!(a2,
+        array![[0., 1., 2., 3., 1.],
+               [4., 5., 6., 7., 2.]]);
+    assert_eq!(a2.strides(), &[1, 2]);
+
 
     // Clone the array
 
@@ -47,6 +55,92 @@ fn append_row_wrong_layout() {
     assert_eq!(b,
         array![[0., 1., 2., 3., 1.],
                [4., 5., 6., 7., 2.]]);
+}
+
+#[test]
+fn append_row_neg_stride_1() {
+    let mut a = Array::zeros((0, 4));
+    a.append_row(aview1(&[0., 1., 2., 3.])).unwrap();
+    a.append_row(aview1(&[4., 5., 6., 7.])).unwrap();
+    assert_eq!(a.shape(), &[2, 4]);
+
+    assert_eq!(a,
+        array![[0., 1., 2., 3.],
+               [4., 5., 6., 7.]]);
+    assert_eq!(a.strides(), &[4, 1]);
+
+    a.invert_axis(Axis(0));
+
+    // Changing the memory layout to fit the next append
+    let mut a2 = a.clone();
+    println!("a = {:?}", a);
+    println!("a2 = {:?}", a2);
+    a2.append_column(aview1(&[1., 2.])).unwrap();
+    assert_eq!(a2,
+        array![[4., 5., 6., 7., 1.],
+               [0., 1., 2., 3., 2.]]);
+    assert_eq!(a2.strides(), &[1, 2]);
+
+    a.invert_axis(Axis(1));
+    let mut a3 = a.clone();
+    a3.append_row(aview1(&[4., 5., 6., 7.])).unwrap();
+    assert_eq!(a3,
+        array![[7., 6., 5., 4.],
+               [3., 2., 1., 0.],
+               [4., 5., 6., 7.]]);
+    assert_eq!(a3.strides(), &[4, 1]);
+
+    a.invert_axis(Axis(0));
+    let mut a4 = a.clone();
+    a4.append_row(aview1(&[4., 5., 6., 7.])).unwrap();
+    assert_eq!(a4,
+        array![[3., 2., 1., 0.],
+               [7., 6., 5., 4.],
+               [4., 5., 6., 7.]]);
+    assert_eq!(a4.strides(), &[4, -1]);
+}
+
+#[test]
+fn append_row_neg_stride_2() {
+    let mut a = Array::zeros((0, 4));
+    a.append_row(aview1(&[0., 1., 2., 3.])).unwrap();
+    a.append_row(aview1(&[4., 5., 6., 7.])).unwrap();
+    assert_eq!(a.shape(), &[2, 4]);
+
+    assert_eq!(a,
+        array![[0., 1., 2., 3.],
+               [4., 5., 6., 7.]]);
+    assert_eq!(a.strides(), &[4, 1]);
+
+    a.invert_axis(Axis(1));
+
+    // Changing the memory layout to fit the next append
+    let mut a2 = a.clone();
+    println!("a = {:?}", a);
+    println!("a2 = {:?}", a2);
+    a2.append_column(aview1(&[1., 2.])).unwrap();
+    assert_eq!(a2,
+        array![[3., 2., 1., 0., 1.],
+               [7., 6., 5., 4., 2.]]);
+    assert_eq!(a2.strides(), &[1, 2]);
+
+    a.invert_axis(Axis(0));
+    let mut a3 = a.clone();
+    a3.append_row(aview1(&[4., 5., 6., 7.])).unwrap();
+    assert_eq!(a3,
+        array![[7., 6., 5., 4.],
+               [3., 2., 1., 0.],
+               [4., 5., 6., 7.]]);
+    assert_eq!(a3.strides(), &[4, 1]);
+
+    a.invert_axis(Axis(1));
+    let mut a4 = a.clone();
+    a4.append_row(aview1(&[4., 5., 6., 7.])).unwrap();
+    assert_eq!(a4,
+        array![[4., 5., 6., 7.],
+               [0., 1., 2., 3.],
+               [4., 5., 6., 7.]]);
+    assert_eq!(a4.strides(), &[4, 1]);
 }
 
 #[test]

--- a/tests/append.rs
+++ b/tests/append.rs
@@ -105,3 +105,44 @@ fn append_array1() {
                [5., 5., 4., 4.],
                [3., 3., 2., 2.]]);
 }
+
+#[test]
+fn append_array_3d() {
+    let mut a = Array::zeros((0, 2, 2));
+    a.try_append_array(Axis(0), array![[[0, 1], [2, 3]]].view()).unwrap();
+    println!("{:?}", a);
+
+    let aa = array![[[51, 52], [53, 54]], [[55, 56], [57, 58]]];
+    let av = aa.view();
+    println!("Send {:?} to append", av);
+    a.try_append_array(Axis(0), av.clone()).unwrap();
+
+    a.swap_axes(0, 1);
+    let aa = array![[[71, 72], [73, 74]], [[75, 76], [77, 78]]];
+    let mut av = aa.view();
+    av.swap_axes(0, 1);
+    println!("Send {:?} to append", av);
+    a.try_append_array(Axis(1), av.clone()).unwrap();
+    println!("{:?}", a);
+    let aa = array![[[81, 82], [83, 84]], [[85, 86], [87, 88]]];
+    let mut av = aa.view();
+    av.swap_axes(0, 1);
+    println!("Send {:?} to append", av);
+    a.try_append_array(Axis(1), av).unwrap();
+    println!("{:?}", a);
+    assert_eq!(a,
+        array![[[0, 1],
+                [51, 52],
+                [55, 56],
+                [71, 72],
+                [75, 76],
+                [81, 82],
+                [85, 86]],
+               [[2, 3],
+                [53, 54],
+                [57, 58],
+                [73, 74],
+                [77, 78],
+                [83, 84],
+                [87, 88]]]);
+}

--- a/tests/append.rs
+++ b/tests/append.rs
@@ -22,6 +22,32 @@ fn append_row() {
 }
 
 #[test]
+fn append_row_wrong_layout() {
+    let mut a = Array::zeros((0, 4));
+    a.try_append_row(aview1(&[0., 1., 2., 3.])).unwrap();
+    a.try_append_row(aview1(&[4., 5., 6., 7.])).unwrap();
+    assert_eq!(a.shape(), &[2, 4]);
+
+    assert_eq!(a.try_append_column(aview1(&[1., 2.])),
+        Err(ShapeError::from_kind(ErrorKind::IncompatibleLayout)));
+
+    assert_eq!(a,
+        array![[0., 1., 2., 3.],
+               [4., 5., 6., 7.]]);
+
+    // Clone the array
+
+    let mut dim = a.raw_dim();
+    dim[1] = 0;
+    let mut b = Array::zeros(dim);
+    b.try_append_array(Axis(1), a.view()).unwrap();
+    assert_eq!(b.try_append_column(aview1(&[1., 2.])), Ok(()));
+    assert_eq!(b,
+        array![[0., 1., 2., 3., 1.],
+               [4., 5., 6., 7., 2.]]);
+}
+
+#[test]
 fn append_row_error() {
     let mut a = Array::zeros((3, 4));
 

--- a/tests/append.rs
+++ b/tests/append.rs
@@ -195,3 +195,22 @@ fn test_append_middle_axis() {
     a.try_append_array(Axis(1), Array::from_iter(12..24).into_shape((3, 2, 2)).unwrap().view()).unwrap();
     println!("{:?}", a);
 }
+
+#[test]
+fn test_append_zero_size() {
+    {
+        let mut a = Array::<i32, _>::zeros((0, 0));
+        a.try_append_array(Axis(0), aview2(&[[]])).unwrap();
+        a.try_append_array(Axis(0), aview2(&[[]])).unwrap();
+        assert_eq!(a.len(), 0);
+        assert_eq!(a.shape(), &[2, 0]);
+    }
+
+    {
+        let mut a = Array::<i32, _>::zeros((0, 0));
+        a.try_append_array(Axis(1), ArrayView::from(&[]).into_shape((0, 1)).unwrap()).unwrap();
+        a.try_append_array(Axis(1), ArrayView::from(&[]).into_shape((0, 1)).unwrap()).unwrap();
+        assert_eq!(a.len(), 0);
+        assert_eq!(a.shape(), &[0, 2]);
+    }
+}

--- a/tests/append.rs
+++ b/tests/append.rs
@@ -5,19 +5,19 @@ use ndarray::{ShapeError, ErrorKind};
 #[test]
 fn append_row() {
     let mut a = Array::zeros((0, 4));
-    a.try_append_row(aview1(&[0., 1., 2., 3.])).unwrap();
-    a.try_append_row(aview1(&[4., 5., 6., 7.])).unwrap();
+    a.append_row(aview1(&[0., 1., 2., 3.])).unwrap();
+    a.append_row(aview1(&[4., 5., 6., 7.])).unwrap();
     assert_eq!(a.shape(), &[2, 4]);
 
     assert_eq!(a,
         array![[0., 1., 2., 3.],
                [4., 5., 6., 7.]]);
 
-    assert_eq!(a.try_append_row(aview1(&[1.])),
+    assert_eq!(a.append_row(aview1(&[1.])),
         Err(ShapeError::from_kind(ErrorKind::IncompatibleShape)));
-    assert_eq!(a.try_append_column(aview1(&[1.])),
+    assert_eq!(a.append_column(aview1(&[1.])),
         Err(ShapeError::from_kind(ErrorKind::IncompatibleShape)));
-    assert_eq!(a.try_append_column(aview1(&[1., 2.])),
+    assert_eq!(a.append_column(aview1(&[1., 2.])),
         Ok(()));
     assert_eq!(a,
         array![[0., 1., 2., 3., 1.],
@@ -27,11 +27,11 @@ fn append_row() {
 #[test]
 fn append_row_wrong_layout() {
     let mut a = Array::zeros((0, 4));
-    a.try_append_row(aview1(&[0., 1., 2., 3.])).unwrap();
-    a.try_append_row(aview1(&[4., 5., 6., 7.])).unwrap();
+    a.append_row(aview1(&[0., 1., 2., 3.])).unwrap();
+    a.append_row(aview1(&[4., 5., 6., 7.])).unwrap();
     assert_eq!(a.shape(), &[2, 4]);
 
-    //assert_eq!(a.try_append_column(aview1(&[1., 2.])), Err(ShapeError::from_kind(ErrorKind::IncompatibleLayout)));
+    //assert_eq!(a.append_column(aview1(&[1., 2.])), Err(ShapeError::from_kind(ErrorKind::IncompatibleLayout)));
 
     assert_eq!(a,
         array![[0., 1., 2., 3.],
@@ -42,8 +42,8 @@ fn append_row_wrong_layout() {
     let mut dim = a.raw_dim();
     dim[1] = 0;
     let mut b = Array::zeros(dim);
-    b.try_append_array(Axis(1), a.view()).unwrap();
-    assert_eq!(b.try_append_column(aview1(&[1., 2.])), Ok(()));
+    b.append(Axis(1), a.view()).unwrap();
+    assert_eq!(b.append_column(aview1(&[1., 2.])), Ok(()));
     assert_eq!(b,
         array![[0., 1., 2., 3., 1.],
                [4., 5., 6., 7., 2.]]);
@@ -53,11 +53,11 @@ fn append_row_wrong_layout() {
 fn append_row_error() {
     let mut a = Array::zeros((3, 4));
 
-    assert_eq!(a.try_append_row(aview1(&[1.])),
+    assert_eq!(a.append_row(aview1(&[1.])),
         Err(ShapeError::from_kind(ErrorKind::IncompatibleShape)));
-    assert_eq!(a.try_append_column(aview1(&[1.])),
+    assert_eq!(a.append_column(aview1(&[1.])),
         Err(ShapeError::from_kind(ErrorKind::IncompatibleShape)));
-    assert_eq!(a.try_append_column(aview1(&[1., 2., 3.])),
+    assert_eq!(a.append_column(aview1(&[1., 2., 3.])),
         Ok(()));
     assert_eq!(a.t(),
         array![[0., 0., 0.],
@@ -70,8 +70,8 @@ fn append_row_error() {
 #[test]
 fn append_row_existing() {
     let mut a = Array::zeros((1, 4));
-    a.try_append_row(aview1(&[0., 1., 2., 3.])).unwrap();
-    a.try_append_row(aview1(&[4., 5., 6., 7.])).unwrap();
+    a.append_row(aview1(&[0., 1., 2., 3.])).unwrap();
+    a.append_row(aview1(&[4., 5., 6., 7.])).unwrap();
     assert_eq!(a.shape(), &[3, 4]);
 
     assert_eq!(a,
@@ -79,11 +79,11 @@ fn append_row_existing() {
                [0., 1., 2., 3.],
                [4., 5., 6., 7.]]);
 
-    assert_eq!(a.try_append_row(aview1(&[1.])),
+    assert_eq!(a.append_row(aview1(&[1.])),
         Err(ShapeError::from_kind(ErrorKind::IncompatibleShape)));
-    assert_eq!(a.try_append_column(aview1(&[1.])),
+    assert_eq!(a.append_column(aview1(&[1.])),
         Err(ShapeError::from_kind(ErrorKind::IncompatibleShape)));
-    assert_eq!(a.try_append_column(aview1(&[1., 2., 3.])),
+    assert_eq!(a.append_column(aview1(&[1., 2., 3.])),
         Ok(()));
     assert_eq!(a,
         array![[0., 0., 0., 0., 1.],
@@ -95,12 +95,12 @@ fn append_row_existing() {
 fn append_row_col_len_1() {
     // Test appending 1 row and then cols from shape 1 x 1
     let mut a = Array::zeros((1, 1));
-    a.try_append_row(aview1(&[1.])).unwrap(); // shape 2 x 1
-    a.try_append_column(aview1(&[2., 3.])).unwrap(); // shape 2 x 2
-    assert_eq!(a.try_append_row(aview1(&[1.])),
+    a.append_row(aview1(&[1.])).unwrap(); // shape 2 x 1
+    a.append_column(aview1(&[2., 3.])).unwrap(); // shape 2 x 2
+    assert_eq!(a.append_row(aview1(&[1.])),
         Err(ShapeError::from_kind(ErrorKind::IncompatibleShape)));
-    //assert_eq!(a.try_append_row(aview1(&[1., 2.])), Err(ShapeError::from_kind(ErrorKind::IncompatibleLayout)));
-    a.try_append_column(aview1(&[4., 5.])).unwrap(); // shape 2 x 3
+    //assert_eq!(a.append_row(aview1(&[1., 2.])), Err(ShapeError::from_kind(ErrorKind::IncompatibleLayout)));
+    a.append_column(aview1(&[4., 5.])).unwrap(); // shape 2 x 3
     assert_eq!(a.shape(), &[2, 3]);
 
     assert_eq!(a,
@@ -111,8 +111,8 @@ fn append_row_col_len_1() {
 #[test]
 fn append_column() {
     let mut a = Array::zeros((4, 0));
-    a.try_append_column(aview1(&[0., 1., 2., 3.])).unwrap();
-    a.try_append_column(aview1(&[4., 5., 6., 7.])).unwrap();
+    a.append_column(aview1(&[0., 1., 2., 3.])).unwrap();
+    a.append_column(aview1(&[4., 5., 6., 7.])).unwrap();
     assert_eq!(a.shape(), &[4, 2]);
 
     assert_eq!(a.t(),
@@ -123,18 +123,18 @@ fn append_column() {
 #[test]
 fn append_array1() {
     let mut a = Array::zeros((0, 4));
-    a.try_append_array(Axis(0), aview2(&[[0., 1., 2., 3.]])).unwrap();
+    a.append(Axis(0), aview2(&[[0., 1., 2., 3.]])).unwrap();
     println!("{:?}", a);
-    a.try_append_array(Axis(0), aview2(&[[4., 5., 6., 7.]])).unwrap();
+    a.append(Axis(0), aview2(&[[4., 5., 6., 7.]])).unwrap();
     println!("{:?}", a);
-    //a.try_append_column(aview1(&[4., 5., 6., 7.])).unwrap();
+    //a.append_column(aview1(&[4., 5., 6., 7.])).unwrap();
     //assert_eq!(a.shape(), &[4, 2]);
 
     assert_eq!(a,
         array![[0., 1., 2., 3.],
                [4., 5., 6., 7.]]);
 
-    a.try_append_array(Axis(0), aview2(&[[5., 5., 4., 4.], [3., 3., 2., 2.]])).unwrap();
+    a.append(Axis(0), aview2(&[[5., 5., 4., 4.], [3., 3., 2., 2.]])).unwrap();
     println!("{:?}", a);
     assert_eq!(a,
         array![[0., 1., 2., 3.],
@@ -146,26 +146,26 @@ fn append_array1() {
 #[test]
 fn append_array_3d() {
     let mut a = Array::zeros((0, 2, 2));
-    a.try_append_array(Axis(0), array![[[0, 1], [2, 3]]].view()).unwrap();
+    a.append(Axis(0), array![[[0, 1], [2, 3]]].view()).unwrap();
     println!("{:?}", a);
 
     let aa = array![[[51, 52], [53, 54]], [[55, 56], [57, 58]]];
     let av = aa.view();
     println!("Send {:?} to append", av);
-    a.try_append_array(Axis(0), av.clone()).unwrap();
+    a.append(Axis(0), av.clone()).unwrap();
 
     a.swap_axes(0, 1);
     let aa = array![[[71, 72], [73, 74]], [[75, 76], [77, 78]]];
     let mut av = aa.view();
     av.swap_axes(0, 1);
     println!("Send {:?} to append", av);
-    a.try_append_array(Axis(1), av.clone()).unwrap();
+    a.append(Axis(1), av.clone()).unwrap();
     println!("{:?}", a);
     let aa = array![[[81, 82], [83, 84]], [[85, 86], [87, 88]]];
     let mut av = aa.view();
     av.swap_axes(0, 1);
     println!("Send {:?} to append", av);
-    a.try_append_array(Axis(1), av).unwrap();
+    a.append(Axis(1), av).unwrap();
     println!("{:?}", a);
     assert_eq!(a,
         array![[[0, 1],
@@ -190,9 +190,9 @@ fn test_append_2d() {
     let mut a = Array::zeros((0, 4));
     let ones = ArrayView::from(&[1.; 12]).into_shape((3, 4)).unwrap();
     let zeros = ArrayView::from(&[0.; 8]).into_shape((2, 4)).unwrap();
-    a.try_append_array(Axis(0), ones).unwrap();
-    a.try_append_array(Axis(0), zeros).unwrap();
-    a.try_append_array(Axis(0), ones).unwrap();
+    a.append(Axis(0), ones).unwrap();
+    a.append(Axis(0), zeros).unwrap();
+    a.append(Axis(0), ones).unwrap();
     println!("{:?}", a);
     assert_eq!(a.shape(), &[8, 4]);
     for (i, row) in a.rows().into_iter().enumerate() {
@@ -204,9 +204,9 @@ fn test_append_2d() {
     a = a.reversed_axes();
     let ones = ones.reversed_axes();
     let zeros = zeros.reversed_axes();
-    a.try_append_array(Axis(1), ones).unwrap();
-    a.try_append_array(Axis(1), zeros).unwrap();
-    a.try_append_array(Axis(1), ones).unwrap();
+    a.append(Axis(1), ones).unwrap();
+    a.append(Axis(1), zeros).unwrap();
+    a.append(Axis(1), ones).unwrap();
     println!("{:?}", a);
     assert_eq!(a.shape(), &[4, 8]);
 
@@ -220,16 +220,16 @@ fn test_append_2d() {
 fn test_append_middle_axis() {
     // ensure we can append to Axis(1) by letting it become outermost
     let mut a = Array::<i32, _>::zeros((3, 0, 2));
-    a.try_append_array(Axis(1), Array::from_iter(0..12).into_shape((3, 2, 2)).unwrap().view()).unwrap();
+    a.append(Axis(1), Array::from_iter(0..12).into_shape((3, 2, 2)).unwrap().view()).unwrap();
     println!("{:?}", a);
-    a.try_append_array(Axis(1), Array::from_iter(12..24).into_shape((3, 2, 2)).unwrap().view()).unwrap();
+    a.append(Axis(1), Array::from_iter(12..24).into_shape((3, 2, 2)).unwrap().view()).unwrap();
     println!("{:?}", a);
 
     // ensure we can append to Axis(1) by letting it become outermost
     let mut a = Array::<i32, _>::zeros((3, 1, 2));
-    a.try_append_array(Axis(1), Array::from_iter(0..12).into_shape((3, 2, 2)).unwrap().view()).unwrap();
+    a.append(Axis(1), Array::from_iter(0..12).into_shape((3, 2, 2)).unwrap().view()).unwrap();
     println!("{:?}", a);
-    a.try_append_array(Axis(1), Array::from_iter(12..24).into_shape((3, 2, 2)).unwrap().view()).unwrap();
+    a.append(Axis(1), Array::from_iter(12..24).into_shape((3, 2, 2)).unwrap().view()).unwrap();
     println!("{:?}", a);
 }
 
@@ -237,16 +237,16 @@ fn test_append_middle_axis() {
 fn test_append_zero_size() {
     {
         let mut a = Array::<i32, _>::zeros((0, 0));
-        a.try_append_array(Axis(0), aview2(&[[]])).unwrap();
-        a.try_append_array(Axis(0), aview2(&[[]])).unwrap();
+        a.append(Axis(0), aview2(&[[]])).unwrap();
+        a.append(Axis(0), aview2(&[[]])).unwrap();
         assert_eq!(a.len(), 0);
         assert_eq!(a.shape(), &[2, 0]);
     }
 
     {
         let mut a = Array::<i32, _>::zeros((0, 0));
-        a.try_append_array(Axis(1), ArrayView::from(&[]).into_shape((0, 1)).unwrap()).unwrap();
-        a.try_append_array(Axis(1), ArrayView::from(&[]).into_shape((0, 1)).unwrap()).unwrap();
+        a.append(Axis(1), ArrayView::from(&[]).into_shape((0, 1)).unwrap()).unwrap();
+        a.append(Axis(1), ArrayView::from(&[]).into_shape((0, 1)).unwrap()).unwrap();
         assert_eq!(a.len(), 0);
         assert_eq!(a.shape(), &[0, 2]);
     }

--- a/tests/append.rs
+++ b/tests/append.rs
@@ -18,7 +18,10 @@ fn append_row() {
     assert_eq!(a.try_append_column(aview1(&[1.])),
         Err(ShapeError::from_kind(ErrorKind::IncompatibleShape)));
     assert_eq!(a.try_append_column(aview1(&[1., 2.])),
-        Err(ShapeError::from_kind(ErrorKind::IncompatibleLayout)));
+        Ok(()));
+    assert_eq!(a,
+        array![[0., 1., 2., 3., 1.],
+               [4., 5., 6., 7., 2.]]);
 }
 
 #[test]
@@ -28,8 +31,7 @@ fn append_row_wrong_layout() {
     a.try_append_row(aview1(&[4., 5., 6., 7.])).unwrap();
     assert_eq!(a.shape(), &[2, 4]);
 
-    assert_eq!(a.try_append_column(aview1(&[1., 2.])),
-        Err(ShapeError::from_kind(ErrorKind::IncompatibleLayout)));
+    //assert_eq!(a.try_append_column(aview1(&[1., 2.])), Err(ShapeError::from_kind(ErrorKind::IncompatibleLayout)));
 
     assert_eq!(a,
         array![[0., 1., 2., 3.],
@@ -56,7 +58,13 @@ fn append_row_error() {
     assert_eq!(a.try_append_column(aview1(&[1.])),
         Err(ShapeError::from_kind(ErrorKind::IncompatibleShape)));
     assert_eq!(a.try_append_column(aview1(&[1., 2., 3.])),
-        Err(ShapeError::from_kind(ErrorKind::IncompatibleLayout)));
+        Ok(()));
+    assert_eq!(a.t(),
+        array![[0., 0., 0.],
+               [0., 0., 0.],
+               [0., 0., 0.],
+               [0., 0., 0.],
+               [1., 2., 3.]]);
 }
 
 #[test]
@@ -76,7 +84,11 @@ fn append_row_existing() {
     assert_eq!(a.try_append_column(aview1(&[1.])),
         Err(ShapeError::from_kind(ErrorKind::IncompatibleShape)));
     assert_eq!(a.try_append_column(aview1(&[1., 2., 3.])),
-        Err(ShapeError::from_kind(ErrorKind::IncompatibleLayout)));
+        Ok(()));
+    assert_eq!(a,
+        array![[0., 0., 0., 0., 1.],
+               [0., 1., 2., 3., 2.],
+               [4., 5., 6., 7., 3.]]);
 }
 
 #[test]
@@ -87,8 +99,7 @@ fn append_row_col_len_1() {
     a.try_append_column(aview1(&[2., 3.])).unwrap(); // shape 2 x 2
     assert_eq!(a.try_append_row(aview1(&[1.])),
         Err(ShapeError::from_kind(ErrorKind::IncompatibleShape)));
-    assert_eq!(a.try_append_row(aview1(&[1., 2.])),
-        Err(ShapeError::from_kind(ErrorKind::IncompatibleLayout)));
+    //assert_eq!(a.try_append_row(aview1(&[1., 2.])), Err(ShapeError::from_kind(ErrorKind::IncompatibleLayout)));
     a.try_append_column(aview1(&[4., 5.])).unwrap(); // shape 2 x 3
     assert_eq!(a.shape(), &[2, 3]);
 

--- a/tests/append.rs
+++ b/tests/append.rs
@@ -345,3 +345,34 @@ fn test_append_zero_size() {
         assert_eq!(a.shape(), &[0, 2]);
     }
 }
+
+#[test]
+fn append_row_neg_stride_3() {
+    let mut a = Array::zeros((0, 4));
+    a.append_row(aview1(&[0., 1., 2., 3.])).unwrap();
+    a.invert_axis(Axis(1));
+    a.append_row(aview1(&[4., 5., 6., 7.])).unwrap();
+    assert_eq!(a.shape(), &[2, 4]);
+    assert_eq!(a, array![[3., 2., 1., 0.], [4., 5., 6., 7.]]);
+    assert_eq!(a.strides(), &[4, -1]);
+}
+
+#[test]
+fn append_row_ignore_strides_length_one_axes() {
+    let strides = &[0, 1, 10, 20];
+    for invert in &[vec![], vec![0], vec![1], vec![0, 1]] {
+        for &stride0 in strides {
+            for &stride1 in strides {
+                let mut a =
+                    Array::from_shape_vec([1, 1].strides([stride0, stride1]), vec![0.]).unwrap();
+                for &ax in invert {
+                    a.invert_axis(Axis(ax));
+                }
+                a.append_row(aview1(&[1.])).unwrap();
+                assert_eq!(a.shape(), &[2, 1]);
+                assert_eq!(a, array![[0.], [1.]]);
+                assert_eq!(a.stride_of(Axis(0)), 1);
+            }
+        }
+    }
+}

--- a/tests/append.rs
+++ b/tests/append.rs
@@ -1,0 +1,84 @@
+
+use ndarray::prelude::*;
+use ndarray::{ShapeError, ErrorKind};
+
+#[test]
+fn append_row() {
+    let mut a = Array::zeros((0, 4));
+    a.try_append_row(aview1(&[0., 1., 2., 3.])).unwrap();
+    a.try_append_row(aview1(&[4., 5., 6., 7.])).unwrap();
+    assert_eq!(a.shape(), &[2, 4]);
+
+    assert_eq!(a,
+        array![[0., 1., 2., 3.],
+               [4., 5., 6., 7.]]);
+
+    assert_eq!(a.try_append_row(aview1(&[1.])),
+        Err(ShapeError::from_kind(ErrorKind::IncompatibleShape)));
+    assert_eq!(a.try_append_column(aview1(&[1.])),
+        Err(ShapeError::from_kind(ErrorKind::IncompatibleShape)));
+    assert_eq!(a.try_append_column(aview1(&[1., 2.])),
+        Err(ShapeError::from_kind(ErrorKind::IncompatibleLayout)));
+}
+
+#[test]
+fn append_row_error() {
+    let mut a = Array::zeros((3, 4));
+
+    assert_eq!(a.try_append_row(aview1(&[1.])),
+        Err(ShapeError::from_kind(ErrorKind::IncompatibleShape)));
+    assert_eq!(a.try_append_column(aview1(&[1.])),
+        Err(ShapeError::from_kind(ErrorKind::IncompatibleShape)));
+    assert_eq!(a.try_append_column(aview1(&[1., 2., 3.])),
+        Err(ShapeError::from_kind(ErrorKind::IncompatibleLayout)));
+}
+
+#[test]
+fn append_row_existing() {
+    let mut a = Array::zeros((1, 4));
+    a.try_append_row(aview1(&[0., 1., 2., 3.])).unwrap();
+    a.try_append_row(aview1(&[4., 5., 6., 7.])).unwrap();
+    assert_eq!(a.shape(), &[3, 4]);
+
+    assert_eq!(a,
+        array![[0., 0., 0., 0.],
+               [0., 1., 2., 3.],
+               [4., 5., 6., 7.]]);
+
+    assert_eq!(a.try_append_row(aview1(&[1.])),
+        Err(ShapeError::from_kind(ErrorKind::IncompatibleShape)));
+    assert_eq!(a.try_append_column(aview1(&[1.])),
+        Err(ShapeError::from_kind(ErrorKind::IncompatibleShape)));
+    assert_eq!(a.try_append_column(aview1(&[1., 2., 3.])),
+        Err(ShapeError::from_kind(ErrorKind::IncompatibleLayout)));
+}
+
+#[test]
+fn append_row_col_len_1() {
+    // Test appending 1 row and then cols from shape 1 x 1
+    let mut a = Array::zeros((1, 1));
+    a.try_append_row(aview1(&[1.])).unwrap(); // shape 2 x 1
+    a.try_append_column(aview1(&[2., 3.])).unwrap(); // shape 2 x 2
+    assert_eq!(a.try_append_row(aview1(&[1.])),
+        Err(ShapeError::from_kind(ErrorKind::IncompatibleShape)));
+    assert_eq!(a.try_append_row(aview1(&[1., 2.])),
+        Err(ShapeError::from_kind(ErrorKind::IncompatibleLayout)));
+    a.try_append_column(aview1(&[4., 5.])).unwrap(); // shape 2 x 3
+    assert_eq!(a.shape(), &[2, 3]);
+
+    assert_eq!(a,
+        array![[0., 2., 4.],
+               [1., 3., 5.]]);
+}
+
+#[test]
+fn append_column() {
+    let mut a = Array::zeros((4, 0));
+    a.try_append_column(aview1(&[0., 1., 2., 3.])).unwrap();
+    a.try_append_column(aview1(&[4., 5., 6., 7.])).unwrap();
+    assert_eq!(a.shape(), &[4, 2]);
+
+    assert_eq!(a.t(),
+        array![[0., 1., 2., 3.],
+               [4., 5., 6., 7.]]);
+}

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -710,6 +710,19 @@ fn test_select() {
 }
 
 #[test]
+fn test_select_1d() {
+    let x = arr1(&[0, 1, 2, 3, 4, 5, 6]);
+    let r1 = x.select(Axis(0), &[1, 3, 4, 2, 2, 5]);
+    assert_eq!(r1, arr1(&[1, 3, 4, 2, 2, 5]));
+    // select nothing
+    let r2 = x.select(Axis(0), &[]);
+    assert_eq!(r2, arr1(&[]));
+    // select nothing from empty
+    let r3 = r2.select(Axis(0), &[]);
+    assert_eq!(r3, arr1(&[]));
+}
+
+#[test]
 fn diag() {
     let d = arr2(&[[1., 2., 3.0f32]]).into_diag();
     assert_eq!(d.dim(), 1);

--- a/tests/assign.rs
+++ b/tests/assign.rs
@@ -1,0 +1,237 @@
+use ndarray::prelude::*;
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+#[test]
+fn assign() {
+    let mut a = arr2(&[[1., 2.], [3., 4.]]);
+    let b = arr2(&[[1., 3.], [2., 4.]]);
+    a.assign(&b);
+    assert_eq!(a, b);
+
+    /* Test broadcasting */
+    a.assign(&ArcArray::zeros(1));
+    assert_eq!(a, ArcArray::zeros((2, 2)));
+
+    /* Test other type */
+    a.assign(&Array::from_elem((2, 2), 3.));
+    assert_eq!(a, ArcArray::from_elem((2, 2), 3.));
+
+    /* Test mut view */
+    let mut a = arr2(&[[1, 2], [3, 4]]);
+    {
+        let mut v = a.view_mut();
+        v.slice_collapse(s![..1, ..]);
+        v.fill(0);
+    }
+    assert_eq!(a, arr2(&[[0, 0], [3, 4]]));
+}
+
+
+#[test]
+fn assign_to() {
+    let mut a = arr2(&[[1., 2.], [3., 4.]]);
+    let b = arr2(&[[0., 3.], [2., 0.]]);
+    b.assign_to(&mut a);
+    assert_eq!(a, b);
+}
+
+#[test]
+fn move_into_copy() {
+    let a = arr2(&[[1., 2.], [3., 4.]]);
+    let acopy = a.clone();
+    let mut b = Array::uninit(a.dim());
+    a.move_into(b.view_mut());
+    let b = unsafe { b.assume_init() };
+    assert_eq!(acopy, b);
+
+    let a = arr2(&[[1., 2.], [3., 4.]]).reversed_axes();
+    let acopy = a.clone();
+    let mut b = Array::uninit(a.dim());
+    a.move_into(b.view_mut());
+    let b = unsafe { b.assume_init() };
+    assert_eq!(acopy, b);
+}
+
+#[test]
+fn move_into_owned() {
+    // Test various memory layouts and holes while moving String elements.
+    for &use_f_order in &[false, true] {
+        for &invert_axis in &[0b00, 0b01, 0b10, 0b11] { // bitmask for axis to invert
+            for &slice in &[false, true] {
+                let mut a = Array::from_shape_fn((5, 4).set_f(use_f_order),
+                                                 |idx| format!("{:?}", idx));
+                if slice {
+                    a.slice_collapse(s![1..-1, ..;2]);
+                }
+
+                if invert_axis & 0b01 != 0 {
+                    a.invert_axis(Axis(0));
+                }
+                if invert_axis & 0b10 != 0 {
+                    a.invert_axis(Axis(1));
+                }
+
+                let acopy = a.clone();
+                let mut b = Array::uninit(a.dim());
+                a.move_into(b.view_mut());
+                let b = unsafe { b.assume_init() };
+
+                assert_eq!(acopy, b);
+            }
+        }
+    }
+}
+
+#[test]
+fn move_into_slicing() {
+    // Count correct number of drops when using move_into and discontiguous arrays (with holes).
+    for &use_f_order in &[false, true] {
+        for &invert_axis in &[0b00, 0b01, 0b10, 0b11] { // bitmask for axis to invert
+            let counter = DropCounter::default();
+            {
+                let (m, n) = (5, 4);
+
+                let mut a = Array::from_shape_fn((m, n).set_f(use_f_order), |_idx| counter.element());
+                a.slice_collapse(s![1..-1, ..;2]);
+                if invert_axis & 0b01 != 0 {
+                    a.invert_axis(Axis(0));
+                }
+                if invert_axis & 0b10 != 0 {
+                    a.invert_axis(Axis(1));
+                }
+
+                let mut b = Array::uninit(a.dim());
+                a.move_into(b.view_mut());
+                let b = unsafe { b.assume_init() };
+
+                let total = m * n;
+                let dropped_1 = total - (m - 2) * (n - 2);
+                assert_eq!(counter.created(), total);
+                assert_eq!(counter.dropped(), dropped_1);
+                drop(b);
+            }
+            counter.assert_drop_count();
+        }
+    }
+}
+
+#[test]
+fn move_into_diag() {
+    // Count correct number of drops when using move_into and discontiguous arrays (with holes).
+    for &use_f_order in &[false, true] {
+        let counter = DropCounter::default();
+        {
+            let (m, n) = (5, 4);
+
+            let a = Array::from_shape_fn((m, n).set_f(use_f_order), |_idx| counter.element());
+            let a = a.into_diag();
+
+            let mut b = Array::uninit(a.dim());
+            a.move_into(b.view_mut());
+            let b = unsafe { b.assume_init() };
+
+            let total = m * n;
+            let dropped_1 = total - Ord::min(m, n);
+            assert_eq!(counter.created(), total);
+            assert_eq!(counter.dropped(), dropped_1);
+            drop(b);
+        }
+        counter.assert_drop_count();
+    }
+}
+
+#[test]
+fn move_into_0dim() {
+    // Count correct number of drops when using move_into and discontiguous arrays (with holes).
+    for &use_f_order in &[false, true] {
+        let counter = DropCounter::default();
+        {
+            let (m, n) = (5, 4);
+
+            // slice into a 0-dim array
+            let a = Array::from_shape_fn((m, n).set_f(use_f_order), |_idx| counter.element());
+            let a = a.slice_move(s![2, 2]);
+
+            assert_eq!(a.ndim(), 0);
+            let mut b = Array::uninit(a.dim());
+            a.move_into(b.view_mut());
+            let b = unsafe { b.assume_init() };
+
+            let total = m * n;
+            let dropped_1 = total - 1;
+            assert_eq!(counter.created(), total);
+            assert_eq!(counter.dropped(), dropped_1);
+            drop(b);
+        }
+        counter.assert_drop_count();
+    }
+}
+
+#[test]
+fn move_into_empty() {
+    // Count correct number of drops when using move_into and discontiguous arrays (with holes).
+    for &use_f_order in &[false, true] {
+        let counter = DropCounter::default();
+        {
+            let (m, n) = (5, 4);
+
+            // slice into an empty array;
+            let a = Array::from_shape_fn((m, n).set_f(use_f_order), |_idx| counter.element());
+            let a = a.slice_move(s![..0, 1..1]);
+            assert!(a.is_empty());
+            let mut b = Array::uninit(a.dim());
+            a.move_into(b.view_mut());
+            let b = unsafe { b.assume_init() };
+
+            let total = m * n;
+            let dropped_1 = total;
+            assert_eq!(counter.created(), total);
+            assert_eq!(counter.dropped(), dropped_1);
+            drop(b);
+        }
+        counter.assert_drop_count();
+    }
+}
+
+
+/// This counter can create elements, and then count and verify
+/// the number of which have actually been dropped again.
+#[derive(Default)]
+struct DropCounter {
+    created: AtomicUsize,
+    dropped: AtomicUsize,
+}
+
+struct Element<'a>(&'a AtomicUsize);
+
+impl DropCounter {
+    fn created(&self) -> usize {
+        self.created.load(Ordering::Relaxed)
+    }
+
+    fn dropped(&self) -> usize {
+        self.dropped.load(Ordering::Relaxed)
+    }
+
+    fn element(&self) -> Element<'_> {
+        self.created.fetch_add(1, Ordering::Relaxed);
+        Element(&self.dropped)
+    }
+
+    fn assert_drop_count(&self) {
+        assert_eq!(
+            self.created(),
+            self.dropped(),
+            "Expected {} dropped elements, but found {}",
+            self.created(),
+            self.dropped()
+        );
+    }
+}
+
+impl<'a> Drop for Element<'a> {
+    fn drop(&mut self) {
+        self.0.fetch_add(1, Ordering::Relaxed);
+    }
+}

--- a/tests/higher_order_f.rs
+++ b/tests/higher_order_f.rs
@@ -6,37 +6,3 @@ fn test_fold_axis_oob() {
     let a = arr2(&[[1., 2.], [3., 4.]]);
     a.fold_axis(Axis(2), 0., |x, y| x + y);
 }
-
-#[test]
-fn assign() {
-    let mut a = arr2(&[[1., 2.], [3., 4.]]);
-    let b = arr2(&[[1., 3.], [2., 4.]]);
-    a.assign(&b);
-    assert_eq!(a, b);
-
-    /* Test broadcasting */
-    a.assign(&ArcArray::zeros(1));
-    assert_eq!(a, ArcArray::zeros((2, 2)));
-
-    /* Test other type */
-    a.assign(&Array::from_elem((2, 2), 3.));
-    assert_eq!(a, ArcArray::from_elem((2, 2), 3.));
-
-    /* Test mut view */
-    let mut a = arr2(&[[1, 2], [3, 4]]);
-    {
-        let mut v = a.view_mut();
-        v.slice_collapse(s![..1, ..]);
-        v.fill(0);
-    }
-    assert_eq!(a, arr2(&[[0, 0], [3, 4]]));
-}
-
-
-#[test]
-fn assign_to() {
-    let mut a = arr2(&[[1., 2.], [3., 4.]]);
-    let b = arr2(&[[0., 3.], [2., 0.]]);
-    b.assign_to(&mut a);
-    assert_eq!(a, b);
-}

--- a/tests/stacking.rs
+++ b/tests/stacking.rs
@@ -20,7 +20,7 @@ fn concatenating() {
                            [2., 9.]]));
 
     let d = concatenate![Axis(0), a.row(0).insert_axis(Axis(1)), aview1(&[9., 9.]).insert_axis(Axis(1))];
-    assert_eq!(d.t(), aview2(&[[2., 2., 9., 9.]]));
+    assert_eq!(d, aview2(&[[2.], [2.], [9.], [9.]]));
 
     let res = ndarray::concatenate(Axis(1), &[a.view(), c.view()]);
     assert_eq!(res.unwrap_err().kind(), ErrorKind::IncompatibleShape);

--- a/tests/stacking.rs
+++ b/tests/stacking.rs
@@ -1,4 +1,4 @@
-use ndarray::{arr2, arr3, aview1, concatenate, stack, Array2, Axis, ErrorKind, Ix1};
+use ndarray::{arr2, arr3, aview1, aview2, concatenate, stack, Array2, Axis, ErrorKind, Ix1};
 
 #[test]
 fn concatenating() {
@@ -14,6 +14,13 @@ fn concatenating() {
 
     let d = concatenate![Axis(0), a.row(0), &[9., 9.]];
     assert_eq!(d, aview1(&[2., 2., 9., 9.]));
+
+    let d = concatenate![Axis(1), a.row(0).insert_axis(Axis(1)), aview1(&[9., 9.]).insert_axis(Axis(1))];
+    assert_eq!(d, aview2(&[[2., 9.],
+                           [2., 9.]]));
+
+    let d = concatenate![Axis(0), a.row(0).insert_axis(Axis(1)), aview1(&[9., 9.]).insert_axis(Axis(1))];
+    assert_eq!(d.t(), aview2(&[[2., 2., 9., 9.]]));
 
     let res = ndarray::concatenate(Axis(1), &[a.view(), c.view()]);
     assert_eq!(res.unwrap_err().kind(), ErrorKind::IncompatibleShape);


### PR DESCRIPTION
For owned arrays specifically (Array), allow appending rows and/or columns or 
whole arrays (along a given axis).

**New methods:**

- `.append_row(ArrayView1<A>) -> Result`
- `.append_column(ArrayView1<A>) -> Result`
- `.append(axis, ArrayView<A, D>) -> Result`
- `.move_into(impl Into<ArrayViewMut>)`

**New features:**

- `stack`, `concatenate` and `.select(...)` now support Clone elements
  (previously only Copy).

The axis we append along should be a "growing axis", i.e the axis with greatest,
and positive, stride. However if that axis is of length 0 or 1, we can always
convert it to the new growing axis.

These methods automatically move the whole array to a compatible memory
layout for appending, if needed.

The examples show that empty arrays are valid both ways (both memory
layouts) - and that might be the easiest way to use these methods for the users.

There were quite a few corner cases in the implementation in this PR, but hopefully
they should all be dealt with in a moderately clean way and with little duplication.

Fixes #269 