### PR TITLE
Update blas test for blas-src 0.8

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -133,12 +133,13 @@ explicitly including it in your code::
     extern crate blas_src;
 
 The following versions have been verified to work together. For ndarray 0.15 or later,
-there is no tight coupling to the ``blas-src`` version, so any version should in theory work.
+there is no tight coupling to the ``blas-src`` version, so version selection is more flexible.
 
 =========== ============ ================ ==============
 ``ndarray`` ``blas-src`` ``openblas-src`` ``netlib-src``
 =========== ============ ================ ==============
-0.15        0.7.0        0.9.0            0.8.0
+0.15        0.8          0.10             0.8
+0.15        0.7          0.9              0.8
 0.14        0.6.1        0.9.0
 0.13        0.2.0        0.6.0
 =========== ============ ================ ==============

--- a/scripts/all-tests.sh
+++ b/scripts/all-tests.sh
@@ -15,7 +15,7 @@ cargo test --verbose --features "$FEATURES"
 cargo test --manifest-path=ndarray-rand/Cargo.toml --no-default-features --verbose
 cargo test --manifest-path=ndarray-rand/Cargo.toml --features quickcheck --verbose
 cargo test --manifest-path=xtest-serialization/Cargo.toml --verbose
-cargo test --manifest-path=xtest-blas/Cargo.toml --verbose
+cargo test --manifest-path=xtest-blas/Cargo.toml --verbose --features openblas-system
 cargo test --examples
 CARGO_TARGET_DIR=target/ cargo test --manifest-path=xtest-numeric/Cargo.toml --verbose
 CARGO_TARGET_DIR=target/ cargo test --manifest-path=xtest-numeric/Cargo.toml --verbose --features test_blas

--- a/xtest-blas/Cargo.toml
+++ b/xtest-blas/Cargo.toml
@@ -8,17 +8,24 @@ publish = false
 test = false
 
 [dev-dependencies]
-ndarray = { path = "../", features = ["approx", "blas"] }
-
 approx = "0.4"
 defmac = "0.2"
 num-traits = "0.2"
 
-blas-src = { version = "0.7.0", features = ["openblas"] }
-openblas-src = { version = "0.9.0", features = ["system"] }
+[dependencies]
+ndarray = { path = "../", features = ["approx", "blas"] }
 
-#blas-src = { version = "0.7.0", features = ["netlib"] }
-#netlib-src = { version = "0.8.0", default-features = false, features = ["cblas", "system"] }
+blas-src = { version = "0.8", optional = true }
 
-#blas-src = { version = "0.7.0", features = ["blis"] }
-#blis-src = { version = "0.2.0", features = ["system"] }
+openblas-src = { version = "0.10", optional = true }
+netlib-src = { version = "0.8", optional = true }
+blis-src = { version = "0.2", features = ["system"], optional = true }
+
+[features]
+# Just for making an example and to help testing, , multiple different possible
+# configurations are selectable here.
+openblas-system = ["blas-src", "blas-src/openblas", "openblas-src/system"]
+openblas-cache = ["blas-src", "blas-src/openblas", "openblas-src/cache"]
+netlib = ["blas-src", "blas-src/netlib"]
+netlib-system = ["blas-src", "blas-src/netlib", "netlib-src/system"]
+blis-system = ["blas-src", "blas-src/blis", "blis-src/system"]

--- a/xtest-blas/src/lib.rs
+++ b/xtest-blas/src/lib.rs
@@ -1,0 +1,6 @@
+
+#[cfg(not(feature = "blas-src"))]
+compile_error!("Missing backend: could not compile.
+       Help: For this testing crate, select one of the blas backend features, for example \
+             openblas-system");
+

--- a/xtest-numeric/Cargo.toml
+++ b/xtest-numeric/Cargo.toml
@@ -10,8 +10,8 @@ ndarray = { path = "..", features = ["approx"] }
 ndarray-rand = { path = "../ndarray-rand/" }
 rand_distr = "0.4"
 
-blas-src = { optional = true, version = "0.7.0", default-features = false, features = ["openblas"] }
-openblas-src = { optional = true, version = "0.9", default-features = false, features = ["cblas", "system"] }
+blas-src = { optional = true, version = "0.8", default-features = false, features = ["openblas"] }
+openblas-src = { optional = true, version = "0.10", default-features = false, features = ["cblas", "system"] }
 
 [dependencies.rand]
 version = "0.8.0"


### PR DESCRIPTION
The version decoupling in ndarray 0.15 was a success, now it's easy to
use ndarray with blas-src 0.7 or 0.8, for example. Update docs and
xblas-test (blas-tests) with the new versions.