### PR TITLE
Update approx to >=0.4, <0.6 to support approx 0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ num-complex = { version = "0.4", default-features = false }
 # Use via the `rayon` crate feature!
 rayon_ = { version = "1.0.3", optional = true, package = "rayon" }
 
-approx = { version = "0.4", optional = true , default-features = false }
+approx = { version = ">=0.4, <0.6", optional = true , default-features = false }
 
 # Use via the `blas` crate feature!
 cblas-sys = { version = "0.1.4", optional = true, default-features = false }


### PR DESCRIPTION
`approx` 0.5 updates its `num-complex` dependency to 0.4, which is the same version of `num-complex` which `ndarray` depends on. So, it's very useful for `ndarray` to support `approx` 0.5. Instead of expanding the range of the `approx` versions, another option would be to add a separate feature for `approx` 0.5, but I don't think the additional complexity would be worth it. When we release the next breaking release of `ndarray`, I think we should change this version specification to "0.5".