### PR TITLE
Make the aview0, aview1, and aview2 free functions be const fns

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.51.0  # MSRV
+          - 1.57.0  # MSRV
 
     name: tests/${{ matrix.rust }}
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 name = "ndarray"
 version = "0.15.6"
 edition = "2018"
-rust-version = "1.51"
+rust-version = "1.57"
 authors = [
   "Ulrik Sverdrup \"bluss\"",
   "Jim Turner"

--- a/scripts/all-tests.sh
+++ b/scripts/all-tests.sh
@@ -6,7 +6,7 @@ set -e
 FEATURES=$1
 CHANNEL=$2
 
-if [ "$CHANNEL" = "1.51.0" ]; then
+if [ "$CHANNEL" = "1.57.0" ]; then
     cargo update --package openblas-src --precise 0.10.5
     cargo update --package openblas-build --precise 0.10.5
     cargo update --package once_cell --precise 1.14.0

--- a/src/aliases.rs
+++ b/src/aliases.rs
@@ -7,43 +7,43 @@ use crate::{ArcArray, Array, ArrayView, ArrayViewMut, Ix, IxDynImpl};
 /// Create a zero-dimensional index
 #[allow(non_snake_case)]
 #[inline(always)]
-pub fn Ix0() -> Ix0 {
+pub const fn Ix0() -> Ix0 {
     Dim::new([])
 }
 /// Create a one-dimensional index
 #[allow(non_snake_case)]
 #[inline(always)]
-pub fn Ix1(i0: Ix) -> Ix1 {
+pub const fn Ix1(i0: Ix) -> Ix1 {
     Dim::new([i0])
 }
 /// Create a two-dimensional index
 #[allow(non_snake_case)]
 #[inline(always)]
-pub fn Ix2(i0: Ix, i1: Ix) -> Ix2 {
+pub const fn Ix2(i0: Ix, i1: Ix) -> Ix2 {
     Dim::new([i0, i1])
 }
 /// Create a three-dimensional index
 #[allow(non_snake_case)]
 #[inline(always)]
-pub fn Ix3(i0: Ix, i1: Ix, i2: Ix) -> Ix3 {
+pub const fn Ix3(i0: Ix, i1: Ix, i2: Ix) -> Ix3 {
     Dim::new([i0, i1, i2])
 }
 /// Create a four-dimensional index
 #[allow(non_snake_case)]
 #[inline(always)]
-pub fn Ix4(i0: Ix, i1: Ix, i2: Ix, i3: Ix) -> Ix4 {
+pub const fn Ix4(i0: Ix, i1: Ix, i2: Ix, i3: Ix) -> Ix4 {
     Dim::new([i0, i1, i2, i3])
 }
 /// Create a five-dimensional index
 #[allow(non_snake_case)]
 #[inline(always)]
-pub fn Ix5(i0: Ix, i1: Ix, i2: Ix, i3: Ix, i4: Ix) -> Ix5 {
+pub const fn Ix5(i0: Ix, i1: Ix, i2: Ix, i3: Ix, i4: Ix) -> Ix5 {
     Dim::new([i0, i1, i2, i3, i4])
 }
 /// Create a six-dimensional index
 #[allow(non_snake_case)]
 #[inline(always)]
-pub fn Ix6(i0: Ix, i1: Ix, i2: Ix, i3: Ix, i4: Ix, i5: Ix) -> Ix6 {
+pub const fn Ix6(i0: Ix, i1: Ix, i2: Ix, i3: Ix, i4: Ix, i5: Ix) -> Ix6 {
     Dim::new([i0, i1, i2, i3, i4, i5])
 }
 

--- a/src/dimension/dim.rs
+++ b/src/dimension/dim.rs
@@ -42,7 +42,7 @@ pub struct Dim<I: ?Sized> {
 
 impl<I> Dim<I> {
     /// Private constructor and accessors for Dim
-    pub(crate) fn new(index: I) -> Dim<I> {
+    pub(crate) const fn new(index: I) -> Dim<I> {
         Dim { index }
     }
     #[inline(always)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1450,7 +1450,7 @@ pub struct RawViewRepr<A> {
 
 impl<A> RawViewRepr<A> {
     #[inline(always)]
-    fn new() -> Self {
+    const fn new() -> Self {
         RawViewRepr { ptr: PhantomData }
     }
 }
@@ -1467,7 +1467,7 @@ pub struct ViewRepr<A> {
 
 impl<A> ViewRepr<A> {
     #[inline(always)]
-    fn new() -> Self {
+    const fn new() -> Self {
         ViewRepr { life: PhantomData }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,7 @@
 //!     needs matching memory layout to be efficient (with some exceptions).
 //!   + Efficient floating point matrix multiplication even for very large
 //!     matrices; can optionally use BLAS to improve it further.
-//! - **Requires Rust 1.51 or later**
+//! - **Requires Rust 1.57 or later**
 //!
 //! ## Crate Feature Flags
 //!


### PR DESCRIPTION
This is something I've wanted for a long time; it allows for creation of const `ArrayView`s. With Rust 1.57, it's now possible. (This was blocked on the ability to panic in const fns.)

This PR also makes the `Ix0`, …, `Ix6` free functions into const fns.

Unfortunately, the const fn implementations of `aview0`, `aview1`, and `aview2` cannot use some existing internal functionality which would simplify the implementation, especially those which require the `Dimension` trait, since const traits / trait impls are not yet available. I think the proposed implementations are simple enough, though.

This will have a merge conflict with #1131. I'll fix it up to no longer conflict once #1131 is merged, assuming #1131 is merged first.

This is a breaking change in the sense that it requires Rust 1.57.