### PR TITLE
Track-caller panics

### DIFF
--- a/src/dimension/mod.rs
+++ b/src/dimension/mod.rs
@@ -310,11 +310,13 @@ pub trait DimensionExt {
     /// Get the dimension at `axis`.
     ///
     /// *Panics* if `axis` is out of bounds.
+    #[track_caller]
     fn axis(&self, axis: Axis) -> Ix;
 
     /// Set the dimension at `axis`.
     ///
     /// *Panics* if `axis` is out of bounds.
+    #[track_caller]
     fn set_axis(&mut self, axis: Axis, value: Ix);
 }
 
@@ -349,6 +351,7 @@ impl DimensionExt for [Ix] {
 /// available.
 ///
 /// **Panics** if `index` is larger than the size of the axis
+#[track_caller]
 // FIXME: Move to Dimension trait
 pub fn do_collapse_axis<D: Dimension>(
     dims: &mut D,
@@ -385,6 +388,7 @@ pub fn abs_index(len: Ix, index: Ixs) -> Ix {
 /// The return value is (start, end, step).
 ///
 /// **Panics** if stride is 0 or if any index is out of bounds.
+#[track_caller]
 fn to_abs_slice(axis_len: usize, slice: Slice) -> (usize, usize, isize) {
     let Slice { start, end, step } = slice;
     let start = abs_index(axis_len, start);
@@ -426,6 +430,7 @@ pub fn offset_from_low_addr_ptr_to_logical_ptr<D: Dimension>(dim: &D, strides: &
 /// Modify dimension, stride and return data pointer offset
 ///
 /// **Panics** if stride is 0 or if any index is out of bounds.
+#[track_caller]
 pub fn do_slice(dim: &mut usize, stride: &mut usize, slice: Slice) -> isize {
     let (start, end, step) = to_abs_slice(*dim, slice);
 

--- a/src/impl_2d.rs
+++ b/src/impl_2d.rs
@@ -23,6 +23,7 @@ where
     /// let array = array![[1., 2.], [3., 4.]];
     /// assert_eq!(array.row(0), array![1., 2.]);
     /// ```
+    #[track_caller]
     pub fn row(&self, index: Ix) -> ArrayView1<'_, A>
     where
         S: Data,
@@ -40,6 +41,7 @@ where
     /// array.row_mut(0)[1] = 5.;
     /// assert_eq!(array, array![[1., 5.], [3., 4.]]);
     /// ```
+    #[track_caller]
     pub fn row_mut(&mut self, index: Ix) -> ArrayViewMut1<'_, A>
     where
         S: DataMut,
@@ -77,6 +79,7 @@ where
     /// let array = array![[1., 2.], [3., 4.]];
     /// assert_eq!(array.column(0), array![1., 3.]);
     /// ```
+    #[track_caller]
     pub fn column(&self, index: Ix) -> ArrayView1<'_, A>
     where
         S: Data,
@@ -94,6 +97,7 @@ where
     /// array.column_mut(0)[1] = 5.;
     /// assert_eq!(array, array![[1., 2.], [5., 4.]]);
     /// ```
+    #[track_caller]
     pub fn column_mut(&mut self, index: Ix) -> ArrayViewMut1<'_, A>
     where
         S: DataMut,

--- a/src/impl_dyn.rs
+++ b/src/impl_dyn.rs
@@ -29,6 +29,7 @@ where
     /// assert_eq!(a, arr3(&[[[1, 2, 3]], [[4, 5, 6]]]).into_dyn());
     /// assert_eq!(a.shape(), &[2, 1, 3]);
     /// ```
+    #[track_caller]
     pub fn insert_axis_inplace(&mut self, axis: Axis) {
         assert!(axis.index() <= self.ndim());
         self.dim = self.dim.insert_axis(axis);
@@ -50,6 +51,7 @@ where
     /// assert_eq!(a, arr1(&[2, 5]).into_dyn());
     /// assert_eq!(a.shape(), &[2]);
     /// ```
+    #[track_caller]
     pub fn index_axis_inplace(&mut self, axis: Axis, index: usize) {
         self.collapse_axis(axis, index);
         self.dim = self.dim.remove_axis(axis);

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -58,6 +58,7 @@ where
     /// number of dimensions (axes) of the array.
     ///
     /// ***Panics*** if the axis is out of bounds.
+    #[track_caller]
     pub fn len_of(&self, axis: Axis) -> usize {
         self.dim[axis.index()]
     }
@@ -138,6 +139,7 @@ where
     /// number of dimensions (axes) of the array.
     ///
     /// ***Panics*** if the axis is out of bounds.
+    #[track_caller]
     pub fn stride_of(&self, axis: Axis) -> isize {
         // strides are reinterpreted as isize
         self.strides[axis.index()] as isize
@@ -457,6 +459,7 @@ where
     ///
     /// **Panics** if an index is out of bounds or step size is zero.<br>
     /// (**Panics** if `D` is `IxDyn` and `info` does not match the number of array axes.)
+    #[track_caller]
     pub fn slice<I>(&self, info: I) -> ArrayView<'_, A, I::OutDim>
     where
         I: SliceArg<D>,
@@ -472,6 +475,7 @@ where
     ///
     /// **Panics** if an index is out of bounds or step size is zero.<br>
     /// (**Panics** if `D` is `IxDyn` and `info` does not match the number of array axes.)
+    #[track_caller]
     pub fn slice_mut<I>(&mut self, info: I) -> ArrayViewMut<'_, A, I::OutDim>
     where
         I: SliceArg<D>,
@@ -503,6 +507,7 @@ where
     /// middle.fill(0);
     /// assert_eq!(a, arr2(&[[1, 0, 1], [1, 0, 1]]));
     /// ```
+    #[track_caller]
     pub fn multi_slice_mut<'a, M>(&'a mut self, info: M) -> M::Output
     where
         M: MultiSliceArg<'a, A, D>,
@@ -518,6 +523,7 @@ where
     ///
     /// **Panics** if an index is out of bounds or step size is zero.<br>
     /// (**Panics** if `D` is `IxDyn` and `info` does not match the number of array axes.)
+    #[track_caller]
     pub fn slice_move<I>(mut self, info: I) -> ArrayBase<S, I::OutDim>
     where
         I: SliceArg<D>,
@@ -587,6 +593,7 @@ where
     /// - if [`SliceInfoElem::NewAxis`] is in `info`, e.g. if [`NewAxis`] was
     ///   used in the [`s!`] macro
     /// - if `D` is `IxDyn` and `info` does not match the number of array axes
+    #[track_caller]
     pub fn slice_collapse<I>(&mut self, info: I)
     where
         I: SliceArg<D>,
@@ -616,6 +623,7 @@ where
     ///
     /// **Panics** if an index is out of bounds or step size is zero.<br>
     /// **Panics** if `axis` is out of bounds.
+    #[track_caller]
     #[must_use = "slice_axis returns an array view with the sliced result"]
     pub fn slice_axis(&self, axis: Axis, indices: Slice) -> ArrayView<'_, A, D>
     where
@@ -630,6 +638,7 @@ where
     ///
     /// **Panics** if an index is out of bounds or step size is zero.<br>
     /// **Panics** if `axis` is out of bounds.
+    #[track_caller]
     #[must_use = "slice_axis_mut returns an array view with the sliced result"]
     pub fn slice_axis_mut(&mut self, axis: Axis, indices: Slice) -> ArrayViewMut<'_, A, D>
     where
@@ -644,6 +653,7 @@ where
     ///
     /// **Panics** if an index is out of bounds or step size is zero.<br>
     /// **Panics** if `axis` is out of bounds.
+    #[track_caller]
     pub fn slice_axis_inplace(&mut self, axis: Axis, indices: Slice) {
         let offset = do_slice(
             &mut self.dim.slice_mut()[axis.index()],
@@ -663,6 +673,7 @@ where
     /// dimensionality of the array.
     ///
     /// **Panics** if an index is out of bounds or step size is zero.
+    #[track_caller]
     pub fn slice_each_axis<F>(&self, f: F) -> ArrayView<'_, A, D>
     where
         F: FnMut(AxisDescription) -> Slice,
@@ -680,6 +691,7 @@ where
     /// dimensionality of the array.
     ///
     /// **Panics** if an index is out of bounds or step size is zero.
+    #[track_caller]
     pub fn slice_each_axis_mut<F>(&mut self, f: F) -> ArrayViewMut<'_, A, D>
     where
         F: FnMut(AxisDescription) -> Slice,
@@ -697,6 +709,7 @@ where
     /// dimensionality of the array.
     ///
     /// **Panics** if an index is out of bounds or step size is zero.
+    #[track_caller]
     pub fn slice_each_axis_inplace<F>(&mut self, mut f: F)
     where
         F: FnMut(AxisDescription) -> Slice,
@@ -853,6 +866,7 @@ where
     /// Indices may be equal.
     ///
     /// ***Panics*** if an index is out of bounds.
+    #[track_caller]
     pub fn swap<I>(&mut self, index1: I, index2: I)
     where
         S: DataMut,
@@ -933,6 +947,7 @@ where
     ///     a.index_axis(Axis(1), 1) == ArrayView::from(&[2., 4., 6.])
     /// );
     /// ```
+    #[track_caller]
     pub fn index_axis(&self, axis: Axis, index: usize) -> ArrayView<'_, A, D::Smaller>
     where
         S: Data,
@@ -965,6 +980,7 @@ where
     ///                   [3., 14.]])
     /// );
     /// ```
+    #[track_caller]
     pub fn index_axis_mut(&mut self, axis: Axis, index: usize) -> ArrayViewMut<'_, A, D::Smaller>
     where
         S: DataMut,
@@ -978,6 +994,7 @@ where
     /// See [`.index_axis()`](Self::index_axis) and [*Subviews*](#subviews) for full documentation.
     ///
     /// **Panics** if `axis` or `index` is out of bounds.
+    #[track_caller]
     pub fn index_axis_move(mut self, axis: Axis, index: usize) -> ArrayBase<S, D::Smaller>
     where
         D: RemoveAxis,
@@ -994,6 +1011,7 @@ where
     /// Selects `index` along the axis, collapsing the axis into length one.
     ///
     /// **Panics** if `axis` or `index` is out of bounds.
+    #[track_caller]
     pub fn collapse_axis(&mut self, axis: Axis, index: usize) {
         let offset = dimension::do_collapse_axis(&mut self.dim, &self.strides, axis.index(), index);
         self.ptr = unsafe { self.ptr.offset(offset) };
@@ -1021,6 +1039,7 @@ where
     ///                     [6., 7.]])
     ///);
     /// ```
+    #[track_caller]
     pub fn select(&self, axis: Axis, indices: &[Ix]) -> Array<A, D>
     where
         A: Clone,
@@ -1286,6 +1305,7 @@ where
     /// **Panics** if `axis` is out of bounds.
     ///
     /// <img src="https://rust-ndarray.github.io/ndarray/images/axis_iter_3_4_5.svg" height="250px">
+    #[track_caller]
     pub fn axis_iter(&self, axis: Axis) -> AxisIter<'_, A, D::Smaller>
     where
         S: Data,
@@ -1301,6 +1321,7 @@ where
     /// (read-write array view).
     ///
     /// **Panics** if `axis` is out of bounds.
+    #[track_caller]
     pub fn axis_iter_mut(&mut self, axis: Axis) -> AxisIterMut<'_, A, D::Smaller>
     where
         S: DataMut,
@@ -1335,6 +1356,7 @@ where
     /// assert_eq!(iter.next_back().unwrap(), arr3(&[[[12, 13]],
     ///                                              [[26, 27]]]));
     /// ```
+    #[track_caller]
     pub fn axis_chunks_iter(&self, axis: Axis, size: usize) -> AxisChunksIter<'_, A, D>
     where
         S: Data,
@@ -1348,6 +1370,7 @@ where
     /// Iterator element is `ArrayViewMut<A, D>`
     ///
     /// **Panics** if `axis` is out of bounds or if `size` is zero.
+    #[track_caller]
     pub fn axis_chunks_iter_mut(&mut self, axis: Axis, size: usize) -> AxisChunksIterMut<'_, A, D>
     where
         S: DataMut,
@@ -1366,6 +1389,7 @@ where
     /// **Panics** if any dimension of `chunk_size` is zero<br>
     /// (**Panics** if `D` is `IxDyn` and `chunk_size` does not match the
     /// number of array axes.)
+    #[track_caller]
     pub fn exact_chunks<E>(&self, chunk_size: E) -> ExactChunks<'_, A, D>
     where
         E: IntoDimension<Dim = D>,
@@ -1406,6 +1430,7 @@ where
     ///          [6, 6, 7, 7, 8, 8, 0],
     ///          [6, 6, 7, 7, 8, 8, 0]]));
     /// ```
+    #[track_caller]
     pub fn exact_chunks_mut<E>(&mut self, chunk_size: E) -> ExactChunksMut<'_, A, D>
     where
         E: IntoDimension<Dim = D>,
@@ -1420,6 +1445,7 @@ where
     /// that fit into the array's shape.
     ///
     /// This is essentially equivalent to [`.windows_with_stride()`] with unit stride.
+    #[track_caller]
     pub fn windows<E>(&self, window_size: E) -> Windows<'_, A, D>
     where
         E: IntoDimension<Dim = D>,
@@ -1472,6 +1498,7 @@ where
     ///          ┃ a₂₀ ┃ a₂₁ ┃     │     │   │     │     ┃ a₂₂ ┃ a₂₃ ┃
     ///          ┗━━━━━┻━━━━━┹─────┴─────┘   └─────┴─────┺━━━━━┻━━━━━┛
     /// ```
+    #[track_caller]
     pub fn windows_with_stride<E>(&self, window_size: E, stride: E) -> Windows<'_, A, D>
     where
         E: IntoDimension<Dim = D>,
@@ -2110,6 +2137,7 @@ where
     ///                 [3., 4.]])
     /// );
     /// ```
+    #[track_caller]
     #[deprecated(note="Obsolete, use `to_shape` or `into_shape_with_order` instead.", since="0.15.2")]
     pub fn reshape<E>(&self, shape: E) -> ArrayBase<S, E::Dim>
     where
@@ -2335,6 +2363,7 @@ where
     ///     a == arr2(&[[1.], [2.], [3.]])
     /// );
     /// ```
+    #[track_caller]
     pub fn swap_axes(&mut self, ax: usize, bx: usize) {
         self.dim.slice_mut().swap(ax, bx);
         self.strides.slice_mut().swap(ax, bx);
@@ -2362,6 +2391,7 @@ where
     /// let b = Array3::<u8>::zeros((1, 2, 3));
     /// assert_eq!(b.permuted_axes([1, 0, 2]).shape(), &[2, 1, 3]);
     /// ```
+    #[track_caller]
     pub fn permuted_axes<T>(self, axes: T) -> ArrayBase<S, D>
     where
         T: IntoDimension<Dim = D>,
@@ -2435,6 +2465,7 @@ where
     /// Reverse the stride of `axis`.
     ///
     /// ***Panics*** if the axis is out of bounds.
+    #[track_caller]
     pub fn invert_axis(&mut self, axis: Axis) {
         unsafe {
             let s = self.strides.axis(axis) as Ixs;
@@ -2481,6 +2512,7 @@ where
     /// ```
     ///
     /// ***Panics*** if an axis is out of bounds.
+    #[track_caller]
     pub fn merge_axes(&mut self, take: Axis, into: Axis) -> bool {
         merge_axes(&mut self.dim, &mut self.strides, take, into)
     }
@@ -2506,6 +2538,7 @@ where
     /// ```
     ///
     /// ***Panics*** if the axis is out of bounds.
+    #[track_caller]
     pub fn insert_axis(self, axis: Axis) -> ArrayBase<S, D::Larger> {
         assert!(axis.index() <= self.ndim());
         // safe because a new axis of length one does not affect memory layout
@@ -2522,6 +2555,7 @@ where
     /// axis to remove is of length 1.
     ///
     /// **Panics** if the axis is out of bounds or its length is zero.
+    #[track_caller]
     pub fn remove_axis(self, axis: Axis) -> ArrayBase<S, D::Smaller>
     where
         D: RemoveAxis,
@@ -2538,6 +2572,7 @@ where
     /// If their shapes disagree, `rhs` is broadcast to the shape of `self`.
     ///
     /// **Panics** if broadcasting isn’t possible.
+    #[track_caller]
     pub fn assign<E: Dimension, S2>(&mut self, rhs: &ArrayBase<S2, E>)
     where
         S: DataMut,
@@ -2553,6 +2588,7 @@ where
     /// [`AssignElem`] determines how elements are assigned.
     ///
     /// **Panics** if shapes disagree.
+    #[track_caller]
     pub fn assign_to<P>(&self, to: P)
     where
         S: Data,
@@ -2631,6 +2667,7 @@ where
     /// If their shapes disagree, `rhs` is broadcast to the shape of `self`.
     ///
     /// **Panics** if broadcasting isn’t possible.
+    #[track_caller]
     #[inline]
     pub fn zip_mut_with<B, S2, E, F>(&mut self, rhs: &ArrayBase<S2, E>, f: F)
     where
@@ -2892,6 +2929,7 @@ where
     /// Return the result as an `Array`.
     ///
     /// **Panics** if `axis` is out of bounds.
+    #[track_caller]
     pub fn fold_axis<B, F>(&self, axis: Axis, init: B, mut fold: F) -> Array<B, D::Smaller>
     where
         D: RemoveAxis,
@@ -2914,6 +2952,7 @@ where
     /// Return the result as an `Array`.
     ///
     /// **Panics** if `axis` is out of bounds.
+    #[track_caller]
     pub fn map_axis<'a, B, F>(&'a self, axis: Axis, mut mapping: F) -> Array<B, D::Smaller>
     where
         D: RemoveAxis,
@@ -2939,6 +2978,7 @@ where
     /// Return the result as an `Array`.
     ///
     /// **Panics** if `axis` is out of bounds.
+    #[track_caller]
     pub fn map_axis_mut<'a, B, F>(&'a mut self, axis: Axis, mut mapping: F) -> Array<B, D::Smaller>
     where
         D: RemoveAxis,
@@ -3042,6 +3082,7 @@ where
 /// using regular transmute in some cases.
 ///
 /// **Panics** if the size of A and B are different.
+#[track_caller]
 #[inline]
 unsafe fn unlimited_transmute<A, B>(data: A) -> B {
     // safe when sizes are equal and caller guarantees that representations are equal

--- a/src/impl_ops.rs
+++ b/src/impl_ops.rs
@@ -72,6 +72,7 @@ where
     E: Dimension,
 {
     type Output = ArrayBase<S, <D as DimMax<E>>::Output>;
+    #[track_caller]
     fn $mth(self, rhs: ArrayBase<S2, E>) -> Self::Output
     {
         self.$mth(&rhs)
@@ -99,6 +100,7 @@ where
     E: Dimension,
 {
     type Output = ArrayBase<S, <D as DimMax<E>>::Output>;
+    #[track_caller]
     fn $mth(self, rhs: &ArrayBase<S2, E>) -> Self::Output
     {
         if self.ndim() == rhs.ndim() && self.shape() == rhs.shape() {
@@ -139,6 +141,7 @@ where
     E: Dimension + DimMax<D>,
 {
     type Output = ArrayBase<S2, <E as DimMax<D>>::Output>;
+    #[track_caller]
     fn $mth(self, rhs: ArrayBase<S2, E>) -> Self::Output
     where
     {
@@ -178,6 +181,7 @@ where
     E: Dimension,
 {
     type Output = Array<A, <D as DimMax<E>>::Output>;
+    #[track_caller]
     fn $mth(self, rhs: &'a ArrayBase<S2, E>) -> Self::Output {
         let (lhs, rhs) = if self.ndim() == rhs.ndim() && self.shape() == rhs.shape() {
             let lhs = self.view().into_dimensionality::<<D as DimMax<E>>::Output>().unwrap();
@@ -447,6 +451,7 @@ mod assign_ops {
                 D: Dimension,
                 E: Dimension,
             {
+                #[track_caller]
                 fn $method(&mut self, rhs: &ArrayBase<S2, E>) {
                     self.zip_mut_with(rhs, |x, y| {
                         x.$method(y.clone());

--- a/src/impl_raw_views.rs
+++ b/src/impl_raw_views.rs
@@ -106,6 +106,7 @@ where
     /// before the split and one array pointer after the split.
     ///
     /// **Panics** if `axis` or `index` is out of bounds.
+    #[track_caller]
     pub fn split_at(self, axis: Axis, index: Ix) -> (Self, Self) {
         assert!(index <= self.len_of(axis));
         let left_ptr = self.ptr.as_ptr();
@@ -139,6 +140,7 @@ where
     /// While this method is safe, for the same reason as regular raw pointer
     /// casts are safe, access through the produced raw view is only possible
     /// in an unsafe block or function.
+    #[track_caller]
     pub fn cast<B>(self) -> RawArrayView<B, D> {
         assert_eq!(
             mem::size_of::<B>(),
@@ -266,9 +268,9 @@ where
     ///     address by moving along all axes must not exceed `isize::MAX`. This
     ///     constraint prevents overflow when calculating the `count` parameter to
     ///     [`.offset()`] regardless of the starting point due to past offsets.
-    ///
-    /// * The product of non-zero axis lengths must not exceed `isize::MAX`.
     /// 
+    /// * The product of non-zero axis lengths must not exceed `isize::MAX`.
+    ///
     /// * Strides must be non-negative.
     ///
     /// This function can use debug assertions to check some of these requirements,
@@ -338,6 +340,7 @@ where
     /// before the split and one array pointer after the split.
     ///
     /// **Panics** if `axis` or `index` is out of bounds.
+    #[track_caller]
     pub fn split_at(self, axis: Axis, index: Ix) -> (Self, Self) {
         let (left, right) = self.into_raw_view().split_at(axis, index);
         unsafe {
@@ -358,6 +361,7 @@ where
     /// While this method is safe, for the same reason as regular raw pointer
     /// casts are safe, access through the produced raw view is only possible
     /// in an unsafe block or function.
+    #[track_caller]
     pub fn cast<B>(self) -> RawArrayViewMut<B, D> {
         assert_eq!(
             mem::size_of::<B>(),

--- a/src/impl_views/indexing.rs
+++ b/src/impl_views/indexing.rs
@@ -62,6 +62,7 @@ pub trait IndexLonger<I> {
     /// [1]: ArrayBase::get
     ///
     /// **Panics** if index is out of bounds.
+    #[track_caller]
     fn index(self, index: I) -> Self::Output;
 
     /// Get a reference of a element through the view.
@@ -77,6 +78,7 @@ pub trait IndexLonger<I> {
     /// [2]: ArrayBase::get_mut
     ///
     /// **Panics** if index is out of bounds.
+    #[track_caller]
     fn get(self, index: I) -> Option<Self::Output>;
 
     /// Get a reference of a element through the view without boundary check
@@ -116,6 +118,7 @@ where
     /// [1]: ArrayBase::get
     ///
     /// **Panics** if index is out of bounds.
+    #[track_caller]
     fn index(self, index: I) -> &'a A {
         debug_bounds_check!(self, index);
         unsafe { &*self.get_ptr(index).unwrap_or_else(|| array_out_of_bounds()) }
@@ -161,6 +164,7 @@ where
     /// [1]: ArrayBase::get_mut
     ///
     /// **Panics** if index is out of bounds.
+    #[track_caller]
     fn index(mut self, index: I) -> &'a mut A {
         debug_bounds_check!(self, index);
         unsafe {

--- a/src/impl_views/splitting.rs
+++ b/src/impl_views/splitting.rs
@@ -88,6 +88,7 @@ where
     ///         0     1      2      3     4  indices →
     ///                                      along Axis(1)
     /// ```
+    #[track_caller]
     pub fn split_at(self, axis: Axis, index: Ix) -> (Self, Self) {
         unsafe {
             let (left, right) = self.into_raw_view().split_at(axis, index);
@@ -136,6 +137,7 @@ where
     /// before the split and one mutable view after the split.
     ///
     /// **Panics** if `axis` or `index` is out of bounds.
+    #[track_caller]
     pub fn split_at(self, axis: Axis, index: Ix) -> (Self, Self) {
         unsafe {
             let (left, right) = self.into_raw_view_mut().split_at(axis, index);
@@ -160,6 +162,7 @@ where
     /// * if any of the views would intersect (i.e. if any element would appear in multiple slices)
     /// * if an index is out of bounds or step size is zero
     /// * if `D` is `IxDyn` and `info` does not match the number of array axes
+    #[track_caller]
     pub fn multi_slice_move<M>(self, info: M) -> M::Output
     where
         M: MultiSliceArg<'a, A, D>,

--- a/src/iterators/mod.rs
+++ b/src/iterators/mod.rs
@@ -858,6 +858,7 @@ impl<A, D: Dimension> AxisIterCore<A, D> {
     ///
     /// **Panics** if `index` is strictly greater than the iterator's remaining
     /// length.
+    #[track_caller]
     fn split_at(self, index: usize) -> (Self, Self) {
         assert!(index <= self.len());
         let mid = self.index + index;
@@ -989,6 +990,7 @@ impl<'a, A, D: Dimension> AxisIter<'a, A, D> {
     ///
     /// **Panics** if `index` is strictly greater than the iterator's remaining
     /// length.
+    #[track_caller]
     pub fn split_at(self, index: usize) -> (Self, Self) {
         let (left, right) = self.iter.split_at(index);
         (
@@ -1075,6 +1077,7 @@ impl<'a, A, D: Dimension> AxisIterMut<'a, A, D> {
     ///
     /// **Panics** if `index` is strictly greater than the iterator's remaining
     /// length.
+    #[track_caller]
     pub fn split_at(self, index: usize) -> (Self, Self) {
         let (left, right) = self.iter.split_at(index);
         (
@@ -1273,6 +1276,7 @@ clone_bounds!(
 /// the number of chunks, and the shape of the last chunk.
 ///
 /// **Panics** if `size == 0`.
+#[track_caller]
 fn chunk_iter_parts<A, D: Dimension>(
     v: ArrayView<'_, A, D>,
     axis: Axis,
@@ -1359,6 +1363,7 @@ macro_rules! chunk_iter_impl {
             ///
             /// **Panics** if `index` is strictly greater than the iterator's remaining
             /// length.
+            #[track_caller]
             pub fn split_at(self, index: usize) -> (Self, Self) {
                 let (left, right) = self.iter.split_at(index);
                 (

--- a/src/linalg/impl_linalg.rs
+++ b/src/linalg/impl_linalg.rs
@@ -65,6 +65,7 @@ where
     /// **Panics** if the array shapes are incompatible.<br>
     /// *Note:* If enabled, uses blas `dot` for elements of `f32, f64` when memory
     /// layout allows.
+    #[track_caller]
     pub fn dot<Rhs>(&self, rhs: &Rhs) -> <Self as Dot<Rhs>>::Output
     where
         Self: Dot<Rhs>,
@@ -191,6 +192,7 @@ where
     /// **Panics** if the arrays are not of the same length.<br>
     /// *Note:* If enabled, uses blas `dot` for elements of `f32, f64` when memory
     /// layout allows.
+    #[track_caller]
     fn dot(&self, rhs: &ArrayBase<S2, Ix1>) -> A {
         self.dot_impl(rhs)
     }
@@ -213,6 +215,7 @@ where
     /// Return a result array with shape *N*.
     ///
     /// **Panics** if shapes are incompatible.
+    #[track_caller]
     fn dot(&self, rhs: &ArrayBase<S2, Ix2>) -> Array<A, Ix1> {
         rhs.t().dot(self)
     }
@@ -251,6 +254,7 @@ where
     ///                         [2., 3.]])
     /// );
     /// ```
+    #[track_caller]
     pub fn dot<Rhs>(&self, rhs: &Rhs) -> <Self as Dot<Rhs>>::Output
     where
         Self: Dot<Rhs>,
@@ -326,6 +330,7 @@ where
     A: LinalgScalar,
 {
     type Output = Array<A, Ix1>;
+    #[track_caller]
     fn dot(&self, rhs: &ArrayBase<S2, Ix1>) -> Array<A, Ix1> {
         let ((m, a), n) = (self.dim(), rhs.dim());
         if a != n {
@@ -353,6 +358,7 @@ where
     /// If their shapes disagree, `rhs` is broadcast to the shape of `self`.
     ///
     /// **Panics** if broadcasting isn’t possible.
+    #[track_caller]
     pub fn scaled_add<S2, E>(&mut self, alpha: A, rhs: &ArrayBase<S2, E>)
     where
         S: DataMut,
@@ -629,6 +635,7 @@ fn mat_mul_general<A>(
 /// *Note:* If enabled, uses blas `gemm` for elements of `f32, f64` when memory
 /// layout allows.  The default matrixmultiply backend is otherwise used for
 /// `f32, f64` for all memory layouts.
+#[track_caller]
 pub fn general_mat_mul<A, S1, S2, S3>(
     alpha: A,
     a: &ArrayBase<S1, Ix2>,
@@ -660,6 +667,7 @@ pub fn general_mat_mul<A, S1, S2, S3>(
 /// ***Panics*** if array shapes are not compatible<br>
 /// *Note:* If enabled, uses blas `gemv` for elements of `f32, f64` when memory
 /// layout allows.
+#[track_caller]
 #[allow(clippy::collapsible_if)]
 pub fn general_mat_vec_mul<A, S1, S2, S3>(
     alpha: A,

--- a/src/numeric/impl_numeric.rs
+++ b/src/numeric/impl_numeric.rs
@@ -151,6 +151,7 @@ where
     /// let var = a.var(1.);
     /// assert_abs_diff_eq!(var, 6.7331, epsilon = 1e-4);
     /// ```
+    #[track_caller]
     #[cfg(feature = "std")]
     pub fn var(&self, ddof: A) -> A
     where
@@ -216,6 +217,7 @@ where
     /// let stddev = a.std(1.);
     /// assert_abs_diff_eq!(stddev, 2.59483, epsilon = 1e-4);
     /// ```
+    #[track_caller]
     #[cfg(feature = "std")]
     pub fn std(&self, ddof: A) -> A
     where
@@ -240,6 +242,7 @@ where
     /// ```
     ///
     /// **Panics** if `axis` is out of bounds.
+    #[track_caller]
     pub fn sum_axis(&self, axis: Axis) -> Array<A, D::Smaller>
     where
         A: Clone + Zero + Add<Output = A>,
@@ -276,6 +279,7 @@ where
     ///     a.mean_axis(Axis(0)).unwrap().mean_axis(Axis(0)).unwrap() == aview0(&3.5)
     /// );
     /// ```
+    #[track_caller]
     pub fn mean_axis(&self, axis: Axis) -> Option<Array<A, D::Smaller>>
     where
         A: Clone + Zero + FromPrimitive + Add<Output = A> + Div<Output = A>,
@@ -334,6 +338,7 @@ where
     /// let var = a.var_axis(Axis(0), 1.);
     /// assert_eq!(var, aview1(&[4., 4.]));
     /// ```
+    #[track_caller]
     #[cfg(feature = "std")]
     pub fn var_axis(&self, axis: Axis, ddof: A) -> Array<A, D::Smaller>
     where
@@ -403,6 +408,7 @@ where
     /// let stddev = a.std_axis(Axis(0), 1.);
     /// assert_eq!(stddev, aview1(&[2., 2.]));
     /// ```
+    #[track_caller]
     #[cfg(feature = "std")]
     pub fn std_axis(&self, axis: Axis, ddof: A) -> Array<A, D::Smaller>
     where

--- a/src/zip/mod.rs
+++ b/src/zip/mod.rs
@@ -46,6 +46,7 @@ where
     /// Broadcast the array to the new dimensions `shape`.
     ///
     /// ***Panics*** if broadcasting isn’t possible.
+    #[track_caller]
     fn broadcast_unwrap(self, shape: E) -> Self::Output;
     private_decl! {}
 }
@@ -270,6 +271,7 @@ where
     /// Return the length of `axis`
     ///
     /// ***Panics*** if `axis` is out of bounds.
+    #[track_caller]
     fn len_of(&self, axis: Axis) -> usize {
         self.dimension[axis.index()]
     }
@@ -702,6 +704,7 @@ macro_rules! map_impl {
             /// Include the producer `p` in the Zip.
             ///
             /// ***Panics*** if `p`’s shape doesn’t match the Zip’s exactly.
+            #[track_caller]
             pub fn and<P>(self, p: P) -> Zip<($($p,)* P::Output, ), D>
                 where P: IntoNdProducer<Dim=D>,
             {
@@ -735,6 +738,7 @@ macro_rules! map_impl {
             /// If their shapes disagree, `rhs` is broadcast to the shape of `self`.
             ///
             /// ***Panics*** if broadcasting isn’t possible.
+            #[track_caller]
             pub fn and_broadcast<'a, P, D2, Elem>(self, p: P)
                 -> Zip<($($p,)* ArrayView<'a, Elem, D>, ), D>
                 where P: IntoNdProducer<Dim=D2, Output=ArrayView<'a, Elem, D2>, Item=&'a Elem>,


### PR DESCRIPTION
Add track caller to any function, method, trait that has a documented panics section. I also used cargo fmt to tidy up my semi-auto track_caller labelling so there may be other changes but they'll just be formatting.

Still need to assess the performance impact of all these track callers!

Fixes #972