### PR TITLE
Make ArrayBase::get_ptr(_mut) public to enable indexing into raw views.

### DIFF
--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -768,7 +768,7 @@ where
         S: DataMut,
         I: NdIndex<D>,
     {
-        unsafe { self.get_ptr_mut(index).map(|ptr| &mut *ptr) }
+        unsafe { self.get_mut_ptr(index).map(|ptr| &mut *ptr) }
     }
 
     /// Return a raw pointer to the element at `index`, or return `None`
@@ -780,7 +780,7 @@ where
     /// let mut a = arr2(&[[1., 2.], [3., 4.]]);
     ///
     /// let v = a.raw_view_mut();
-    /// let p = a.get_ptr_mut((0, 1)).unwrap();
+    /// let p = a.get_mut_ptr((0, 1)).unwrap();
     ///
     /// unsafe {
     ///     *p = 5.;
@@ -788,7 +788,7 @@ where
     ///
     /// assert_eq!(a.get((0, 1)), Some(&5.));
     /// ```
-    pub fn get_ptr_mut<I>(&mut self, index: I) -> Option<*mut A>
+    pub fn get_mut_ptr<I>(&mut self, index: I) -> Option<*mut A>
     where
         S: RawDataMut,
         I: NdIndex<D>,

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -732,13 +732,26 @@ where
     /// ```
     pub fn get<I>(&self, index: I) -> Option<&A>
     where
-        I: NdIndex<D>,
         S: Data,
+        I: NdIndex<D>,
     {
         unsafe { self.get_ptr(index).map(|ptr| &*ptr) }
     }
 
-    pub(crate) fn get_ptr<I>(&self, index: I) -> Option<*const A>
+    /// Return a raw pointer to the element at `index`, or return `None`
+    /// if the index is out of bounds.
+    ///
+    /// ```
+    /// use ndarray::arr2;
+    ///
+    /// let a = arr2(&[[1., 2.], [3., 4.]]);
+    ///
+    /// let v = a.raw_view();
+    /// let p = a.get_ptr((0, 1)).unwrap();
+    ///
+    /// assert_eq!(unsafe { *p }, 2.);
+    /// ```
+    pub fn get_ptr<I>(&self, index: I) -> Option<*const A>
     where
         I: NdIndex<D>,
     {
@@ -758,7 +771,24 @@ where
         unsafe { self.get_ptr_mut(index).map(|ptr| &mut *ptr) }
     }
 
-    pub(crate) fn get_ptr_mut<I>(&mut self, index: I) -> Option<*mut A>
+    /// Return a raw pointer to the element at `index`, or return `None`
+    /// if the index is out of bounds.
+    ///
+    /// ```
+    /// use ndarray::arr2;
+    ///
+    /// let mut a = arr2(&[[1., 2.], [3., 4.]]);
+    ///
+    /// let v = a.raw_view_mut();
+    /// let p = a.get_ptr_mut((0, 1)).unwrap();
+    ///
+    /// unsafe {
+    ///     *p = 5.;
+    /// }
+    ///
+    /// assert_eq!(a.get((0, 1)), Some(&5.));
+    /// ```
+    pub fn get_ptr_mut<I>(&mut self, index: I) -> Option<*mut A>
     where
         S: RawDataMut,
         I: NdIndex<D>,

--- a/src/impl_views/indexing.rs
+++ b/src/impl_views/indexing.rs
@@ -164,7 +164,7 @@ where
     fn index(mut self, index: I) -> &'a mut A {
         debug_bounds_check!(self, index);
         unsafe {
-            match self.get_ptr_mut(index) {
+            match self.get_mut_ptr(index) {
                 Some(ptr) => &mut *ptr,
                 None => array_out_of_bounds(),
             }
@@ -182,7 +182,7 @@ where
     fn get(mut self, index: I) -> Option<&'a mut A> {
         debug_bounds_check!(self, index);
         unsafe {
-            match self.get_ptr_mut(index) {
+            match self.get_mut_ptr(index) {
                 Some(ptr) => Some(&mut *ptr),
                 None => None,
             }


### PR DESCRIPTION
Noticed this as we would like to provide raw views into NumPy arrays when it is difficult to enforce the required aliasing guarantees for reference-based views, c.f. https://github.com/PyO3/rust-numpy/pull/260#discussion_r790126849

 I do wonder whether there is a reason these cannot be made public but could not find anything using Git archaeology.