### PR TITLE
Update to quickcheck 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ rawpointer = { version = "0.2" }
 
 [dev-dependencies]
 defmac = "0.2"
-quickcheck = { version = "0.9", default-features = false }
+quickcheck = { version = "1.0", default-features = false }
 approx = "0.4"
 itertools = { version = "0.10.0", default-features = false, features = ["use_std"] }
 

--- a/ndarray-rand/Cargo.toml
+++ b/ndarray-rand/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["multidimensional", "matrix", "rand", "ndarray"]
 [dependencies]
 ndarray = { version = "0.15", path = ".." }
 rand_distr = "0.4.0"
-quickcheck = { version = "0.9", default-features = false, optional = true }
+quickcheck = { version = "1.0", default-features = false, optional = true }
 
 [dependencies.rand]
 version = "0.8.0"
@@ -24,7 +24,7 @@ features = ["small_rng"]
 
 [dev-dependencies]
 rand_isaac = "0.3.0"
-quickcheck = { version = "0.9", default-features = false }
+quickcheck = { version = "1.0", default-features = false }
 
 [package.metadata.release]
 no-dev-version = true

--- a/ndarray-rand/src/lib.rs
+++ b/ndarray-rand/src/lib.rs
@@ -304,7 +304,7 @@ pub enum SamplingStrategy {
 // `Arbitrary` enables `quickcheck` to generate random `SamplingStrategy` values for testing.
 #[cfg(feature = "quickcheck")]
 impl Arbitrary for SamplingStrategy {
-    fn arbitrary<G: Gen>(g: &mut G) -> Self {
+    fn arbitrary(g: &mut Gen) -> Self {
         if bool::arbitrary(g) {
             SamplingStrategy::WithReplacement
         } else {

--- a/src/dimension/mod.rs
+++ b/src/dimension/mod.rs
@@ -920,12 +920,16 @@ mod test {
     }
 
     quickcheck! {
-        fn extended_gcd_solves_eq(a: isize, b: isize) -> bool {
+        // FIXME: This test can't handle larger values at the moment
+        fn extended_gcd_solves_eq(a: i16, b: i16) -> bool {
+            let (a, b) = (a as isize, b as isize);
             let (g, (x, y)) = extended_gcd(a, b);
             a * x + b * y == g
         }
 
-        fn extended_gcd_correct_gcd(a: isize, b: isize) -> bool {
+        // FIXME: This test can't handle larger values at the moment
+        fn extended_gcd_correct_gcd(a: i16, b: i16) -> bool {
+            let (a, b) = (a as isize, b as isize);
             let (g, _) = extended_gcd(a, b);
             g == gcd(a, b)
         }
@@ -941,9 +945,12 @@ mod test {
     }
 
     quickcheck! {
+        // FIXME: This test can't handle larger values at the moment
         fn solve_linear_diophantine_eq_solution_existence(
-            a: isize, b: isize, c: isize
+            a: i16, b: i16, c: i16
         ) -> TestResult {
+            let (a, b, c) = (a as isize, b as isize, c as isize);
+
             if a == 0 || b == 0 {
                 TestResult::discard()
             } else {
@@ -953,9 +960,12 @@ mod test {
             }
         }
 
+        // FIXME: This test can't handle larger values at the moment
         fn solve_linear_diophantine_eq_correct_solution(
-            a: isize, b: isize, c: isize, t: isize
+            a: i8, b: i8, c: i8, t: i8
         ) -> TestResult {
+            let (a, b, c, t) = (a as isize, b as isize, c as isize, t as isize);
+
             if a == 0 || b == 0 {
                 TestResult::discard()
             } else {
@@ -972,17 +982,23 @@ mod test {
     }
 
     quickcheck! {
+        // FIXME: This test is extremely slow, even with i16 values, investigate
         fn arith_seq_intersect_correct(
-            first1: isize, len1: isize, step1: isize,
-            first2: isize, len2: isize, step2: isize
+            first1: i8, len1: i8, step1: i8,
+            first2: i8, len2: i8, step2: i8
         ) -> TestResult {
             use std::cmp;
+
+            let (len1, len2) = (len1 as isize, len2 as isize);
+            let (first1, step1) = (first1 as isize, step1 as isize);
+            let (first2, step2) = (first2 as isize, step2 as isize);
 
             if len1 == 0 || len2 == 0 {
                 // This case is impossible to reach in `arith_seq_intersect()`
                 // because the `min*` and `max*` arguments are inclusive.
                 return TestResult::discard();
             }
+
             let len1 = len1.abs();
             let len2 = len2.abs();
 


### PR DESCRIPTION
New in 1.0 is that integers now generate values in their whole range.
That creates a different situation for the tests taking isize than
before.

Shrink their accepted values for now, and leave as fixmes to investigate and
improve.

In some cases, the tests are slow to execute.
In other cases, the tests fail with large values (probably overflow),
and following that, the case shrinking is extremely slow.