### PR TITLE
Fix a few inconsistencies around negative strides in constructors

### DIFF
--- a/src/impl_views/constructors.rs
+++ b/src/impl_views/constructors.rs
@@ -13,6 +13,7 @@ use crate::error::ShapeError;
 use crate::extension::nonnull::nonnull_debug_checked_from_ptr;
 use crate::imp_prelude::*;
 use crate::{is_aligned, StrideShape};
+use crate::dimension::offset_from_ptr_to_memory;
 
 /// Methods for read-only array views.
 impl<'a, A, D> ArrayView<'a, A, D>
@@ -55,7 +56,7 @@ where
         let dim = shape.dim;
         dimension::can_index_slice_with_strides(xs, &dim, &shape.strides)?;
         let strides = shape.strides.strides_for_dim(&dim);
-        unsafe { Ok(Self::new_(xs.as_ptr(), dim, strides)) }
+        unsafe { Ok(Self::new_(xs.as_ptr().offset(-offset_from_ptr_to_memory(&dim, &strides)), dim, strides)) }
     }
 
     /// Create an `ArrayView<A, D>` from shape information and a raw pointer to
@@ -152,7 +153,7 @@ where
         let dim = shape.dim;
         dimension::can_index_slice_with_strides(xs, &dim, &shape.strides)?;
         let strides = shape.strides.strides_for_dim(&dim);
-        unsafe { Ok(Self::new_(xs.as_mut_ptr(), dim, strides)) }
+        unsafe { Ok(Self::new_(xs.as_mut_ptr().offset(-offset_from_ptr_to_memory(&dim, &strides)), dim, strides)) }
     }
 
     /// Create an `ArrayViewMut<A, D>` from shape information and a

--- a/src/impl_views/constructors.rs
+++ b/src/impl_views/constructors.rs
@@ -30,6 +30,7 @@ where
     /// use ndarray::arr3;
     /// use ndarray::ShapeBuilder;
     ///
+    /// // advanced example where we are even specifying exact strides to use (which is optional).
     /// let s = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
     /// let a = ArrayView::from_shape((2, 3, 2).strides((1, 4, 2)),
     ///                               &s).unwrap();


### PR DESCRIPTION
The ArrayView from_shape constructors that allow and have a natural interpretation for the array head pointer, now support negative strides properly.

Note that the raw view and raw pointer constructors for regular views don't support negative strides yet. There are assertions to check this. The goal of this PR is to have consistency for the next release, not to add new features for negative strides.

The first commit is by @SparrowLii (some changes dropped from that commit) from PR #901.

Closes #942