### PR TITLE
Const generics Improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.49.0  # MSRV
+          - 1.51.0  # MSRV
 
     steps:
       - uses: actions/checkout@v2

--- a/src/arraytraits.rs
+++ b/src/arraytraits.rs
@@ -6,17 +6,17 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::hash;
-use std::iter::FromIterator;
+use alloc::boxed::Box;
+use alloc::vec::Vec;
 use std::iter::IntoIterator;
 use std::mem;
 use std::ops::{Index, IndexMut};
-use alloc::boxed::Box;
-use alloc::vec::Vec;
+use std::{hash, mem::size_of};
+use std::{iter::FromIterator, slice};
 
-use crate::imp_prelude::*;
 use crate::iter::{Iter, IterMut};
 use crate::NdIndex;
+use crate::{dimension, imp_prelude::*};
 
 use crate::numeric_util;
 use crate::{FoldWhile, Zip};
@@ -323,6 +323,30 @@ where
     }
 }
 
+/// Implementation of ArrayView2::from(&S) where S is a slice to a 2D array
+///
+/// **Panics** if the product of non-zero axis lengths overflows `isize` (This can only occur if A
+/// is zero-sized because slices cannot contain more than `isize::MAX` number of bytes).
+impl<'a, A, const N: usize> From<&'a [[A; N]]> for ArrayView<'a, A, Ix2> {
+    /// Create a two-dimensional read-only array view of the data in `slice`
+    fn from(xs: &'a [[A; N]]) -> Self {
+        let cols = N;
+        let rows = xs.len();
+        let dim = Ix2(rows, cols);
+        if size_of::<A>() == 0 {
+            dimension::size_of_shape_checked(&dim)
+                .expect("Product of non-zero axis lengths must not overflow isize.");
+        }
+
+        // `cols * rows` is guaranteed to fit in `isize` because we checked that it fits in
+        // `isize::MAX`
+        unsafe {
+            let data = slice::from_raw_parts(xs.as_ptr() as *const A, cols * rows);
+            ArrayView::from_shape_ptr(dim, data.as_ptr())
+        }
+    }
+}
+
 /// Implementation of `ArrayView::from(&A)` where `A` is an array.
 impl<'a, A, S, D> From<&'a ArrayBase<S, D>> for ArrayView<'a, A, D>
 where
@@ -352,6 +376,30 @@ where
             );
         }
         unsafe { Self::from_shape_ptr(xs.len(), xs.as_mut_ptr()) }
+    }
+}
+
+/// Implementation of ArrayViewMut2::from(&S) where S is a slice to a 2D array
+///
+/// **Panics** if the product of non-zero axis lengths overflows `isize` (This can only occur if A
+/// is zero-sized because slices cannot contain more than `isize::MAX` number of bytes).
+impl<'a, A, const N: usize> From<&'a mut [[A; N]]> for ArrayViewMut<'a, A, Ix2> {
+    /// Create a two-dimensional read-write array view of the data in `slice`
+    fn from(xs: &'a mut [[A; N]]) -> Self {
+        let cols = N;
+        let rows = xs.len();
+        let dim = Ix2(rows, cols);
+        if size_of::<A>() == 0 {
+            dimension::size_of_shape_checked(&dim)
+                .expect("Product of non-zero axis lengths must not overflow isize.");
+        }
+
+        // `cols * rows` is guaranteed to fit in `isize` because we checked that it fits in
+        // `isize::MAX`
+        unsafe {
+            let data = slice::from_raw_parts_mut(xs.as_mut_ptr() as *mut A, cols * rows);
+            ArrayViewMut::from_shape_ptr(dim, data.as_mut_ptr())
+        }
     }
 }
 

--- a/src/arraytraits.rs
+++ b/src/arraytraits.rs
@@ -14,12 +14,12 @@ use std::ops::{Index, IndexMut};
 use std::{hash, mem::size_of};
 use std::{iter::FromIterator, slice};
 
-use crate::iter::{Iter, IterMut};
-use crate::NdIndex;
-use crate::{dimension, imp_prelude::*};
-
-use crate::numeric_util;
-use crate::{FoldWhile, Zip};
+use crate::imp_prelude::*;
+use crate::{
+    dimension,
+    iter::{Iter, IterMut},
+    numeric_util, FoldWhile, NdIndex, Zip,
+};
 
 #[cold]
 #[inline(never)]

