### PR TITLE
Add crate feature matrixmultiply-threading

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,8 @@ docs = ["approx", "serde", "rayon"]
 std = ["num-traits/std", "matrixmultiply/std"]
 rayon = ["rayon_", "std"]
 
+matrixmultiply-threading = ["matrixmultiply/threading"]
+
 [profile.release]
 [profile.bench]
 debug = true

--- a/README.rst
+++ b/README.rst
@@ -86,6 +86,10 @@ your `Cargo.toml`.
     Uses ``blas-src`` for pluggable backend, which needs to be configured
     separately (see below).
 
+- ``matrixmultiply-threading``
+
+  - Enable the ``threading`` feature in the matrixmultiply package
+
 How to use with cargo
 ---------------------
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,6 +87,8 @@
 //!   - Enable transparent BLAS support for matrix multiplication.
 //!     Uses ``blas-src`` for pluggable backend, which needs to be configured
 //!     separately (see the README).
+//! - `matrixmultiply-threading`
+//!   - Enable the ``threading`` feature in the matrixmultiply package
 //!
 //! ## Documentation
 //!


### PR DESCRIPTION
This feature enables threading in the matrixmultiply crate.

It makes that feature flag easier to use.