### PR TITLE
Add link to Slicing docs on libary documentation page

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,8 +40,8 @@
 //! ## Highlights
 //!
 //! - Generic *n*-dimensional array
-//! - Slicing, also with arbitrary step size, and negative indices to mean
-//!   elements from the end of the axis.
+//! - [Slicing](ArrayBase#slicing), also with arbitrary step size, and negative
+//!   indices to mean elements from the end of the axis.
 //! - Views and subviews of arrays; iterators that yield subviews.
 //! - Higher order operations and arithmetic are performant
 //! - Array views can be used to slice and mutate any `[T]` data using


### PR DESCRIPTION
This commit adds a convenient short cut to directly access the slicing docs.
I use these docs quite often and since the usage is slightly different from what we are used to from numpy, I think this is a good addition.