--- a/src/zip/ndproducer.rs
+++ b/src/zip/ndproducer.rs
@@ -1,4 +1,3 @@
-
 use crate::imp_prelude::*;
 use crate::Layout;
 use crate::NdIndex;
@@ -160,6 +159,26 @@ impl<'a, A: 'a> IntoNdProducer for &'a [A] {
 
 /// A mutable slice is a mutable one-dimensional producer
 impl<'a, A: 'a> IntoNdProducer for &'a mut [A] {
+    type Item = <Self::Output as NdProducer>::Item;
+    type Dim = Ix1;
+    type Output = ArrayViewMut1<'a, A>;
+    fn into_producer(self) -> Self::Output {
+        <_>::from(self)
+    }
+}
+
+/// A one-dimensional array is a one-dimensional producer
+impl<'a, A: 'a, const N: usize> IntoNdProducer for &'a [A; N] {
+    type Item = <Self::Output as NdProducer>::Item;
+    type Dim = Ix1;
+    type Output = ArrayView1<'a, A>;
+    fn into_producer(self) -> Self::Output {
+        <_>::from(self)
+    }
+}
+
+/// A mutable one-dimensional array is a mutable one-dimensional producer
+impl<'a, A: 'a, const N: usize> IntoNdProducer for &'a mut [A; N] {
     type Item = <Self::Output as NdProducer>::Item;
     type Dim = Ix1;
     type Output = ArrayViewMut1<'a, A>;
@@ -399,4 +418,3 @@ impl<A, D: Dimension> NdProducer for RawArrayViewMut<A, D> {
         self.split_at(axis, index)
     }
 }
-

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -12,7 +12,6 @@ use defmac::defmac;
 use itertools::{zip, Itertools};
 use ndarray::prelude::*;
 use ndarray::{arr3, rcarr2};
-use ndarray::indices;
 use ndarray::{Slice, SliceInfo, SliceInfoElem};
 use num_complex::Complex;
 use std::convert::TryFrom;
