### PR TITLE
move_into: Split into methods `.move_into()` and `.move_into_uninit()`.

### DIFF
--- a/src/impl_owned_array.rs
+++ b/src/impl_owned_array.rs
@@ -1,5 +1,6 @@
 
 use alloc::vec::Vec;
+use std::mem;
 use std::mem::MaybeUninit;
 
 use rawpointer::PointerExt;
@@ -33,7 +34,7 @@ impl<A> Array<A, Ix0> {
     /// assert_eq!(scalar, Foo);
     /// ```
     pub fn into_scalar(self) -> A {
-        let size = ::std::mem::size_of::<A>();
+        let size = mem::size_of::<A>();
         if size == 0 {
             // Any index in the `Vec` is fine since all elements are identical.
             self.data.into_vec().remove(0)
@@ -208,7 +209,7 @@ impl<A, D> Array<A, D>
         let data_len = self.data.len();
 
         let has_unreachable_elements = self_len != data_len;
-        if !has_unreachable_elements || std::mem::size_of::<A>() == 0 {
+        if !has_unreachable_elements || mem::size_of::<A>() == 0 || !mem::needs_drop::<A>() {
             unsafe {
                 self.data.set_len(0);
             }


### PR DESCRIPTION
Two methods for `Array`:

- `.move_into(impl Into<ArrayViewMut<A, ..>>)`
- `.move_into_uninit(impl Into<ArrayViewMut<MaybeUninit<A>, ..>>)`

The `uninit` version is an optimization - it is more efficient since we don't need to keep track of the overwriting of existing values in the array. However, we optimize so that if `A` has no drop, they should be equivalent. So the user can use whichever fits best without worrying so much.

The new `move_into`  turned out to be very simple: just swap the elements in the old and new array. This means we never have a partially moved-from array to keep track of and no headaches. We simply delegate over to the non-drop method if we can. We also use a `needs_drop` check in `move_into_uninit` to skip all the complicated dropping code if the element type doesn't have drop.