### PR TITLE
Add "forwards" of the approx methods .abs_diff_eq and .relative_eq

### DIFF
--- a/src/array_approx.rs
+++ b/src/array_approx.rs
@@ -21,9 +21,10 @@ where
         if self.shape() != other.shape() {
             return false;
         }
+
         Zip::from(self)
             .and(other)
-            .all(|a, b| A::abs_diff_eq(a, b, epsilon.clone()))
+            .all(move |a, b| A::abs_diff_eq(a, b, epsilon.clone()))
     }
 }
 
@@ -49,9 +50,10 @@ where
         if self.shape() != other.shape() {
             return false;
         }
+
         Zip::from(self)
             .and(other)
-            .all(|a, b| A::relative_eq(a, b, epsilon.clone(), max_relative.clone()))
+            .all(move |a, b| A::relative_eq(a, b, epsilon.clone(), max_relative.clone()))
     }
 }
 
@@ -72,11 +74,50 @@ where
         if self.shape() != other.shape() {
             return false;
         }
+
         Zip::from(self)
             .and(other)
-            .all(|a, b| A::ulps_eq(a, b, epsilon.clone(), max_ulps))
+            .all(move |a, b| A::ulps_eq(a, b, epsilon.clone(), max_ulps))
     }
 }
+
+impl<A, S, D> ArrayBase<S, D>
+where
+    S: Data<Elem = A>,
+    D: Dimension,
+{
+    /// A test for equality that uses the elementwise absolute difference to compute the
+    /// approximate equality of two arrays.
+    ///
+    /// **Requires crate feature `"approx"`**
+    pub fn abs_diff_eq<S2>(&self, other: &ArrayBase<S2, D>, epsilon: A::Epsilon) -> bool
+    where
+        A: AbsDiffEq<S2::Elem>,
+        A::Epsilon: Clone,
+        S2: Data,
+    {
+        <Self as AbsDiffEq<_>>::abs_diff_eq(self, other, epsilon)
+    }
+
+    /// A test for equality that uses an elementwise relative comparison if the values are far
+    /// apart; and the absolute difference otherwise.
+    ///
+    /// **Requires crate feature `"approx"`**
+    pub fn relative_eq<S2>(
+        &self,
+        other: &ArrayBase<S2, D>,
+        epsilon: A::Epsilon,
+        max_relative: A::Epsilon,
+    ) -> bool
+    where
+        A: RelativeEq<S2::Elem>,
+        A::Epsilon: Clone,
+        S2: Data
+    {
+        <Self as RelativeEq<_>>::relative_eq(self, other, epsilon, max_relative)
+    }
+}
+
 
 #[cfg(test)]
 mod tests {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,8 +168,6 @@ mod aliases;
 #[macro_use]
 mod itertools;
 mod argument_traits;
-#[cfg(feature = "approx")]
-mod array_approx;
 #[cfg(feature = "serde")]
 mod array_serde;
 mod arrayformat;
@@ -1520,6 +1518,9 @@ impl<'a, A> CowRepr<'a, A> {
     }
 }
 
+// NOTE: The order of modules decides in which order methods on the type ArrayBase
+// (mainly mentioning that as the most relevant type) show up in the documentation.
+// Consider the doc effect of ordering modules here.
 mod impl_clone;
 
 mod impl_internal_constructors;
@@ -1612,6 +1613,9 @@ pub mod linalg;
 
 mod impl_ops;
 pub use crate::impl_ops::ScalarOperand;
+
+#[cfg(feature = "approx")]
+mod array_approx;
 
 // Array view methods
 mod impl_views;


### PR DESCRIPTION
This is a nod to the all_close method that was removed. The replacement
methods still require the "approx" feature gate, but we forward them as
inherent methods on the array, to make them easier to call (no trait
import needed).

Closes #763 