### PR TITLE
Implement Kronecker product

### DIFF
--- a/src/linalg/impl_linalg.rs
+++ b/src/linalg/impl_linalg.rs
@@ -710,7 +710,6 @@ where
     S1: Data<Elem = A>,
     S2: Data<Elem = A>,
     A: LinalgScalar,
-    A: std::ops::Mul<&'a ArrayBase<S2, Ix2>, Output = Array<A, Ix2>>,
 {
     let dimar = a.shape()[0];
     let dimac = a.shape()[1];

--- a/src/linalg/impl_linalg.rs
+++ b/src/linalg/impl_linalg.rs
@@ -711,7 +711,7 @@ where
     S1: Data<Elem = A>,
     S2: Data<Elem = A>,
     A: LinalgScalar,
-    A: std::ops::Mul<&'a ArrayBase<S2, Ix2>, Output = ArrayBase<OwnedRepr<A>, Ix2>>,
+    A: std::ops::Mul<&'a ArrayBase<S2, Ix2>, Output = Array<A, Ix2>>,
 {
     let dimar = a.shape()[0];
     let dimac = a.shape()[1];

--- a/src/linalg/impl_linalg.rs
+++ b/src/linalg/impl_linalg.rs
@@ -706,7 +706,7 @@ unsafe fn general_mat_vec_mul_impl<A, S1, S2>(
 ///
 /// The kronecker product of a LxN matrix A and a MxR matrix B is a (L*M)x(N*R)
 /// matrix K formed by the block multiplication A_ij * B.
-pub fn kron<'a, A, S1, S2>(a: &ArrayBase<S1, Ix2>, b: &'a ArrayBase<S2, Ix2>) -> ArrayBase<OwnedRepr<A>, Ix2>
+pub fn kron<'a, A, S1, S2>(a: &ArrayBase<S1, Ix2>, b: &'a ArrayBase<S2, Ix2>) -> Array<A, Ix2>
 where
     S1: Data<Elem = A>,
     S2: Data<Elem = A>,

--- a/src/linalg/impl_linalg.rs
+++ b/src/linalg/impl_linalg.rs
@@ -705,7 +705,7 @@ unsafe fn general_mat_vec_mul_impl<A, S1, S2>(
 ///
 /// The kronecker product of a LxN matrix A and a MxR matrix B is a (L*M)x(N*R)
 /// matrix K formed by the block multiplication A_ij * B.
-pub fn kron<'a, A, S1, S2>(a: &ArrayBase<S1, Ix2>, b: &'a ArrayBase<S2, Ix2>) -> Array<A, Ix2>
+pub fn kron<A, S1, S2>(a: &ArrayBase<S1, Ix2>, b: &ArrayBase<S2, Ix2>) -> Array<A, Ix2>
 where
     S1: Data<Elem = A>,
     S2: Data<Elem = A>,

--- a/src/linalg/impl_linalg.rs
+++ b/src/linalg/impl_linalg.rs
@@ -727,7 +727,9 @@ where
     Zip::from(out.exact_chunks_mut((dimbr, dimbc)))
         .and(a)
         .for_each(|out, &a| {
-            (a * b).assign_to(out);
+            Zip::from(out).and(b).for_each(|out, &b| {
+                *out = MaybeUninit::new(a * b);
+            })
         });
     unsafe { out.assume_init() }
 }

--- a/src/linalg/mod.rs
+++ b/src/linalg/mod.rs
@@ -11,5 +11,6 @@
 pub use self::impl_linalg::general_mat_mul;
 pub use self::impl_linalg::general_mat_vec_mul;
 pub use self::impl_linalg::Dot;
+pub use self::impl_linalg::kron;
 
 mod impl_linalg;

--- a/tests/oper.rs
+++ b/tests/oper.rs
@@ -6,6 +6,7 @@
 )]
 #![cfg(feature = "std")]
 use ndarray::linalg::general_mat_mul;
+use ndarray::linalg::kron;
 use ndarray::prelude::*;
 use ndarray::{rcarr1, rcarr2};
 use ndarray::{Data, LinalgScalar};
@@ -819,4 +820,66 @@ fn vec_mat_mul() {
             }
         }
     }
+}
+
+#[test]
+fn kron_square_f64() {
+    let a = arr2(&[[1.0, 0.0], [0.0, 1.0]]);
+    let b = arr2(&[[0.0, 1.0], [1.0, 0.0]]);
+
+    assert_eq!(
+        kron(&a, &b),
+        arr2(&[
+            [0.0, 1.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 1.0],
+            [0.0, 0.0, 1.0, 0.0]
+        ]),
+    );
+
+    assert_eq!(
+        kron(&b, &a),
+        arr2(&[
+            [0.0, 0.0, 1.0, 0.0],
+            [0.0, 0.0, 0.0, 1.0],
+            [1.0, 0.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0, 0.0]
+        ]),
+    )
+}
+
+#[test]
+fn kron_square_i64() {
+    let a = arr2(&[[1, 0], [0, 1]]);
+    let b = arr2(&[[0, 1], [1, 0]]);
+
+    assert_eq!(
+        kron(&a, &b),
+        arr2(&[[0, 1, 0, 0], [1, 0, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0]]),
+    );
+
+    assert_eq!(
+        kron(&b, &a),
+        arr2(&[[0, 0, 1, 0], [0, 0, 0, 1], [1, 0, 0, 0], [0, 1, 0, 0]]),
+    )
+}
+
+#[test]
+fn kron_i64() {
+    let a = arr2(&[[1, 0]]);
+    let b = arr2(&[[0, 1], [1, 0]]);
+    let r = arr2(&[[0, 1, 0, 0], [1, 0, 0, 0]]);
+    assert_eq!(kron(&a, &b), r);
+
+    let a = arr2(&[[1, 0], [0, 0], [0, 1]]);
+    let b = arr2(&[[0, 1], [1, 0]]);
+    let r = arr2(&[
+        [0, 1, 0, 0],
+        [1, 0, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 1],
+        [0, 0, 1, 0],
+    ]);
+    assert_eq!(kron(&a, &b), r);
 }


### PR DESCRIPTION
Picking up from https://github.com/rust-ndarray/ndarray/pull/1039 and based on my original implementation in https://github.com/rust-ndarray/ndarray/issues/652 with the feedback from @bluss.

I found this implementation performs the same vs #1039 modulo using `uninit`, at least for my use case.