### PR TITLE
Add try_into_owned_nocopy method

### DIFF
--- a/src/data_traits.rs
+++ b/src/data_traits.rs
@@ -16,7 +16,9 @@ use std::ptr::NonNull;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 
-use crate::{ArrayBase, CowRepr, Dimension, OwnedArcRepr, OwnedRepr, RawViewRepr, ViewRepr};
+use crate::{
+    ArcArray, Array, ArrayBase, CowRepr, Dimension, OwnedArcRepr, OwnedRepr, RawViewRepr, ViewRepr,
+};
 
 /// Array representation trait.
 ///
@@ -97,7 +99,7 @@ pub unsafe trait Data: RawData {
     /// Converts the array to a uniquely owned array, cloning elements if necessary.
     #[doc(hidden)]
     #[allow(clippy::wrong_self_convention)]
-    fn into_owned<D>(self_: ArrayBase<Self, D>) -> ArrayBase<OwnedRepr<Self::Elem>, D>
+    fn into_owned<D>(self_: ArrayBase<Self, D>) -> Array<Self::Elem, D>
     where
         Self::Elem: Clone,
         D: Dimension;
@@ -107,7 +109,7 @@ pub unsafe trait Data: RawData {
     #[doc(hidden)]
     fn try_into_owned_nocopy<D>(
         self_: ArrayBase<Self, D>,
-    ) -> Result<ArrayBase<OwnedRepr<Self::Elem>, D>, ArrayBase<Self, D>>
+    ) -> Result<Array<Self::Elem, D>, ArrayBase<Self, D>>
     where
         D: Dimension;
 
@@ -115,7 +117,7 @@ pub unsafe trait Data: RawData {
     /// cloning elements if necessary.
     #[doc(hidden)]
     #[allow(clippy::wrong_self_convention)]
-    fn to_shared<D>(self_: &ArrayBase<Self, D>) -> ArrayBase<OwnedArcRepr<Self::Elem>, D>
+    fn to_shared<D>(self_: &ArrayBase<Self, D>) -> ArcArray<Self::Elem, D>
     where
         Self::Elem: Clone,
         D: Dimension,
@@ -268,7 +270,7 @@ where
 }
 
 unsafe impl<A> Data for OwnedArcRepr<A> {
-    fn into_owned<D>(mut self_: ArrayBase<Self, D>) -> ArrayBase<OwnedRepr<Self::Elem>, D>
+    fn into_owned<D>(mut self_: ArrayBase<Self, D>) -> Array<Self::Elem, D>
     where
         A: Clone,
         D: Dimension,
@@ -284,7 +286,7 @@ unsafe impl<A> Data for OwnedArcRepr<A> {
 
     fn try_into_owned_nocopy<D>(
         self_: ArrayBase<Self, D>,
-    ) -> Result<ArrayBase<OwnedRepr<Self::Elem>, D>, ArrayBase<Self, D>>
+    ) -> Result<Array<Self::Elem, D>, ArrayBase<Self, D>>
     where
         D: Dimension,
     {
@@ -304,7 +306,7 @@ unsafe impl<A> Data for OwnedArcRepr<A> {
     }
 
     #[allow(clippy::wrong_self_convention)]
-    fn to_shared<D>(self_: &ArrayBase<Self, D>) -> ArrayBase<OwnedArcRepr<Self::Elem>, D>
+    fn to_shared<D>(self_: &ArrayBase<Self, D>) -> ArcArray<Self::Elem, D>
     where
         Self::Elem: Clone,
         D: Dimension,
@@ -357,7 +359,7 @@ unsafe impl<A> RawDataMut for OwnedRepr<A> {
 
 unsafe impl<A> Data for OwnedRepr<A> {
     #[inline]
-    fn into_owned<D>(self_: ArrayBase<Self, D>) -> ArrayBase<OwnedRepr<Self::Elem>, D>
+    fn into_owned<D>(self_: ArrayBase<Self, D>) -> Array<Self::Elem, D>
     where
         A: Clone,
         D: Dimension,
@@ -368,7 +370,7 @@ unsafe impl<A> Data for OwnedRepr<A> {
     #[inline]
     fn try_into_owned_nocopy<D>(
         self_: ArrayBase<Self, D>,
-    ) -> Result<ArrayBase<Self, D>, ArrayBase<Self, D>>
+    ) -> Result<Array<Self::Elem, D>, ArrayBase<Self, D>>
     where
         D: Dimension,
     {
@@ -423,7 +425,7 @@ unsafe impl<'a, A> RawData for ViewRepr<&'a A> {
 }
 
 unsafe impl<'a, A> Data for ViewRepr<&'a A> {
-    fn into_owned<D>(self_: ArrayBase<Self, D>) -> ArrayBase<OwnedRepr<Self::Elem>, D>
+    fn into_owned<D>(self_: ArrayBase<Self, D>) -> Array<Self::Elem, D>
     where
         Self::Elem: Clone,
         D: Dimension,
@@ -433,7 +435,7 @@ unsafe impl<'a, A> Data for ViewRepr<&'a A> {
 
     fn try_into_owned_nocopy<D>(
         self_: ArrayBase<Self, D>,
-    ) -> Result<ArrayBase<OwnedRepr<Self::Elem>, D>, ArrayBase<Self, D>>
+    ) -> Result<Array<Self::Elem, D>, ArrayBase<Self, D>>
     where
         D: Dimension,
     {
@@ -477,7 +479,7 @@ unsafe impl<'a, A> RawDataMut for ViewRepr<&'a mut A> {
 }
 
 unsafe impl<'a, A> Data for ViewRepr<&'a mut A> {
-    fn into_owned<D>(self_: ArrayBase<Self, D>) -> ArrayBase<OwnedRepr<Self::Elem>, D>
+    fn into_owned<D>(self_: ArrayBase<Self, D>) -> Array<Self::Elem, D>
     where
         Self::Elem: Clone,
         D: Dimension,
@@ -487,7 +489,7 @@ unsafe impl<'a, A> Data for ViewRepr<&'a mut A> {
 
     fn try_into_owned_nocopy<D>(
         self_: ArrayBase<Self, D>,
-    ) -> Result<ArrayBase<OwnedRepr<Self::Elem>, D>, ArrayBase<Self, D>>
+    ) -> Result<Array<Self::Elem, D>, ArrayBase<Self, D>>
     where
         D: Dimension,
     {
@@ -648,7 +650,7 @@ where
 
 unsafe impl<'a, A> Data for CowRepr<'a, A> {
     #[inline]
-    fn into_owned<D>(self_: ArrayBase<CowRepr<'a, A>, D>) -> ArrayBase<OwnedRepr<Self::Elem>, D>
+    fn into_owned<D>(self_: ArrayBase<CowRepr<'a, A>, D>) -> Array<Self::Elem, D>
     where
         A: Clone,
         D: Dimension,
@@ -665,7 +667,7 @@ unsafe impl<'a, A> Data for CowRepr<'a, A> {
 
     fn try_into_owned_nocopy<D>(
         self_: ArrayBase<Self, D>,
-    ) -> Result<ArrayBase<OwnedRepr<Self::Elem>, D>, ArrayBase<Self, D>>
+    ) -> Result<Array<Self::Elem, D>, ArrayBase<Self, D>>
     where
         D: Dimension,
     {

--- a/src/data_traits.rs
+++ b/src/data_traits.rs
@@ -102,6 +102,15 @@ pub unsafe trait Data: RawData {
         Self::Elem: Clone,
         D: Dimension;
 
+    /// Converts the array into `Array<A, D>` if this is possible without
+    /// cloning the array elements. Otherwise, returns `self_` unchanged.
+    #[doc(hidden)]
+    fn try_into_owned_nocopy<D>(
+        self_: ArrayBase<Self, D>,
+    ) -> Result<ArrayBase<OwnedRepr<Self::Elem>, D>, ArrayBase<Self, D>>
+    where
+        D: Dimension;
+
     /// Return a shared ownership (copy on write) array based on the existing one,
     /// cloning elements if necessary.
     #[doc(hidden)]
@@ -273,6 +282,27 @@ unsafe impl<A> Data for OwnedArcRepr<A> {
         }
     }
 
+    fn try_into_owned_nocopy<D>(
+        self_: ArrayBase<Self, D>,
+    ) -> Result<ArrayBase<OwnedRepr<Self::Elem>, D>, ArrayBase<Self, D>>
+    where
+        D: Dimension,
+    {
+        match Arc::try_unwrap(self_.data.0) {
+            Ok(owned_data) => unsafe {
+                // Safe because the data is equivalent.
+                Ok(ArrayBase::from_data_ptr(owned_data, self_.ptr)
+                    .with_strides_dim(self_.strides, self_.dim))
+            },
+            Err(arc_data) => unsafe {
+                // Safe because the data is equivalent; we're just
+                // reconstructing `self_`.
+                Err(ArrayBase::from_data_ptr(OwnedArcRepr(arc_data), self_.ptr)
+                    .with_strides_dim(self_.strides, self_.dim))
+            },
+        }
+    }
+
     #[allow(clippy::wrong_self_convention)]
     fn to_shared<D>(self_: &ArrayBase<Self, D>) -> ArrayBase<OwnedArcRepr<Self::Elem>, D>
     where
@@ -334,6 +364,16 @@ unsafe impl<A> Data for OwnedRepr<A> {
     {
         self_
     }
+
+    #[inline]
+    fn try_into_owned_nocopy<D>(
+        self_: ArrayBase<Self, D>,
+    ) -> Result<ArrayBase<Self, D>, ArrayBase<Self, D>>
+    where
+        D: Dimension,
+    {
+        Ok(self_)
+    }
 }
 
 unsafe impl<A> DataMut for OwnedRepr<A> {}
@@ -390,6 +430,15 @@ unsafe impl<'a, A> Data for ViewRepr<&'a A> {
     {
         self_.to_owned()
     }
+
+    fn try_into_owned_nocopy<D>(
+        self_: ArrayBase<Self, D>,
+    ) -> Result<ArrayBase<OwnedRepr<Self::Elem>, D>, ArrayBase<Self, D>>
+    where
+        D: Dimension,
+    {
+        Err(self_)
+    }
 }
 
 unsafe impl<'a, A> RawDataClone for ViewRepr<&'a A> {
@@ -434,6 +483,15 @@ unsafe impl<'a, A> Data for ViewRepr<&'a mut A> {
         D: Dimension,
     {
         self_.to_owned()
+    }
+
+    fn try_into_owned_nocopy<D>(
+        self_: ArrayBase<Self, D>,
+    ) -> Result<ArrayBase<OwnedRepr<Self::Elem>, D>, ArrayBase<Self, D>>
+    where
+        D: Dimension,
+    {
+        Err(self_)
     }
 }
 
@@ -601,6 +659,22 @@ unsafe impl<'a, A> Data for CowRepr<'a, A> {
                 // safe because the data is equivalent so ptr, dims remain valid
                 ArrayBase::from_data_ptr(data, self_.ptr)
                     .with_strides_dim(self_.strides, self_.dim)
+            },
+        }
+    }
+
+    fn try_into_owned_nocopy<D>(
+        self_: ArrayBase<Self, D>,
+    ) -> Result<ArrayBase<OwnedRepr<Self::Elem>, D>, ArrayBase<Self, D>>
+    where
+        D: Dimension,
+    {
+        match self_.data {
+            CowRepr::View(_) => Err(self_),
+            CowRepr::Owned(data) => unsafe {
+                // safe because the data is equivalent so ptr, dims remain valid
+                Ok(ArrayBase::from_data_ptr(data, self_.ptr)
+                    .with_strides_dim(self_.strides, self_.dim))
             },
         }
     }

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -241,6 +241,34 @@ where
         S::into_owned(self)
     }
 
+    /// Converts the array into `Array<A, D>` if this is possible without
+    /// cloning the array elements. Otherwise, returns `self` unchanged.
+    ///
+    /// ```
+    /// use ndarray::{array, rcarr2, ArcArray2, Array2};
+    ///
+    /// // Reference-counted, clone-on-write `ArcArray`.
+    /// let a: ArcArray2<_> = rcarr2(&[[1., 2.], [3., 4.]]);
+    /// {
+    ///     // Another reference to the same data.
+    ///     let b: ArcArray2<_> = a.clone();
+    ///     // Since there are two references to the same data, `.into_owned()`
+    ///     // would require cloning the data, so `.try_into_owned_nocopy()`
+    ///     // returns `Err`.
+    ///     assert!(b.try_into_owned_nocopy().is_err());
+    /// }
+    /// // Here, since the second reference has been dropped, the `ArcArray`
+    /// // can be converted into an `Array` without cloning the data.
+    /// let unique: Array2<_> = a.try_into_owned_nocopy().unwrap();
+    /// assert_eq!(unique, array![[1., 2.], [3., 4.]]);
+    /// ```
+    pub fn try_into_owned_nocopy(self) -> Result<Array<A, D>, Self>
+    where
+        S: Data,
+    {
+        S::try_into_owned_nocopy(self)
+    }
+
     /// Turn the array into a shared ownership (copy on write) array,
     /// without any copying.
     pub fn into_shared(self) -> ArcArray<A, D>


### PR DESCRIPTION
I've been working on improvements to the layout handling in `ndarray-linalg` to make the code easier to understand, fix bugs, and avoid unnecessary cloning and by-clone transposes. One of operations I need to implement is, "Convert an `ArrayBase` into a LAPACK-compatible `Array` (i.e. `strides = [1, s]`, with `s >= nrows`), while avoiding unnecessary cloning." I don't think it's possible to implement this today without adding more methods to `ArrayBase`. To address this, I propose adding a `try_into_owned_nocopy` method which is similar to `into_owned` but returns `Err(self)` if the data would need to be cloned, instead of actually performing the cloning. This way, if the data needs to be cloned, I can clone it into an array of the correct layout, like this:

```rust
match array.try_into_owned_nocopy() {
    Ok(o) if is_lapack_compatible(&o) => o,
    Ok(o) => clone_into_new_lapack_array(&o),
    Err(a) => clone_into_new_lapack_array(&a),
}
```

There are other ways this problem could be solved, but `try_into_owned_nocopy` is the best I came up with.

A couple of notes about the PR:

1. ~If we implement `DataOwned` for `CowRepr` in another PR, then I'd change the bound on `try_into_owned_nocopy` to be `S: DataOwned`, since there wouldn't be any reason to call it on any non-`DataOwned` types.~ Edit: I was wrong; the method is actually useful for `S: Data` after all, and there isn't a strong reason to restrict it to `S: DataOwned` anyway.

2. I'm not completely satisfied with the name `try_into_owned_nocopy`. Other suggestions would be welcome.