### PR TITLE
implement outer() for 1D array

### DIFF
--- a/src/linalg/impl_linalg.rs
+++ b/src/linalg/impl_linalg.rs
@@ -137,6 +137,21 @@ where
         }
         self.dot_generic(rhs)
     }
+
+    /// Outer product of two 1D arrays.
+    /// 
+    /// The outer product of two vectors a (of dimension M) and b (of dimension N) 
+    /// is defined as an (M*N)-dimensional matrix whose ij-th element is a_i * b_j. 
+    /// This implementation essentially calls `dot` by reshaping the vectors.
+    pub fn outer<S2>(&self, b: &ArrayBase<S2, Ix1>) -> Array<A, Ix2>
+    where
+        S2: Data<Elem = A>,
+        A: LinalgScalar,
+    {
+        let (size_a, size_b) = (self.shape()[0], b.shape()[0]);
+        let b_reshaped = b.view().into_shape((1, size_b)).unwrap();
+        self.view().into_shape((size_a, 1)).unwrap().dot(&b_reshaped)
+    }
 }
 
 /// Return a pointer to the starting element in BLAS's view.

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -80,6 +80,13 @@ fn test_mat_mul() {
     assert_eq!(c.dot(&a), a);
 }
 
+#[test]
+fn test_outer_product() {
+    let a: Array1<f64> = array![2., 4.];
+    let b: Array1<f64> = array![3., 5.];
+    assert_eq!(a.outer(&b), array![[6., 10.], [12., 20.]]);
+}
+
 #[deny(unsafe_code)]
 #[test]
 fn test_slice() {


### PR DESCRIPTION
A naive outer product implementation. 

Related to issue #1148.