### PR TITLE
Fix warnings in examples

### DIFF
--- a/src/arraytraits.rs
+++ b/src/arraytraits.rs
@@ -176,7 +176,6 @@ where
     ///
     /// ```rust
     /// use ndarray::{Array, arr1};
-    /// use std::iter::FromIterator;
     ///
     /// // Either use `from_iter` directly or use `Iterator::collect`.
     /// let array = Array::from_iter((0..5).map(|x| x * x));

--- a/src/doc/ndarray_for_numpy_users/coord_transform.rs
+++ b/src/doc/ndarray_for_numpy_users/coord_transform.rs
@@ -83,7 +83,7 @@
 //!     for i in 0..nelems {
 //!         rotated
 //!             .slice_mut(s![.., .., i])
-//!             .assign({ &rmat.slice(s![.., .., i]).dot(&eye2d) });
+//!             .assign(&rmat.slice(s![.., .., i]).dot(&eye2d));
 //!     }
 //! }
 //! ```

--- a/src/doc/ndarray_for_numpy_users/mod.rs
+++ b/src/doc/ndarray_for_numpy_users/mod.rs
@@ -179,7 +179,7 @@
 //! ```
 //! use ndarray::prelude::*;
 //! #
-//! # fn main() {}
+//! # fn main() { let _ = arr0(1); }
 //! ```
 //!
 //! ## Array creation

--- a/src/doc/ndarray_for_numpy_users/rk_step.rs
+++ b/src/doc/ndarray_for_numpy_users/rk_step.rs
@@ -104,7 +104,7 @@
 //!     (y_new, f_new, error)
 //! }
 //! #
-//! # fn main() {}
+//! # fn main() { let _ = rk_step::<fn(_, ArrayView1<'_, _>) -> _>; }
 //! ```
 //!
 //! It's possible to improve the efficiency by doing the following:
@@ -165,7 +165,7 @@
 //!     (y_new, error)
 //! }
 //! #
-//! # fn main() {}
+//! # fn main() { let _ = rk_step::<fn(_, ArrayView1<'_, f64>, ArrayViewMut1<'_, f64>)>; }
 //! ```
 //!
 //! [f64.mul_add()]: https://doc.rust-lang.org/std/primitive.f64.html#method.mul_add

--- a/src/impl_constructors.rs
+++ b/src/impl_constructors.rs
@@ -133,10 +133,10 @@ where
     /// to type `A` fails.
     ///
     /// ```rust
+    /// # #[cfg(feature = "approx")] {
     /// use approx::assert_abs_diff_eq;
     /// use ndarray::{Array, arr1};
     ///
-    /// # #[cfg(feature = "approx")] {
     /// let array = Array::logspace(10.0, 0.0, 3.0, 4);
     /// assert_abs_diff_eq!(array, arr1(&[1e0, 1e1, 1e2, 1e3]));
     ///
@@ -163,11 +163,11 @@ where
     /// to type `A` fails.
     ///
     /// ```rust
+    /// # fn example() -> Option<()> {
+    /// # #[cfg(feature = "approx")] {
     /// use approx::assert_abs_diff_eq;
     /// use ndarray::{Array, arr1};
     ///
-    /// # fn example() -> Option<()> {
-    /// # #[cfg(feature = "approx")] {
     /// let array = Array::geomspace(1e0, 1e3, 4)?;
     /// assert_abs_diff_eq!(array, arr1(&[1e0, 1e1, 1e2, 1e3]), epsilon = 1e-12);
     ///
@@ -541,8 +541,6 @@ where
     ///
     /// ```
     /// use ndarray::{s, Array2};
-    /// use ndarray::Zip;
-    /// use ndarray::Axis;
     ///
     /// // Example Task: Let's create a column shifted copy of the input
     ///
@@ -561,6 +559,8 @@ where
     ///         b.assume_init()
     ///     }
     /// }
