### PR TITLE
Implement by-value iterator for owned arrays

### DIFF
--- a/src/data_repr.rs
+++ b/src/data_repr.rs
@@ -53,6 +53,10 @@ impl<A> OwnedRepr<A> {
         self.ptr.as_ptr()
     }
 
+    pub(crate) fn as_ptr_mut(&self) -> *mut A {
+        self.ptr.as_ptr()
+    }
+
     pub(crate) fn as_nonnull_mut(&mut self) -> NonNull<A> {
         self.ptr
     }

--- a/src/data_repr.rs
+++ b/src/data_repr.rs
@@ -92,6 +92,13 @@ impl<A> OwnedRepr<A> {
         self.len = new_len;
     }
 
+    /// Return the length (number of elements in total)
+    pub(crate) fn release_all_elements(&mut self) -> usize {
+        let ret = self.len;
+        self.len = 0;
+        ret
+    }
+
     /// Cast self into equivalent repr of other element type
     ///
     /// ## Safety

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -498,6 +498,7 @@ where
     ///
     /// **Panics** if an index is out of bounds or step size is zero.<br>
     /// **Panics** if `axis` is out of bounds.
+    #[must_use = "slice_axis returns an array view with the sliced result"]
     pub fn slice_axis(&self, axis: Axis, indices: Slice) -> ArrayView<'_, A, D>
     where
         S: Data,
@@ -511,6 +512,7 @@ where
     ///
     /// **Panics** if an index is out of bounds or step size is zero.<br>
     /// **Panics** if `axis` is out of bounds.
+    #[must_use = "slice_axis_mut returns an array view with the sliced result"]
     pub fn slice_axis_mut(&mut self, axis: Axis, indices: Slice) -> ArrayViewMut<'_, A, D>
     where
         S: DataMut,

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -2226,17 +2226,14 @@ where
         A: 'a,
         S: Data,
     {
-        if let Some(slc) = self.as_slice_memory_order() {
-            let v = crate::iterators::to_vec_mapped(slc.iter(), f);
-            unsafe {
-                ArrayBase::from_shape_vec_unchecked(
+        unsafe {
+            if let Some(slc) = self.as_slice_memory_order() {
+                ArrayBase::from_shape_trusted_iter_unchecked(
                     self.dim.clone().strides(self.strides.clone()),
-                    v,
-                )
+                    slc.iter(), f)
+            } else {
+                ArrayBase::from_shape_trusted_iter_unchecked(self.dim.clone(), self.iter(), f)
             }
-        } else {
-            let v = crate::iterators::to_vec_mapped(self.iter(), f);
-            unsafe { ArrayBase::from_shape_vec_unchecked(self.dim.clone(), v) }
         }
     }
 
@@ -2256,11 +2253,10 @@ where
         if self.is_contiguous() {
             let strides = self.strides.clone();
             let slc = self.as_slice_memory_order_mut().unwrap();
-            let v = crate::iterators::to_vec_mapped(slc.iter_mut(), f);
-            unsafe { ArrayBase::from_shape_vec_unchecked(dim.strides(strides), v) }
+            unsafe { ArrayBase::from_shape_trusted_iter_unchecked(dim.strides(strides),
+                        slc.iter_mut(), f) }
         } else {
-            let v = crate::iterators::to_vec_mapped(self.iter_mut(), f);
-            unsafe { ArrayBase::from_shape_vec_unchecked(dim, v) }
+            unsafe { ArrayBase::from_shape_trusted_iter_unchecked(dim, self.iter_mut(), f) }
         }
     }
 

--- a/src/iterators/into_iter.rs
+++ b/src/iterators/into_iter.rs
@@ -1,0 +1,136 @@
+// Copyright 2020-2021 bluss and ndarray developers.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::mem;
+use std::ptr::NonNull;
+
+use crate::imp_prelude::*;
+use crate::OwnedRepr;
+
+use super::Baseiter;
+use crate::impl_owned_array::drop_unreachable_raw;
+
+
+/// By-value iterator for an array
+pub struct IntoIter<A, D>
+where
+    D: Dimension,
+{
+    array_data: OwnedRepr<A>,
+    inner: Baseiter<A, D>,
+    data_len: usize,
+    /// first memory address of an array element
+    array_head_ptr: NonNull<A>,
+    // if true, the array owns elements that are not reachable by indexing
+    // through all the indices of the dimension.
+    has_unreachable_elements: bool,
+}
+
+impl<A, D> IntoIter<A, D> 
+where
+    D: Dimension,
+{
+    /// Create a new by-value iterator that consumes `array`
+    pub(crate) fn new(mut array: Array<A, D>) -> Self {
+        unsafe {
+            let array_head_ptr = array.ptr;
+            let ptr = array.as_mut_ptr();
+            let mut array_data = array.data;
+            let data_len = array_data.release_all_elements();
+            debug_assert!(data_len >= array.dim.size());
+            let has_unreachable_elements = array.dim.size() != data_len;
+            let inner = Baseiter::new(ptr, array.dim, array.strides);
+
+            IntoIter {
+                array_data,
+                inner,
+                data_len,
+                array_head_ptr,
+                has_unreachable_elements,
+            }
+        }
+    }
+}
+
+impl<A, D: Dimension> Iterator for IntoIter<A, D> {
+    type Item = A;
+
+    #[inline]
+    fn next(&mut self) -> Option<A> {
+        self.inner.next().map(|p| unsafe { p.read() })
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
+}
+
+impl<A, D: Dimension> ExactSizeIterator for IntoIter<A, D> {
+    fn len(&self) -> usize { self.inner.len() }
+}
+
+impl<A, D> Drop for IntoIter<A, D>
+where
+    D: Dimension
+{
+    fn drop(&mut self) {
+        if !self.has_unreachable_elements || mem::size_of::<A>() == 0 || !mem::needs_drop::<A>() {
+            return;
+        }
+
+        // iterate til the end
+        while let Some(_) = self.next() { }
+
+        unsafe {
+            let data_ptr = self.array_data.as_ptr_mut();
+            let view = RawArrayViewMut::new(self.array_head_ptr, self.inner.dim.clone(),
+                                            self.inner.strides.clone());
+            debug_assert!(self.inner.dim.size() < self.data_len, "data_len {} and dim size {}",
+                          self.data_len, self.inner.dim.size());
+            drop_unreachable_raw(view, data_ptr, self.data_len);
+        }
+    }
+}
+
+impl<A, D> IntoIterator for Array<A, D>
+where
+    D: Dimension
+{
+    type Item = A;
+    type IntoIter = IntoIter<A, D>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        IntoIter::new(self)
+    }
+}
+
+impl<A, D> IntoIterator for ArcArray<A, D>
+where
+    D: Dimension,
+    A: Clone,
+{
+    type Item = A;
+    type IntoIter = IntoIter<A, D>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        IntoIter::new(self.into_owned())
+    }
+}
+
+impl<A, D> IntoIterator for CowArray<'_, A, D>
+where
+    D: Dimension,
+    A: Clone,
+{
+    type Item = A;
+    type IntoIter = IntoIter<A, D>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        IntoIter::new(self.into_owned())
+    }
+}

