### PR TITLE
Check expr type for expr;step in s![] macro at compile time, and remove AxisSliceInfo::step_by

### DIFF
--- a/blas-tests/tests/oper.rs
+++ b/blas-tests/tests/oper.rs
@@ -6,7 +6,7 @@ extern crate num_traits;
 use ndarray::linalg::general_mat_mul;
 use ndarray::linalg::general_mat_vec_mul;
 use ndarray::prelude::*;
-use ndarray::{AxisSliceInfo, Ix, Ixs};
+use ndarray::{AxisSliceInfo, Ix, Ixs, Slice};
 use ndarray::{Data, LinalgScalar};
 
 use approx::{assert_abs_diff_eq, assert_relative_eq};
@@ -419,12 +419,12 @@ fn scaled_add_3() {
                 let mut a = range_mat64(m, k);
                 let mut answer = a.clone();
                 let cdim = if n == 1 { vec![q] } else { vec![n, q] };
-                let cslice = if n == 1 {
-                    vec![AxisSliceInfo::from(..).step_by(s2)]
+                let cslice: Vec<AxisSliceInfo> = if n == 1 {
+                    vec![Slice::from(..).step_by(s2).into()]
                 } else {
                     vec![
-                        AxisSliceInfo::from(..).step_by(s1),
-                        AxisSliceInfo::from(..).step_by(s2),
+                        Slice::from(..).step_by(s1).into(),
+                        Slice::from(..).step_by(s2).into(),
                     ]
                 };
 

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -92,13 +92,13 @@ pub struct NewAxis;
 ///
 /// `AxisSliceInfo::Slice { start: a, end: Some(b), step: 2 }` is every second
 /// element from `a` until `b`. It can also be created with
-/// `AxisSliceInfo::from(a..b).step_by(2)`. The Python equivalent is `[a:b:2]`.
-/// The macro equivalent is `s![a..b;2]`.
+/// `AxisSliceInfo::from(Slice::from(a..b).step_by(2))`. The Python equivalent
+/// is `[a:b:2]`. The macro equivalent is `s![a..b;2]`.
 ///
 /// `AxisSliceInfo::Slice { start: a, end: None, step: -1 }` is every element,
 /// from `a` until the end, in reverse order. It can also be created with
-/// `AxisSliceInfo::from(a..).step_by(-1)`. The Python equivalent is `[a::-1]`.
-/// The macro equivalent is `s![a..;-1]`.
+/// `AxisSliceInfo::from(Slice::from(a..).step_by(-1))`. The Python equivalent
+/// is `[a::-1]`. The macro equivalent is `s![a..;-1]`.
 ///
 /// `AxisSliceInfo::NewAxis` is a new axis of length 1. It can also be created
 /// with `AxisSliceInfo::from(NewAxis)`. The Python equivalent is
@@ -135,30 +135,6 @@ impl AxisSliceInfo {
     /// Returns `true` if `self` is a `NewAxis` value.
     pub fn is_new_axis(&self) -> bool {
         matches!(self, AxisSliceInfo::NewAxis)
-    }
-
-    /// Returns a new `AxisSliceInfo` with the given step size (multiplied with
-    /// the previous step size).
-    ///
-    /// `step` must be nonzero.
-    /// (This method checks with a debug assertion that `step` is not zero.)
-    ///
-    /// **Panics** if `self` is not the `AxisSliceInfo::Slice` variant.
-    #[inline]
-    pub fn step_by(self, step: isize) -> Self {
-        debug_assert_ne!(step, 0, "AxisSliceInfo::step_by: step must be nonzero");
-        match self {
-            AxisSliceInfo::Slice {
-                start,
-                end,
-                step: orig_step,
-            } => AxisSliceInfo::Slice {
-                start,
-                end,
-                step: orig_step * step,
-            },
-            _ => panic!("AxisSliceInfo::step_by: `self` must be the `Slice` variant"),
-        }
     }
 }
 

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -880,7 +880,9 @@ macro_rules! s(
     };
     // convert range/index/new-axis and step into AxisSliceInfo
     (@convert $r:expr, $s:expr) => {
-        <$crate::AxisSliceInfo as ::std::convert::From<_>>::from($r).step_by($s as isize)
+        <$crate::AxisSliceInfo as ::std::convert::From<_>>::from(
+            <$crate::Slice as ::std::convert::From<_>>::from($r).step_by($s as isize)
+        )
     };
     ($($t:tt)*) => {
         $crate::s![@parse

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -223,7 +223,7 @@ fn test_slice_array_dyn() {
         AxisSliceInfo::from(1..),
         AxisSliceInfo::from(1),
         AxisSliceInfo::from(NewAxis),
-        AxisSliceInfo::from(..).step_by(2),
+        AxisSliceInfo::from(Slice::from(..).step_by(2)),
     ])
     .unwrap();
     arr.slice(info);
@@ -232,7 +232,7 @@ fn test_slice_array_dyn() {
     let info2 = SliceInfo::<_, Ix3, IxDyn>::try_from([
         AxisSliceInfo::from(1..),
         AxisSliceInfo::from(1),
-        AxisSliceInfo::from(..).step_by(2),
+        AxisSliceInfo::from(Slice::from(..).step_by(2)),
     ])
     .unwrap();
     arr.view().slice_collapse(info2);
@@ -245,7 +245,7 @@ fn test_slice_dyninput_array_dyn() {
         AxisSliceInfo::from(1..),
         AxisSliceInfo::from(1),
         AxisSliceInfo::from(NewAxis),
-        AxisSliceInfo::from(..).step_by(2),
+        AxisSliceInfo::from(Slice::from(..).step_by(2)),
     ])
     .unwrap();
     arr.slice(info);
@@ -254,7 +254,7 @@ fn test_slice_dyninput_array_dyn() {
     let info2 = SliceInfo::<_, Ix3, IxDyn>::try_from([
         AxisSliceInfo::from(1..),
         AxisSliceInfo::from(1),
-        AxisSliceInfo::from(..).step_by(2),
+        AxisSliceInfo::from(Slice::from(..).step_by(2)),
     ])
     .unwrap();
     arr.view().slice_collapse(info2);
@@ -267,7 +267,7 @@ fn test_slice_dyninput_vec_fixed() {
         AxisSliceInfo::from(1..),
         AxisSliceInfo::from(1),
         AxisSliceInfo::from(NewAxis),
-        AxisSliceInfo::from(..).step_by(2),
+        AxisSliceInfo::from(Slice::from(..).step_by(2)),
     ])
     .unwrap();
     arr.slice(info);
@@ -276,7 +276,7 @@ fn test_slice_dyninput_vec_fixed() {
     let info2 = SliceInfo::<_, Ix3, Ix2>::try_from(vec![
         AxisSliceInfo::from(1..),
         AxisSliceInfo::from(1),
-        AxisSliceInfo::from(..).step_by(2),
+        AxisSliceInfo::from(Slice::from(..).step_by(2)),
     ])
     .unwrap();
     arr.view().slice_collapse(info2);
@@ -289,7 +289,7 @@ fn test_slice_dyninput_vec_dyn() {
         AxisSliceInfo::from(1..),
         AxisSliceInfo::from(1),
         AxisSliceInfo::from(NewAxis),
-        AxisSliceInfo::from(..).step_by(2),
+        AxisSliceInfo::from(Slice::from(..).step_by(2)),
     ])
     .unwrap();
     arr.slice(info);
@@ -298,7 +298,7 @@ fn test_slice_dyninput_vec_dyn() {
     let info2 = SliceInfo::<_, Ix3, IxDyn>::try_from(vec![
         AxisSliceInfo::from(1..),
         AxisSliceInfo::from(1),
-        AxisSliceInfo::from(..).step_by(2),
+        AxisSliceInfo::from(Slice::from(..).step_by(2)),
     ])
     .unwrap();
     arr.view().slice_collapse(info2);

--- a/tests/oper.rs
+++ b/tests/oper.rs
@@ -561,7 +561,7 @@ fn scaled_add_2() {
 #[test]
 fn scaled_add_3() {
     use approx::assert_relative_eq;
-    use ndarray::{SliceInfo, AxisSliceInfo};
+    use ndarray::{AxisSliceInfo, Slice, SliceInfo};
     use std::convert::TryFrom;
 
     let beta = -2.3;
@@ -583,12 +583,12 @@ fn scaled_add_3() {
                 let mut a = range_mat64(m, k);
                 let mut answer = a.clone();
                 let cdim = if n == 1 { vec![q] } else { vec![n, q] };
-                let cslice = if n == 1 {
-                    vec![AxisSliceInfo::from(..).step_by(s2)]
+                let cslice: Vec<AxisSliceInfo> = if n == 1 {
+                    vec![Slice::from(..).step_by(s2).into()]
                 } else {
                     vec![
-                        AxisSliceInfo::from(..).step_by(s1),
-                        AxisSliceInfo::from(..).step_by(s2),
+                        Slice::from(..).step_by(s1).into(),
+                        Slice::from(..).step_by(s2).into(),
                     ]
                 };
 


### PR DESCRIPTION
Before, if the `expr;step` notation was used with an index as the `expr`, e.g. `s![4;2]`, the macro would panic at runtime. Now, it errors at compile time. This is accomplished by converting the `expr` to a `Slice` before converting it into the final `AxisSliceInfo`.

The `AxisSliceInfo::step_by` method is awkward because it panics for all cases except the `Slice` variant. This method is no longer necessary because the `s![]` macro now calls `Slice::step_by()` instead.