### PR TITLE
Add additional array -> array view conversions

### DIFF
--- a/src/arraytraits.rs
+++ b/src/arraytraits.rs
@@ -333,7 +333,21 @@ where Slice: AsRef<[A]>
     }
 }
 
-/// Implementation of ArrayView2::from(&S) where S is a slice to a 2D array
+/// Implementation of ArrayView2::from(&[[A; N]; M])
+///
+/// **Panics** if the product of non-zero axis lengths overflows `isize` (This can only occur if A
+/// is zero-sized because slices cannot contain more than `isize::MAX` number of bytes).
+/// **Panics** if N == 0 and the number of rows is greater than isize::MAX.
+impl<'a, A, const M: usize, const N: usize> From<&'a [[A; N]; M]> for ArrayView<'a, A, Ix2>
+{
+    /// Create a two-dimensional read-only array view of the data in `slice`
+    fn from(xs: &'a [[A; N]; M]) -> Self
+    {
+        Self::from(&xs[..])
+    }
+}
+
+/// Implementation of ArrayView2::from(&[[A; N]])
 ///
 /// **Panics** if the product of non-zero axis lengths overflows `isize`. (This
 /// can only occur if A is zero-sized or if `N` is zero, because slices cannot
@@ -380,7 +394,21 @@ where Slice: AsMut<[A]>
     }
 }
 
-/// Implementation of ArrayViewMut2::from(&S) where S is a slice to a 2D array
+/// Implementation of ArrayViewMut2::from(&mut [[A; N]; M])
+///
+/// **Panics** if the product of non-zero axis lengths overflows `isize` (This can only occur if A
+/// is zero-sized because slices cannot contain more than `isize::MAX` number of bytes).
+/// **Panics** if N == 0 and the number of rows is greater than isize::MAX.
+impl<'a, A, const M: usize, const N: usize> From<&'a mut [[A; N]; M]> for ArrayViewMut<'a, A, Ix2>
+{
+    /// Create a two-dimensional read-write array view of the data in `slice`
+    fn from(xs: &'a mut [[A; N]; M]) -> Self
+    {
+        Self::from(&mut xs[..])
+    }
+}
+
+/// Implementation of ArrayViewMut2::from(&mut [[A; N]])
 ///
 /// **Panics** if the product of non-zero axis lengths overflows `isize`. (This
 /// can only occur if `A` is zero-sized or if `N` is zero, because slices

--- a/tests/append.rs
+++ b/tests/append.rs
@@ -383,9 +383,9 @@ fn test_append_zero_size()
 
     {
         let mut a = Array::<i32, _>::zeros((0, 0));
-        a.append(Axis(1), ArrayView::from(&[]).into_shape_with_order((0, 1)).unwrap())
+        a.append(Axis(1), ArrayView1::from(&[]).into_shape_with_order((0, 1)).unwrap())
             .unwrap();
-        a.append(Axis(1), ArrayView::from(&[]).into_shape_with_order((0, 1)).unwrap())
+        a.append(Axis(1), ArrayView1::from(&[]).into_shape_with_order((0, 1)).unwrap())
             .unwrap();
         assert_eq!(a.len(), 0);
         assert_eq!(a.shape(), &[0, 2]);


### PR DESCRIPTION
It is best to be "complete" with implementations when possible, since
it can always be a breaking change to add it later.

As shown in the test change in this commit, this is a minor type
inference breakage due to `ArrayView::from(&[])` being ambiguous.

Empty array views should be relatively rare - and one can use
`ArrayView1` or other means to disambiguate.