### PR TITLE
Simplifications for slicing-related types

### DIFF
--- a/src/dimension/mod.rs
+++ b/src/dimension/mod.rs
@@ -599,8 +599,8 @@ fn slice_min_max(axis_len: usize, slice: Slice) -> Option<(usize, usize)> {
 /// Returns `true` iff the slices intersect.
 pub fn slices_intersect<D: Dimension>(
     dim: &D,
-    indices1: &impl SliceArg<D>,
-    indices2: &impl SliceArg<D>,
+    indices1: impl SliceArg<D>,
+    indices2: impl SliceArg<D>,
 ) -> bool {
     debug_assert_eq!(indices1.in_ndim(), indices2.in_ndim());
     for (&axis_len, &si1, &si2) in izip!(

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -338,9 +338,9 @@ where
     ///
     /// **Panics** if an index is out of bounds or step size is zero.<br>
     /// (**Panics** if `D` is `IxDyn` and `info` does not match the number of array axes.)
-    pub fn slice<I>(&self, info: &I) -> ArrayView<'_, A, I::OutDim>
+    pub fn slice<I>(&self, info: I) -> ArrayView<'_, A, I::OutDim>
     where
-        I: SliceArg<D> + ?Sized,
+        I: SliceArg<D>,
         S: Data,
     {
         self.view().slice_move(info)
@@ -353,9 +353,9 @@ where
     ///
     /// **Panics** if an index is out of bounds or step size is zero.<br>
     /// (**Panics** if `D` is `IxDyn` and `info` does not match the number of array axes.)
-    pub fn slice_mut<I>(&mut self, info: &I) -> ArrayViewMut<'_, A, I::OutDim>
+    pub fn slice_mut<I>(&mut self, info: I) -> ArrayViewMut<'_, A, I::OutDim>
     where
-        I: SliceArg<D> + ?Sized,
+        I: SliceArg<D>,
         S: DataMut,
     {
         self.view_mut().slice_move(info)
@@ -399,9 +399,9 @@ where
     ///
     /// **Panics** if an index is out of bounds or step size is zero.<br>
     /// (**Panics** if `D` is `IxDyn` and `info` does not match the number of array axes.)
-    pub fn slice_move<I>(mut self, info: &I) -> ArrayBase<S, I::OutDim>
+    pub fn slice_move<I>(mut self, info: I) -> ArrayBase<S, I::OutDim>
     where
-        I: SliceArg<D> + ?Sized,
+        I: SliceArg<D>,
     {
         assert_eq!(
             info.in_ndim(),
@@ -468,9 +468,9 @@ where
     /// - if [`AxisSliceInfo::NewAxis`] is in `info`, e.g. if [`NewAxis`] was
     ///   used in the [`s!`] macro
     /// - if `D` is `IxDyn` and `info` does not match the number of array axes
-    pub fn slice_collapse<I>(&mut self, info: &I)
+    pub fn slice_collapse<I>(&mut self, info: I)
     where
-        I: SliceArg<D> + ?Sized,
+        I: SliceArg<D>,
     {
         assert_eq!(
             info.in_ndim(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -492,9 +492,8 @@ pub type Ixs = isize;
 ///
 /// The slicing argument can be passed using the macro [`s![]`](macro.s!.html),
 /// which will be used in all examples. (The explicit form is an instance of
-/// [`&SliceInfo`]; see its docs for more information.)
-///
-/// [`&SliceInfo`]: struct.SliceInfo.html
+/// [`SliceInfo`] or another type which implements [`SliceArg`]; see their docs
+/// for more information.)
 ///
 /// If a range is used, the axis is preserved. If an index is used, that index
 /// is selected and the axis is removed; this selects a subview. See
@@ -510,7 +509,7 @@ pub type Ixs = isize;
 /// [`NewAxis`]: struct.NewAxis.html
 ///
 /// When slicing arrays with generic dimensionality, creating an instance of
-/// [`&SliceInfo`] to pass to the multi-axis slicing methods like [`.slice()`]
+/// [`SliceInfo`] to pass to the multi-axis slicing methods like [`.slice()`]
 /// is awkward. In these cases, it's usually more convenient to use
 /// [`.slice_each_axis()`]/[`.slice_each_axis_mut()`]/[`.slice_each_axis_inplace()`]
 /// or to create a view and then slice individual axes of the view using

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -324,6 +324,24 @@ pub unsafe trait SliceArg<D: Dimension>: AsRef<[AxisSliceInfo]> {
     private_decl! {}
 }
 
+unsafe impl<T, D> SliceArg<D> for &T
+where
+    T: SliceArg<D> + ?Sized,
+    D: Dimension,
+{
+    type OutDim = T::OutDim;
+
+    fn in_ndim(&self) -> usize {
+        T::in_ndim(self)
+    }
+
+    fn out_ndim(&self) -> usize {
+        T::out_ndim(self)
+    }
+
+    private_impl! {}
+}
+
 macro_rules! impl_slicearg_samedim {
     ($in_dim:ty) => {
         unsafe impl<T, Dout> SliceArg<$in_dim> for SliceInfo<T, $in_dim, Dout>

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -219,7 +219,7 @@ fn test_slice_dyninput_array_fixed() {
 #[test]
 fn test_slice_array_dyn() {
     let mut arr = Array3::<f64>::zeros((5, 2, 5));
-    let info = &SliceInfo::<_, Ix3, IxDyn>::try_from([
+    let info = SliceInfo::<_, Ix3, IxDyn>::try_from([
         AxisSliceInfo::from(1..),
         AxisSliceInfo::from(1),
         AxisSliceInfo::from(NewAxis),
@@ -229,7 +229,7 @@ fn test_slice_array_dyn() {
     arr.slice(info);
     arr.slice_mut(info);
     arr.view().slice_move(info);
-    let info2 = &SliceInfo::<_, Ix3, IxDyn>::try_from([
+    let info2 = SliceInfo::<_, Ix3, IxDyn>::try_from([
         AxisSliceInfo::from(1..),
         AxisSliceInfo::from(1),
         AxisSliceInfo::from(..).step_by(2),
@@ -241,7 +241,7 @@ fn test_slice_array_dyn() {
 #[test]
 fn test_slice_dyninput_array_dyn() {
     let mut arr = Array3::<f64>::zeros((5, 2, 5)).into_dyn();
-    let info = &SliceInfo::<_, Ix3, IxDyn>::try_from([
+    let info = SliceInfo::<_, Ix3, IxDyn>::try_from([
         AxisSliceInfo::from(1..),
         AxisSliceInfo::from(1),
         AxisSliceInfo::from(NewAxis),
@@ -251,7 +251,7 @@ fn test_slice_dyninput_array_dyn() {
     arr.slice(info);
     arr.slice_mut(info);
     arr.view().slice_move(info);
-    let info2 = &SliceInfo::<_, Ix3, IxDyn>::try_from([
+    let info2 = SliceInfo::<_, Ix3, IxDyn>::try_from([
         AxisSliceInfo::from(1..),
         AxisSliceInfo::from(1),
         AxisSliceInfo::from(..).step_by(2),
@@ -273,7 +273,7 @@ fn test_slice_dyninput_vec_fixed() {
     arr.slice(info);
     arr.slice_mut(info);
     arr.view().slice_move(info);
-    let info2 = &SliceInfo::<_, Ix3, Ix2>::try_from(vec![
+    let info2 = SliceInfo::<_, Ix3, Ix2>::try_from(vec![
         AxisSliceInfo::from(1..),
         AxisSliceInfo::from(1),
         AxisSliceInfo::from(..).step_by(2),
@@ -295,7 +295,7 @@ fn test_slice_dyninput_vec_dyn() {
     arr.slice(info);
     arr.slice_mut(info);
     arr.view().slice_move(info);
-    let info2 = &SliceInfo::<_, Ix3, IxDyn>::try_from(vec![
+    let info2 = SliceInfo::<_, Ix3, IxDyn>::try_from(vec![
         AxisSliceInfo::from(1..),
         AxisSliceInfo::from(1),
         AxisSliceInfo::from(..).step_by(2),

--- a/tests/oper.rs
+++ b/tests/oper.rs
@@ -596,7 +596,7 @@ fn scaled_add_3() {
 
                 {
                     let mut av = a.slice_mut(s![..;s1, ..;s2]);
-                    let c = c.slice(&SliceInfo::<_, IxDyn, IxDyn>::try_from(cslice).unwrap());
+                    let c = c.slice(SliceInfo::<_, IxDyn, IxDyn>::try_from(cslice).unwrap());
 
                     let mut answerv = answer.slice_mut(s![..;s1, ..;s2]);
                     answerv += &(beta * &c);


### PR DESCRIPTION
I realized that now that we no longer have a slicing API based on the `Dimension::SliceArg` associated type, the `s![]` macro can return an owned type, the tricky conversions involving pointer casts no longer need to exist, and `SliceInfo` no longer needs to be `?Sized`.

This PR does the following:

- Implement `SliceArg<D> for &T`.
- Change the slicing methods to take `I` rather than `&I`.
- Make the `s![]` macro return an owned `SliceInfo` rather than a reference.
- Replace the conversions of `SliceInfo` involving tricky pointer casts with similar conversions not involving pointer casts.
- Make `SliceInfo` be `Sized` and remove the `#[repr(transparent)]` attribute. These changes aren't necessary, but seem like a nice simplification.