### PR TITLE
Implement PartialEq for array == &array and &array == array

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,13 @@
+Version 0.15.1 (not released yet)
+===========================
+
+Enhancements
+------------
+
+- Arrays and views now implement PartialEq so that it's possible to compare
+  arrays with references to arrays and vice versa by [@bluss]
+
+
 Version 0.15.0 (2021-03-25)
 ===========================
 

--- a/src/arraytraits.rs
+++ b/src/arraytraits.rs
@@ -112,6 +112,34 @@ where
     }
 }
 
+/// Return `true` if the array shapes and all elements of `self` and
+/// `rhs` are equal. Return `false` otherwise.
+impl<'a, A, B, S, S2, D> PartialEq<&'a ArrayBase<S2, D>> for ArrayBase<S, D>
+where
+    A: PartialEq<B>,
+    S: Data<Elem = A>,
+    S2: Data<Elem = B>,
+    D: Dimension,
+{
+    fn eq(&self, rhs: &&ArrayBase<S2, D>) -> bool {
+        *self == **rhs
+    }
+}
+
+/// Return `true` if the array shapes and all elements of `self` and
+/// `rhs` are equal. Return `false` otherwise.
+impl<'a, A, B, S, S2, D> PartialEq<ArrayBase<S2, D>> for &'a ArrayBase<S, D>
+where
+    A: PartialEq<B>,
+    S: Data<Elem = A>,
+    S2: Data<Elem = B>,
+    D: Dimension,
+{
+    fn eq(&self, rhs: &ArrayBase<S2, D>) -> bool {
+        **self == *rhs
+    }
+}
+
 impl<S, D> Eq for ArrayBase<S, D>
 where
     D: Dimension,

--- a/tests/windows.rs
+++ b/tests/windows.rs
@@ -133,7 +133,7 @@ fn test_window_neg_stride() {
 
     itertools::assert_equal(
         array.slice(s![.., ..;-1]).windows((2, 2)),
-        answer.iter().map(|a| a.view())
+        answer.iter()
     );
 
     answer.invert_axis(Axis(0));
@@ -141,7 +141,7 @@ fn test_window_neg_stride() {
 
     itertools::assert_equal(
         array.slice(s![..;-1, ..;-1]).windows((2, 2)),
-        answer.iter().map(|a| a.view())
+        answer.iter()
     );
 
     answer.invert_axis(Axis(1));
@@ -149,6 +149,6 @@ fn test_window_neg_stride() {
 
     itertools::assert_equal(
         array.slice(s![..;-1, ..]).windows((2, 2)),
-        answer.iter().map(|a| a.view())
+        answer.iter()
     );
 }


### PR DESCRIPTION
This adds missing implementations - so that we can compare a == &b and
&a == b where a and b are arrays or array views.

The change to the windows test shows why this is beneficial - no need to
create views from &Array etc just to do a comparison.