### PR TITLE
Deprecate stack_new_axis (Use stack)

### DIFF
--- a/src/doc/ndarray_for_numpy_users/mod.rs
+++ b/src/doc/ndarray_for_numpy_users/mod.rs
@@ -530,8 +530,8 @@
 //! ------|-----------|------
 //! `a[:] = 3.` | [`a.fill(3.)`][.fill()] | set all array elements to the same scalar value
 //! `a[:] = b` | [`a.assign(&b)`][.assign()] | copy the data from array `b` into array `a`
-//! `np.concatenate((a,b), axis=1)` | [`stack![Axis(1), a, b]`][stack!] or [`stack(Axis(1), &[a.view(), b.view()])`][stack()] | concatenate arrays `a` and `b` along axis 1
-//! `np.stack((a,b), axis=1)` | [`stack_new_axis![Axis(1), a, b]`][stack_new_axis!] or [`stack_new_axis(Axis(1), vec![a.view(), b.view()])`][stack_new_axis()] | stack arrays `a` and `b` along axis 1
+//! `np.concatenate((a,b), axis=1)` | [`concatenate![Axis(1), a, b]`][concatenate!] or [`concatenate(Axis(1), &[a.view(), b.view()])`][concatenate()] | concatenate arrays `a` and `b` along axis 1
+//! `np.stack((a,b), axis=1)` | [`stack![Axis(1), a, b]`][stack!] or [`stack(Axis(1), vec![a.view(), b.view()])`][stack()] | stack arrays `a` and `b` along axis 1
 //! `a[:,np.newaxis]` or `np.expand_dims(a, axis=1)` | [`a.insert_axis(Axis(1))`][.insert_axis()] | create an array from `a`, inserting a new axis 1
 //! `a.transpose()` or `a.T` | [`a.t()`][.t()] or [`a.reversed_axes()`][.reversed_axes()] | transpose of array `a` (view for `.t()` or by-move for `.reversed_axes()`)
 //! `np.diag(a)` | [`a.diag()`][.diag()] | view the diagonal of `a`
@@ -585,6 +585,8 @@
 //! [.ncols()]: ../../struct.ArrayBase.html#method.ncols
 //! [.column()]: ../../struct.ArrayBase.html#method.column
 //! [.column_mut()]: ../../struct.ArrayBase.html#method.column_mut
+//! [concatenate!]: ../../macro.concatenate.html
+//! [concatenate()]: ../../fn.concatenate.html
 //! [CowArray]: ../../type.CowArray.html
 //! [::default()]: ../../struct.ArrayBase.html#method.default
 //! [.diag()]: ../../struct.ArrayBase.html#method.diag
@@ -641,8 +643,6 @@
 //! [.shape()]: ../../struct.ArrayBase.html#method.shape
 //! [stack!]: ../../macro.stack.html
 //! [stack()]: ../../fn.stack.html
-//! [stack_new_axis!]: ../../macro.stack_new_axis.html
-//! [stack_new_axis()]: ../../fn.stack_new_axis.html
 //! [.strides()]: ../../struct.ArrayBase.html#method.strides
 //! [.index_axis()]: ../../struct.ArrayBase.html#method.index_axis
 //! [.sum_axis()]: ../../struct.ArrayBase.html#method.sum_axis

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,6 +151,7 @@ pub use crate::arraytraits::AsArray;
 pub use crate::linalg_traits::NdFloat;
 pub use crate::linalg_traits::LinalgScalar;
 
+#[allow(deprecated)] // stack_new_axis
 pub use crate::stacking::{concatenate, stack, stack_new_axis};
 
 pub use crate::math_cell::MathCell;

--- a/src/stacking.rs
+++ b/src/stacking.rs
@@ -43,6 +43,7 @@ where
     D: Dimension,
     D::Larger: RemoveAxis,
 {
+    #[allow(deprecated)]
     stack_new_axis(axis, arrays)
 }
 
@@ -108,6 +109,7 @@ where
     }
 }
 
+#[deprecated(note="Use under the name stack instead.", since="0.15.0")]
 /// Stack arrays along the new axis.
 ///
 /// ***Errors*** if the arrays have mismatching shapes.
@@ -273,6 +275,7 @@ macro_rules! concatenate {
 /// # }
 /// ```
 #[macro_export]
+#[deprecated(note="Use under the name stack instead.", since="0.15.0")]
 macro_rules! stack_new_axis {
     ($axis:expr, $( $array:expr ),+ ) => {
         $crate::stack_new_axis($axis, &[ $($crate::ArrayView::from(&$array) ),* ]).unwrap()


### PR DESCRIPTION
Fixes #928

Some doc fixes (for numpy users) to refer to stack and concatenate correctly.