### PR TITLE
Implement From<Array<A, D>> for ArcArray<A, D>

### DIFF
--- a/src/arraytraits.rs
+++ b/src/arraytraits.rs
@@ -354,6 +354,15 @@ where
     }
 }
 
+impl<A, D> From<Array<A, D>> for ArcArray<A, D>
+where
+    D: Dimension,
+{
+    fn from(arr: Array<A, D>) -> ArcArray<A, D> {
+        arr.into_shared()
+    }
+}
+
 /// Argument conversion into an array view
 ///
 /// The trait is parameterized over `A`, the element type, and `D`, the


### PR DESCRIPTION
I'd like to make `CowRepr` implement `DataOwned`, where `DataOwned` is changed to mean "a storage type which can own its data". The only issue is the `.into_shared()` method, which says, "Turn the array into a shared ownership (copy on write) array, without any copying." We can't always turn a `CowArray` into an `ArcArray` without copying. One approach (which would be a breaking change) would be to remove `DataOwned::into_shared` and just rely on this `From` implementation instead. Then, we could implement `DataOwned` for `CowRepr` without issues.

Regardless of the `CowRepr` stuff, this impl still seems useful.