@@ -731,7 +730,7 @@ fn diag() {
     let a = arr2(&[[1., 2., 3.0f32], [0., 0., 0.]]);
     let d = a.view().into_diag();
     assert_eq!(d.dim(), 2);
-    let d = arr2::<f32, _>(&[[]]).into_diag();
+    let d = arr2::<f32, 0>(&[[]]).into_diag();
     assert_eq!(d.dim(), 0);
     let d = ArcArray::<f32, _>::zeros(()).into_diag();
     assert_eq!(d.dim(), 1);
@@ -960,7 +959,7 @@ fn zero_axes() {
     a.map_inplace(|_| panic!());
     a.for_each(|_| panic!());
     println!("{:?}", a);
-    let b = arr2::<f32, _>(&[[], [], [], []]);
+    let b = arr2::<f32, 0>(&[[], [], [], []]);
     println!("{:?}\n{:?}", b.shape(), b);
 
     // we can even get a subarray of b
@@ -2071,9 +2070,8 @@ fn test_view_from_shape_ptr() {
 #[test]
 fn test_view_from_shape_ptr_deny_neg_strides() {
     let data = [0, 1, 2, 3, 4, 5];
-    let _view = unsafe {
-        ArrayView::from_shape_ptr((2, 3).strides((-3isize as usize, 1)), data.as_ptr())
-    };
+    let _view =
+        unsafe { ArrayView::from_shape_ptr((2, 3).strides((-3isize as usize, 1)), data.as_ptr()) };
 }
 
 #[should_panic(expected = "Unsupported")]
@@ -2466,74 +2464,48 @@ mod array_cow_tests {
 
 #[test]
 fn test_remove_index() {
-    let mut a = arr2(&[[1, 2, 3],
-                       [4, 5, 6],
-                       [7, 8, 9],
-                       [10,11,12]]);
+    let mut a = arr2(&[[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]]);
     a.remove_index(Axis(0), 1);
     a.remove_index(Axis(1), 2);
     assert_eq!(a.shape(), &[3, 2]);
-    assert_eq!(a,
-        array![[1, 2],
-               [7, 8],
-               [10,11]]);
+    assert_eq!(a, array![[1, 2], [7, 8], [10, 11]]);
 
-    let mut a = arr2(&[[1, 2, 3],
-                       [4, 5, 6],
-                       [7, 8, 9],
-                       [10,11,12]]);
+    let mut a = arr2(&[[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]]);
     a.invert_axis(Axis(0));
     a.remove_index(Axis(0), 1);
     a.remove_index(Axis(1), 2);
     assert_eq!(a.shape(), &[3, 2]);
-    assert_eq!(a,
-        array![[10,11],
-               [4, 5],
-               [1, 2]]);
+    assert_eq!(a, array![[10, 11], [4, 5], [1, 2]]);
 
     a.remove_index(Axis(1), 1);
 
     assert_eq!(a.shape(), &[3, 1]);
-    assert_eq!(a,
-        array![[10],
-               [4],
-               [1]]);
+    assert_eq!(a, array![[10], [4], [1]]);
     a.remove_index(Axis(1), 0);
     assert_eq!(a.shape(), &[3, 0]);
-    assert_eq!(a,
-        array![[],
-               [],
-               []]);
+    assert_eq!(a, array![[], [], []]);
 }
 
-#[should_panic(expected="must be less")]
+#[should_panic(expected = "must be less")]
 #[test]
 fn test_remove_index_oob1() {
-    let mut a = arr2(&[[1, 2, 3],
-                       [4, 5, 6],
-                       [7, 8, 9],
-                       [10,11,12]]);
+    let mut a = arr2(&[[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]]);
     a.remove_index(Axis(0), 4);
 }
 
-#[should_panic(expected="must be less")]
+#[should_panic(expected = "must be less")]
 #[test]
 fn test_remove_index_oob2() {
     let mut a = array![[10], [4], [1]];
     a.remove_index(Axis(1), 0);
     assert_eq!(a.shape(), &[3, 0]);
-    assert_eq!(a,
-        array![[],
-               [],
-               []]);
+    assert_eq!(a, array![[], [], []]);
     a.remove_index(Axis(0), 1); // ok
-    assert_eq!(a,
-        array![[],
-               []]);
+    assert_eq!(a, array![[], []]);
     a.remove_index(Axis(1), 0); // oob
 }
 
-#[should_panic(expected="index out of bounds")]
+#[should_panic(expected = "index out of bounds")]
 #[test]
 fn test_remove_index_oob3() {
     let mut a = array![[10], [4], [1]];
@@ -2552,14 +2524,10 @@ fn test_split_complex_view() {
 
 #[test]
 fn test_split_complex_view_roundtrip() {
-    let a_re = Array3::from_shape_fn((3,1,5), |(i, j, _k)| {
-        i * j
-    });
-    let a_im = Array3::from_shape_fn((3,1,5), |(_i, _j, k)| {
-        k
-    });
-    let a = Array3::from_shape_fn((3,1,5), |(i,j,k)| {
-        Complex::new(a_re[[i,j,k]], a_im[[i,j,k]])
+    let a_re = Array3::from_shape_fn((3, 1, 5), |(i, j, _k)| i * j);
+    let a_im = Array3::from_shape_fn((3, 1, 5), |(_i, _j, k)| k);
+    let a = Array3::from_shape_fn((3, 1, 5), |(i, j, k)| {
+        Complex::new(a_re[[i, j, k]], a_im[[i, j, k]])
     });
     let Complex { re, im } = a.view().split_complex();
     assert_eq!(a_re, re);
@@ -2590,18 +2558,18 @@ fn test_split_complex_zerod() {
 
 #[test]
 fn test_split_complex_permuted() {
-    let a = Array3::from_shape_fn((3, 4, 5), |(i, j, k)| {
-        Complex::new(i * k + j, k)
-    });
-    let permuted = a.view().permuted_axes([1,0,2]);
+    let a = Array3::from_shape_fn((3, 4, 5), |(i, j, k)| Complex::new(i * k + j, k));
+    let permuted = a.view().permuted_axes([1, 0, 2]);
     let Complex { re, im } = permuted.split_complex();
-    assert_eq!(re.get((3,2,4)).unwrap(), &11);
-    assert_eq!(im.get((3,2,4)).unwrap(), &4);
+    assert_eq!(re.get((3, 2, 4)).unwrap(), &11);
+    assert_eq!(im.get((3, 2, 4)).unwrap(), &4);
 }
 
 #[test]
 fn test_split_complex_invert_axis() {
-    let mut a = Array::from_shape_fn((2, 3, 2), |(i, j, k)| Complex::new(i as f64 + j as f64, i as f64 + k as f64));
+    let mut a = Array::from_shape_fn((2, 3, 2), |(i, j, k)| {
+        Complex::new(i as f64 + j as f64, i as f64 + k as f64)
+    });
     a.invert_axis(Axis(1));
     let cmplx = a.view().split_complex();
     assert_eq!(cmplx.re, a.mapv(|z| z.re));

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -11,7 +11,9 @@ use approx::assert_relative_eq;
 use defmac::defmac;
 use itertools::{zip, Itertools};
 use ndarray::prelude::*;
-use ndarray::{arr3, indices, rcarr2, Slice, SliceInfo, SliceInfoElem};
+use ndarray::{arr3, rcarr2};
+use ndarray::indices;
+use ndarray::{Slice, SliceInfo, SliceInfoElem};
 use num_complex::Complex;
 use std::convert::TryFrom;
 
@@ -2069,8 +2071,9 @@ fn test_view_from_shape_ptr() {
 #[test]
 fn test_view_from_shape_ptr_deny_neg_strides() {
     let data = [0, 1, 2, 3, 4, 5];
-    let _view =
-        unsafe { ArrayView::from_shape_ptr((2, 3).strides((-3isize as usize, 1)), data.as_ptr()) };
+    let _view = unsafe {
+        ArrayView::from_shape_ptr((2, 3).strides((-3isize as usize, 1)), data.as_ptr())
+    };
 }
 
 #[should_panic(expected = "Unsupported")]
@@ -2463,48 +2466,74 @@ mod array_cow_tests {
 
 #[test]
 fn test_remove_index() {
-    let mut a = arr2(&[[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]]);
+    let mut a = arr2(&[[1, 2, 3],
+                       [4, 5, 6],
+                       [7, 8, 9],
+                       [10,11,12]]);
     a.remove_index(Axis(0), 1);
     a.remove_index(Axis(1), 2);
     assert_eq!(a.shape(), &[3, 2]);
-    assert_eq!(a, array![[1, 2], [7, 8], [10, 11]]);
+    assert_eq!(a,
+        array![[1, 2],
+               [7, 8],
+               [10,11]]);
 
-    let mut a = arr2(&[[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]]);
+    let mut a = arr2(&[[1, 2, 3],
+                       [4, 5, 6],
+                       [7, 8, 9],
+                       [10,11,12]]);
     a.invert_axis(Axis(0));
     a.remove_index(Axis(0), 1);
     a.remove_index(Axis(1), 2);
     assert_eq!(a.shape(), &[3, 2]);
-    assert_eq!(a, array![[10, 11], [4, 5], [1, 2]]);
+    assert_eq!(a,
+        array![[10,11],
+               [4, 5],
+               [1, 2]]);
 
     a.remove_index(Axis(1), 1);
 
     assert_eq!(a.shape(), &[3, 1]);
-    assert_eq!(a, array![[10], [4], [1]]);
+    assert_eq!(a,
+        array![[10],
+               [4],
+               [1]]);
     a.remove_index(Axis(1), 0);
     assert_eq!(a.shape(), &[3, 0]);
-    assert_eq!(a, array![[], [], []]);
+    assert_eq!(a,
+        array![[],
+               [],
+               []]);
 }
 
-#[should_panic(expected = "must be less")]
+#[should_panic(expected="must be less")]
 #[test]
 fn test_remove_index_oob1() {
-    let mut a = arr2(&[[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]]);
+    let mut a = arr2(&[[1, 2, 3],
+                       [4, 5, 6],
+                       [7, 8, 9],
+                       [10,11,12]]);
     a.remove_index(Axis(0), 4);
 }
 
-#[should_panic(expected = "must be less")]
+#[should_panic(expected="must be less")]
 #[test]
 fn test_remove_index_oob2() {
     let mut a = array![[10], [4], [1]];
     a.remove_index(Axis(1), 0);
     assert_eq!(a.shape(), &[3, 0]);
-    assert_eq!(a, array![[], [], []]);
+    assert_eq!(a,
+        array![[],
+               [],
+               []]);
     a.remove_index(Axis(0), 1); // ok
-    assert_eq!(a, array![[], []]);
+    assert_eq!(a,
+        array![[],
+               []]);
     a.remove_index(Axis(1), 0); // oob
 }
 
-#[should_panic(expected = "index out of bounds")]
+#[should_panic(expected="index out of bounds")]
 #[test]
 fn test_remove_index_oob3() {
     let mut a = array![[10], [4], [1]];
@@ -2523,10 +2552,14 @@ fn test_split_complex_view() {
 
 #[test]
 fn test_split_complex_view_roundtrip() {
-    let a_re = Array3::from_shape_fn((3, 1, 5), |(i, j, _k)| i * j);
-    let a_im = Array3::from_shape_fn((3, 1, 5), |(_i, _j, k)| k);
-    let a = Array3::from_shape_fn((3, 1, 5), |(i, j, k)| {
-        Complex::new(a_re[[i, j, k]], a_im[[i, j, k]])
+    let a_re = Array3::from_shape_fn((3,1,5), |(i, j, _k)| {
+        i * j
+    });
+    let a_im = Array3::from_shape_fn((3,1,5), |(_i, _j, k)| {
+        k
+    });
+    let a = Array3::from_shape_fn((3,1,5), |(i,j,k)| {
+        Complex::new(a_re[[i,j,k]], a_im[[i,j,k]])
     });
     let Complex { re, im } = a.view().split_complex();
     assert_eq!(a_re, re);
@@ -2557,18 +2590,18 @@ fn test_split_complex_zerod() {
 
 #[test]
 fn test_split_complex_permuted() {
-    let a = Array3::from_shape_fn((3, 4, 5), |(i, j, k)| Complex::new(i * k + j, k));
-    let permuted = a.view().permuted_axes([1, 0, 2]);
+    let a = Array3::from_shape_fn((3, 4, 5), |(i, j, k)| {
+        Complex::new(i * k + j, k)
+    });
+    let permuted = a.view().permuted_axes([1,0,2]);
     let Complex { re, im } = permuted.split_complex();
-    assert_eq!(re.get((3, 2, 4)).unwrap(), &11);
-    assert_eq!(im.get((3, 2, 4)).unwrap(), &4);
+    assert_eq!(re.get((3,2,4)).unwrap(), &11);
+    assert_eq!(im.get((3,2,4)).unwrap(), &4);
 }
 
 #[test]
 fn test_split_complex_invert_axis() {
-    let mut a = Array::from_shape_fn((2, 3, 2), |(i, j, k)| {
-        Complex::new(i as f64 + j as f64, i as f64 + k as f64)
-    });
+    let mut a = Array::from_shape_fn((2, 3, 2), |(i, j, k)| Complex::new(i as f64 + j as f64, i as f64 + k as f64));
     a.invert_axis(Axis(1));
     let cmplx = a.view().split_complex();
     assert_eq!(cmplx.re, a.mapv(|z| z.re));

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -11,8 +11,7 @@ use approx::assert_relative_eq;
 use defmac::defmac;
 use itertools::{zip, Itertools};
 use ndarray::prelude::*;
-use ndarray::{arr3, rcarr2};
-use ndarray::{Slice, SliceInfo, SliceInfoElem};
+use ndarray::{arr3, indices, rcarr2, Slice, SliceInfo, SliceInfoElem};
 use num_complex::Complex;
 use std::convert::TryFrom;
 


### PR DESCRIPTION
Adds the easy const generics improvements mentioned in #961. This includes implementation of `IntoNdProducer`, `FixedInitializer`, and `NdIndex<IxDyn>` for arrays as well as `From` implementations for 2D slices (slices of higher dimensions is also possible).