+    /// 
+    /// # let _ = shift_by_two;
     /// ```
     pub fn uninit<Sh>(shape: Sh) -> ArrayBase<S::MaybeUninit, D>
     where

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -928,7 +928,7 @@ where
     /// Iterator element is `ArrayView1<A>` (1D array view).
     ///
     /// ```
-    /// use ndarray::{arr3, Axis, arr1};
+    /// use ndarray::arr3;
     ///
     /// let a = arr3(&[[[ 0,  1,  2],    // -- row 0, 0
     ///                 [ 3,  4,  5]],   // -- row 0, 1
@@ -996,7 +996,7 @@ where
     /// Iterator element is `ArrayView1<A>` (1D array view).
     ///
     /// ```
-    /// use ndarray::{arr3, Axis, arr1};
+    /// use ndarray::arr3;
     ///
     /// // The generalized columns of a 3D array:
     /// // are directed along the 0th axis: 0 and 6, 1 and 7 and so on...
@@ -1177,7 +1177,6 @@ where
     /// ```
     /// use ndarray::Array;
     /// use ndarray::{arr3, Axis};
-    /// use std::iter::FromIterator;
     ///
     /// let a = Array::from_iter(0..28).into_shape((2, 7, 2)).unwrap();
     /// let mut iter = a.axis_chunks_iter(Axis(1), 2);
@@ -2397,10 +2396,10 @@ where
     /// Elements are visited in arbitrary order.
     ///
     /// ```
+    /// # #[cfg(feature = "approx")] {
     /// use approx::assert_abs_diff_eq;
     /// use ndarray::arr2;
     ///
-    /// # #[cfg(feature = "approx")] {
     /// let mut a = arr2(&[[ 0., 1.],
     ///                    [-1., 2.]]);
     /// a.mapv_inplace(f32::exp);

--- a/src/impl_views/conversions.rs
+++ b/src/impl_views/conversions.rs
@@ -96,7 +96,7 @@ impl<'a, A> ArrayViewMut<'a, A, Ix0> {
     ///
     /// let mut array: Array0<f64> = arr0(5.);
     /// let view = array.view_mut();
-    /// let mut scalar = view.into_scalar();
+    /// let scalar = view.into_scalar();
     /// *scalar = 7.;
     /// assert_eq!(scalar, &7.);
     /// assert_eq!(array[()], 7.);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,9 @@
     clippy::while_let_on_iterator, // is not an error
     clippy::from_iter_instead_of_collect, // using from_iter is good style
 )]
+#![doc(test(attr(deny(warnings))))]
+#![doc(test(attr(allow(unused_variables))))]
+#![doc(test(attr(allow(deprecated))))]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 //! The `ndarray` crate provides an *n*-dimensional container for general elements

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -12,8 +12,9 @@
 //! and macros that you can import easily as a group.
 //!
 //! ```
-//!
 //! use ndarray::prelude::*;
+//!
+//! # let _ = arr0(1); // use the import
 //! ```
 
 #[doc(no_inline)]

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -741,7 +741,7 @@ impl_slicenextdim!((), NewAxis, Ix0, Ix1);
 ///     + v.slice(s![1..-1, 2..  ])
 ///     + v.slice(s![2..  , 1..-1])
 /// }
-/// # fn main() { }
+/// # fn main() { let _ = laplacian; }
 /// ```
 ///
 /// # Negative *step*

--- a/src/zip/mod.rs
+++ b/src/zip/mod.rs
@@ -184,7 +184,7 @@ trait ZippableTuple: Sized {
 ///
 /// // Example 3: Recreate Example 2 using map_collect to make a new array
 ///
-/// let mut totals2 = Zip::from(a.rows()).map_collect(|row| row.sum());
+/// let totals2 = Zip::from(a.rows()).map_collect(|row| row.sum());
 ///
 /// // Check the result against the previous example.
 /// assert_eq!(totals, totals2);


### PR DESCRIPTION
Add attributes to fail example tests on warnings. Exempt a few warnings,
for example unused variables, which are not worth fixing (would make the
examples worse in many cases).