### PR TITLE
Make build_uninit public

### DIFF
--- a/src/impl_constructors.rs
+++ b/src/impl_constructors.rs
@@ -530,7 +530,7 @@ where
     /// ### Safety
     ///
     /// The whole of the array must be initialized before it is converted
-    /// using [`.assume_init()`] or otherwise traversed.
+    /// using [`.assume_init()`] or otherwise traversed/read with the element type `A`.
     ///
     /// ### Examples
     ///
@@ -580,10 +580,10 @@ where
     /// The uninitialized elements of type `A` are represented by the type `MaybeUninit<A>`,
     /// an easier way to handle uninit values correctly.
     ///
-    /// The `builder` closure gets unshared access to the array through a raw view
-    /// and can use it to modify the array before it is returned. This allows initializing
-    /// the array for any owned array type (avoiding clone requirements for copy-on-write,
-    /// because the array is unshared when initially created).
+    /// The `builder` closure gets unshared access to the array through a view and can use it to
+    /// modify the array before it is returned. This allows initializing the array for any owned
+    /// array type (avoiding clone requirements for copy-on-write, because the array is unshared
+    /// when initially created).
     ///
     /// Only *when* the array is completely initialized with valid elements, can it be
     /// converted to an array of `A` elements using [`.assume_init()`].
@@ -593,17 +593,18 @@ where
     /// ### Safety
     ///
     /// The whole of the array must be initialized before it is converted
-    /// using [`.assume_init()`] or otherwise traversed.
+    /// using [`.assume_init()`] or otherwise traversed/read with the element type `A`.
     ///
-    pub(crate) fn build_uninit<Sh, F>(shape: Sh, builder: F) -> ArrayBase<S::MaybeUninit, D>
+    /// [`.assume_init()`]: ArrayBase::assume_init
+    pub fn build_uninit<Sh, F>(shape: Sh, builder: F) -> ArrayBase<S::MaybeUninit, D>
     where
         Sh: ShapeBuilder<Dim = D>,
-        F: FnOnce(RawArrayViewMut<MaybeUninit<A>, D>),
+        F: FnOnce(ArrayViewMut<MaybeUninit<A>, D>),
     {
         let mut array = Self::uninit(shape);
         // Safe because: the array is unshared here
         unsafe {
-            builder(array.raw_view_mut_unchecked());
+            builder(array.raw_view_mut_unchecked().deref_into_view_mut());
         }
         array
     }

--- a/src/zip/mod.rs
+++ b/src/zip/mod.rs
@@ -745,7 +745,7 @@ macro_rules! map_impl {
                     // Use partial to count the number of filled elements, and can drop the right
                     // number of elements on unwinding (if it happens during apply/collect).
                     unsafe {
-                        let output_view = output.cast::<R>();
+                        let output_view = output.into_raw_view_mut().cast::<R>();
                         self.and(output_view)
                             .collect_with_partial(f)
                             .release_ownership();


### PR DESCRIPTION
This builder method is needed - `uninit` on itself is very hard to use
while generalizing over owned arrays (we have some expression problems
with Rust generics here). This functionality is needed by ndarray-linalg.

Fixes #987 