### PR TITLE
Guarantee that `.as_slice_memory_order_mut()` preserves strides 

### DIFF
--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -1536,6 +1536,10 @@ where
 
     /// Return the array’s data as a slice if it is contiguous,
     /// return `None` otherwise.
+    ///
+    /// In the contiguous case, in order to return a unique reference, this
+    /// method unshares the data if necessary, but it preserves the existing
+    /// strides.
     pub fn as_slice_memory_order_mut(&mut self) -> Option<&mut [A]>
     where
         S: DataMut,

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -217,7 +217,7 @@ where
                 )
             }
         } else {
-            self.map(|x| x.clone())
+            self.map(A::clone)
         }
     }
 


### PR DESCRIPTION
Fixes #1018.