### PR TITLE
Add logo to docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 // except according to those terms.
 #![crate_name = "ndarray"]
 #![doc(html_root_url = "https://docs.rs/ndarray/0.15/")]
+#![doc(html_logo_url = "https://rust-ndarray.github.io/images/rust-ndarray_logo.svg")]
 #![allow(
     clippy::many_single_char_names,
     clippy::deref_addrof,


### PR DESCRIPTION
I noticed the logo in the upper left corner of the [`wgpu` docs](https://docs.rs/wgpu/0.7.1/wgpu/) and thought it was kind of fun, so I've created this PR. This is the same logo I created for the [`rust-ndarray` GitHub organization](https://github.com/rust-ndarray/). The Ferris crab inside of the brackets is from [here](https://www.rustacean.net/); it's licensed as CC0 (public domain).

Note that the image URL will not work until this is merged (since the image will be hosted by GitHub). Edit: I just saw that a PNG version of the logo is currently located in the GitHub pages repository. Would it be better to host the image from GitHub Pages instead?