--- a/src/iterators/mod.rs
+++ b/src/iterators/mod.rs
@@ -9,6 +9,7 @@
 #[macro_use]
 mod macros;
 mod chunks;
+mod into_iter;
 pub mod iter;
 mod lanes;
 mod windows;
@@ -26,6 +27,7 @@ use super::{Dimension, Ix, Ixs};
 pub use self::chunks::{ExactChunks, ExactChunksIter, ExactChunksIterMut, ExactChunksMut};
 pub use self::lanes::{Lanes, LanesMut};
 pub use self::windows::Windows;
+pub use self::into_iter::IntoIter;
 
 use std::slice::{self, Iter as SliceIter, IterMut as SliceIterMut};
 
@@ -1465,6 +1467,7 @@ unsafe impl TrustedIterator for ::std::ops::Range<usize> {}
 // FIXME: These indices iter are dubious -- size needs to be checked up front.
 unsafe impl<D> TrustedIterator for IndicesIter<D> where D: Dimension {}
 unsafe impl<D> TrustedIterator for IndicesIterF<D> where D: Dimension {}
+unsafe impl<A, D> TrustedIterator for IntoIter<A, D> where D: Dimension {}
 
 /// Like Iterator::collect, but only for trusted length iterators
 pub fn to_vec<I>(iter: I) -> Vec<I::Item>


### PR DESCRIPTION
Implement `IntoIterator` for `Array`. This uses the same code for "dropping unreachable elements" that `.move_into()` does (from the #932 PR).

New features: 

- `Array::into_iter` (same for ArcArray, CowArray)

Fixes #196