### PR TITLE
Improve performance of "no-broadcasting-needed" scenario in &array +&array operation

### DIFF
--- a/benches/bench1.rs
+++ b/benches/bench1.rs
@@ -11,7 +11,7 @@ extern crate test;
 
 use std::mem::MaybeUninit;
 
-use ndarray::ShapeBuilder;
+use ndarray::{ShapeBuilder, Array3, Array4};
 use ndarray::{arr0, arr1, arr2, azip, s};
 use ndarray::{Array, Array1, Array2, Axis, Ix, Zip};
 use ndarray::{Ix1, Ix2, Ix3, Ix5, IxDyn};
@@ -997,4 +997,22 @@ fn into_dyn_dyn(bench: &mut test::Bencher) {
     let a = Array::<f32, _>::zeros(IxDyn(&[10, 10, 10]));
     let a = a.view();
     bench.iter(|| a.clone().into_dyn());
+}
+
+#[bench]
+fn broadcast_same_dim(bench: &mut test::Bencher) {
+    let s = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+    let s = Array4::from_shape_vec((2, 2, 3, 2), s.to_vec()).unwrap();
+    let a = s.slice(s![.., ..;-1, ..;2, ..]);
+    let b = s.slice(s![.., .., ..;2, ..]);
+    bench.iter(|| &a + &b);
+}
+
+#[bench]
+fn broadcast_one_side(bench: &mut test::Bencher) {
+    let s = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+    let s2 = [1 ,2 ,3 ,4 ,5 ,6];
+    let a = Array4::from_shape_vec((4, 1, 3, 2), s.to_vec()).unwrap();
+    let b = Array3::from_shape_vec((1, 3, 2), s2.to_vec()).unwrap();
+    bench.iter(|| &a + &b);
 }

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -1804,12 +1804,36 @@ where
         E: Dimension,
     {
         let shape = co_broadcast::<D, E, <D as DimMax<E>>::Output>(&self.dim, &other.dim)?;
-        if let Some(view1) = self.broadcast(shape.clone()) {
-            if let Some(view2) = other.broadcast(shape) {
+        let view1 = if shape.slice() == self.dim.slice() {
+            self.to_dimensionality::<<D as DimMax<E>>::Output>()
+        } else {
+            self.broadcast(shape.clone())
+        };
+        let view2 = if shape.slice() == other.dim.slice() {
+            other.to_dimensionality::<<D as DimMax<E>>::Output>()
+        } else {
+            other.broadcast(shape)
+        };
+        if let Some(view1) = view1 {
+            if let Some(view2) = view2 {
                 return Ok((view1, view2));
             }
         }
         Err(from_kind(ErrorKind::IncompatibleShape))
+    }
+
+    /// Creat an array view from an array with the same shape, but different dimensionality
+    /// type. Return None if the numbers of axes mismatch.
+    #[inline]
+    pub(crate) fn to_dimensionality<D2>(&self) -> Option<ArrayView<'_, A, D2>>
+    where
+        D2: Dimension,
+        S: Data,
+    {
+        let dim = <D2>::from_dimension(&self.dim)?;
+        let strides = <D2>::from_dimension(&self.strides)?;
+
+        unsafe { Some(ArrayView::new(self.ptr, dim, strides)) }
     }
 
     /// Swap axes `ax` and `bx`.

--- a/src/impl_ops.rs
+++ b/src/impl_ops.rs
@@ -186,7 +186,7 @@ where
         } else {
             self.broadcast_with(rhs).unwrap()
         };
-        Zip::from(&lhs).and(&rhs).map_collect(clone_opf(A::$mth))
+        Zip::from(lhs).and(rhs).map_collect(clone_opf(A::$mth))
     }
 }
 

--- a/src/impl_ops.rs
+++ b/src/impl_ops.rs
@@ -179,7 +179,13 @@ where
 {
     type Output = Array<A, <D as DimMax<E>>::Output>;
     fn $mth(self, rhs: &'a ArrayBase<S2, E>) -> Self::Output {
-        let (lhs, rhs) = self.broadcast_with(rhs).unwrap();
+        let (lhs, rhs) = if self.ndim() == rhs.ndim() && self.shape() == rhs.shape() {
+            let lhs = self.to_dimensionality::<<D as DimMax<E>>::Output>().unwrap();
+            let rhs = rhs.to_dimensionality::<<D as DimMax<E>>::Output>().unwrap();
+            (lhs, rhs)
+        } else {
+            self.broadcast_with(rhs).unwrap()
+        };
         Zip::from(&lhs).and(&rhs).map_collect(clone_opf(A::$mth))
     }
 }

--- a/src/impl_ops.rs
+++ b/src/impl_ops.rs
@@ -180,8 +180,8 @@ where
     type Output = Array<A, <D as DimMax<E>>::Output>;
     fn $mth(self, rhs: &'a ArrayBase<S2, E>) -> Self::Output {
         let (lhs, rhs) = if self.ndim() == rhs.ndim() && self.shape() == rhs.shape() {
-            let lhs = self.to_dimensionality::<<D as DimMax<E>>::Output>().unwrap();
-            let rhs = rhs.to_dimensionality::<<D as DimMax<E>>::Output>().unwrap();
+            let lhs = self.view().into_dimensionality::<<D as DimMax<E>>::Output>().unwrap();
+            let rhs = rhs.view().into_dimensionality::<<D as DimMax<E>>::Output>().unwrap();
             (lhs, rhs)
         } else {
             self.broadcast_with(rhs).unwrap()

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -1627,6 +1627,12 @@ fn arithmetic_broadcast() {
         sa2 + &sb2 + sc2.into_owned(),
         arr3(&[[[15, 19], [32, 36]], [[14, 18], [31, 35]]])
     );
+
+    // Same shape
+    let a = s.slice(s![..;-1, ..;2, ..]);
+    let b = s.slice(s![.., ..;2, ..]);
+    assert_eq!(a.shape(), b.shape());
+    assert_eq!(&a + &b, arr3(&[[[3, 7], [19, 23]], [[3, 7], [19, 23]]]));
 }
 
 #[test]


### PR DESCRIPTION
This PR does the following:
1. Add a method `to_dimensionality` which creats an array view from an array with the same shape, but different dimensionality type. 
2. Use `to_dimensionality` to avoid unnecessary  calls of `broadcast` in &array + &array operation.

Updates #936 