### PR TITLE
add mapv_into_any(), resolves #1031

### DIFF
--- a/tests/array.rs
+++ b/tests/array.rs
@@ -990,6 +990,20 @@ fn map1() {
 }
 
 #[test]
+fn mapv_into_any_same_type() {
+    let a: Array<f64, _> = array![[1., 2., 3.], [4., 5., 6.]];
+    let a_plus_one: Array<f64, _> = array![[2., 3., 4.], [5., 6., 7.]];
+    assert_eq!(a.mapv_into_any(|a| a + 1.), a_plus_one);
+}
+
+#[test]
+fn mapv_into_any_diff_types() {
+    let a: Array<f64, _> = array![[1., 2., 3.], [4., 5., 6.]];
+    let a_even: Array<bool, _> = array![[false, true, false], [true, false, true]];
+    assert_eq!(a.mapv_into_any(|a| a.round() as i32 % 2 == 0), a_even);
+}
+
+#[test]
 fn as_slice_memory_order_mut_arcarray() {
     // Test that mutation breaks sharing for `ArcArray`.
     let a = rcarr2(&[[1., 2.], [3., 4.0f32]]);


### PR DESCRIPTION
First attempt at pull request for #1031.

Since Rust does not yet have [specialization](https://github.com/rust-lang/rfcs/pull/1210), mapping between generic numerical types in ndarray is challenging when the types *might* be different.  For example, we might want to perform on operation on an array of real numbers to get an array that might be real or might be complex.  We can do this now with `ArrayBase::mapv()`, but if it turns out that both the input and output are the same type (e.g. real numbers) then `mapv()` will perform unnecessary allocation of a new array compared to `mapv_into()`.

This PR proposes a generic method `ArrayBase::mapv_into_any()` whose signature accepts a closure mapping between different types `FnMut(A) -> B` but which uses memory-efficient `mapv_into()` when `A` and `B` are the same type.  The type comparison is performed at runtime.  This is the most memory-efficient way to map between arrays of *possibly* different types using stable Rust.

The use of `unsafe` is discussed [on the Rust language forum](https://users.rust-lang.org/t/runtime-specialization-when-types-are-equal/60628).