### PR TITLE
Fix Miri errors for WindowsIter and ExactChunksIter/Mut

### DIFF
--- a/src/impl_views/conversions.rs
+++ b/src/impl_views/conversions.rs
@@ -183,6 +183,27 @@ where
     }
 }
 
+/// Private raw array view methods
+impl<A, D> RawArrayView<A, D>
+where
+    D: Dimension,
+{
+    #[inline]
+    pub(crate) fn into_base_iter(self) -> Baseiter<A, D> {
+        unsafe { Baseiter::new(self.ptr.as_ptr(), self.dim, self.strides) }
+    }
+}
+
+impl<A, D> RawArrayViewMut<A, D>
+where
+    D: Dimension,
+{
+    #[inline]
+    pub(crate) fn into_base_iter(self) -> Baseiter<A, D> {
+        unsafe { Baseiter::new(self.ptr.as_ptr(), self.dim, self.strides) }
+    }
+}
+
 /// Private array view methods
 impl<'a, A, D> ArrayView<'a, A, D>
 where

--- a/src/iterators/macros.rs
+++ b/src/iterators/macros.rs
@@ -84,7 +84,7 @@ impl<$($typarm)*> NdProducer for $fulltype {
     }
 
     unsafe fn uget_ptr(&self, i: &Self::Dim) -> *mut A {
-        self.$base.uget_ptr(i)
+        self.$base.uget_ptr(i) as *mut _
     }
 
     fn stride_of(&self, axis: Axis) -> isize {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1559,10 +1559,6 @@ where
         unsafe { ArrayView::new(ptr, dim, strides) }
     }
 
-    fn raw_strides(&self) -> D {
-        self.strides.clone()
-    }
-
     /// Remove array axis `axis` and return the result.
     fn try_remove_axis(self, axis: Axis) -> ArrayBase<S, D::Smaller> {
         let d = self.dim.try_remove_axis(axis);


### PR DESCRIPTION
Before this PR, running `MIRIFLAGS="-Zmiri-tag-raw-pointers" cargo miri test` caused Miri to report undefined behavior for code using the `WindowsIter`, `ExactChunksIter`, and `ExactChunksIterMut` iterators. This PR fixes the underlying issue. Basically, Miri doesn't like code which uses a reference to an element to access other elements. Before this PR, these iterators wrapped the `ElementsBase` and `ElementsBaseMut` iterators, and they created views from the references returned by those inner iterators. Accessing elements within those views (other than the first element) led to the Miri error, since the view's pointer was derived from a reference to a single element. Now, the iterators wrap `Baseiter` instead, which produces raw pointers instead of references.

Although not necessary to satisfy Miri, this PR also changes the `Windows`, `ExactChunks`, and `ExactChunksMut` producers to wrap raw views instead of normal views. This avoids potential confusion regarding which elements are accessible through the views produced by these producers.

With this PR, #1138, and bluss/matrixmultiply#67, `MIRIFLAGS="-Zmiri-tag-raw-pointers -Zmiri-check-number-validity" RUSTFLAGS="-Zrandomize-layout" cargo +nightly miri test` runs without errors (in about 8 minutes on my machine).