### PR TITLE
Require len > 1 axis for layout preference

### DIFF
--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -171,6 +171,34 @@ mod tests {
     }
 
     #[test]
+    fn no_layouts() {
+        let a = M::zeros((5, 5));
+        let b = M::zeros((5, 5).f());
+
+        // 2D row/column matrixes
+        let arow = a.slice(s![0..1, ..]);
+        let acol = a.slice(s![.., 0..1]);
+        let brow = b.slice(s![0..1, ..]);
+        let bcol = b.slice(s![.., 0..1]);
+        assert_layouts!(arow, CORDER, FORDER);
+        assert_not_layouts!(acol, CORDER, CPREFER, FORDER, FPREFER);
+        assert_layouts!(bcol, CORDER, FORDER);
+        assert_not_layouts!(brow, CORDER, CPREFER, FORDER, FPREFER);
+
+        // 2D row/column matrixes - now made with insert axis
+        for &axis in &[Axis(0), Axis(1)] {
+            let arow = a.slice(s![0, ..]).insert_axis(axis);
+            let acol = a.slice(s![.., 0]).insert_axis(axis);
+            let brow = b.slice(s![0, ..]).insert_axis(axis);
+            let bcol = b.slice(s![.., 0]).insert_axis(axis);
+            assert_layouts!(arow, CORDER, FORDER);
+            assert_not_layouts!(acol, CORDER, CPREFER, FORDER, FPREFER);
+            assert_layouts!(bcol, CORDER, FORDER);
+            assert_not_layouts!(brow, CORDER, CPREFER, FORDER, FPREFER);
+        }
+    }
+
+    #[test]
     fn skip_layouts() {
         let a = M::zeros((5, 5));
         {

--- a/src/zip/mod.rs
+++ b/src/zip/mod.rs
@@ -69,9 +69,9 @@ where
         } else if n > 1 && self.raw_view().reversed_axes().is_standard_layout() {
             Layout::f()
         } else if n > 1 {
-            if self.stride_of(Axis(0)) == 1 {
+            if self.len_of(Axis(0)) > 1 && self.stride_of(Axis(0)) == 1 {
                 Layout::fpref()
-            } else if self.stride_of(Axis(n - 1)) == 1 {
+            } else if self.len_of(Axis(n - 1)) > 1 && self.stride_of(Axis(n - 1)) == 1 {
                 Layout::cpref()
             } else {
                 Layout::none()


### PR DESCRIPTION
This change means that we are not drawn to prefer an axis with length 1 as the "innermost/tightest" axis in Zip.

This fixes the bad performance reported in https://github.com/rust-ndarray/ndarray/pull/932#issuecomment-816082477, specifically select_axis1. The runtime for that benchmark decreases from 21 to 3.4 μs, which is quite substantial and just due to misidentification (in that case) of which axis to prefer for the loop.
