### PR TITLE
Remove doc(hidden) attr from items in trait impls

### DIFF
--- a/src/data_traits.rs
+++ b/src/data_traits.rs
@@ -630,7 +630,6 @@ where
         }
     }
 
-    #[doc(hidden)]
     unsafe fn clone_from_with_ptr(
         &mut self,
         other: &Self,

--- a/src/indexes.rs
+++ b/src/indexes.rs
@@ -180,22 +180,18 @@ impl<D: Dimension + Copy> NdProducer for Indices<D> {
 
     private_impl! {}
 
-    #[doc(hidden)]
     fn raw_dim(&self) -> Self::Dim {
         self.dim
     }
 
-    #[doc(hidden)]
     fn equal_dim(&self, dim: &Self::Dim) -> bool {
         self.dim.equal(dim)
     }
 
-    #[doc(hidden)]
     fn as_ptr(&self) -> Self::Ptr {
         IndexPtr { index: self.start }
     }
 
-    #[doc(hidden)]
     fn layout(&self) -> Layout {
         if self.dim.ndim() <= 1 {
             Layout::one_dimensional()
@@ -204,19 +200,16 @@ impl<D: Dimension + Copy> NdProducer for Indices<D> {
         }
     }
 
-    #[doc(hidden)]
     unsafe fn as_ref(&self, ptr: Self::Ptr) -> Self::Item {
         ptr.index.into_pattern()
     }
 
-    #[doc(hidden)]
     unsafe fn uget_ptr(&self, i: &Self::Dim) -> Self::Ptr {
         let mut index = *i;
         index += &self.start;
         IndexPtr { index }
     }
 
-    #[doc(hidden)]
     fn stride_of(&self, axis: Axis) -> Self::Stride {
         axis.index()
     }
@@ -226,7 +219,6 @@ impl<D: Dimension + Copy> NdProducer for Indices<D> {
         0
     }
 
-    #[doc(hidden)]
     fn split_at(self, axis: Axis, index: usize) -> (Self, Self) {
         let start_a = self.start;
         let mut start_b = start_a;

--- a/src/iterators/macros.rs
+++ b/src/iterators/macros.rs
@@ -63,42 +63,34 @@ impl<$($typarm)*> NdProducer for $fulltype {
     type Ptr = *mut A;
     type Stride = isize;
 
-    #[doc(hidden)]
     fn raw_dim(&self) -> D {
         self.$base.raw_dim()
     }
 
-    #[doc(hidden)]
     fn layout(&self) -> Layout {
         self.$base.layout()
     }
 
-    #[doc(hidden)]
     fn as_ptr(&self) -> *mut A {
         self.$base.as_ptr() as *mut _
     }
 
-    #[doc(hidden)]
     fn contiguous_stride(&self) -> isize {
         self.$base.contiguous_stride()
     }
 
-    #[doc(hidden)]
     unsafe fn as_ref(&$self_, $ptr: *mut A) -> Self::Item {
         $refexpr
     }
 
-    #[doc(hidden)]
     unsafe fn uget_ptr(&self, i: &Self::Dim) -> *mut A {
         self.$base.uget_ptr(i)
     }
 
-    #[doc(hidden)]
     fn stride_of(&self, axis: Axis) -> isize {
         self.$base.stride_of(axis)
     }
 
-    #[doc(hidden)]
     fn split_at(self, axis: Axis, index: usize) -> (Self, Self) {
         let (a, b) = self.$base.split_at(axis, index);
         ($typename {
@@ -114,6 +106,7 @@ impl<$($typarm)*> NdProducer for $fulltype {
             )*
         })
     }
+
     private_impl!{}
 }
 

--- a/src/iterators/mod.rs
+++ b/src/iterators/mod.rs
@@ -1105,15 +1105,14 @@ impl<'a, A, D: Dimension> NdProducer for AxisIter<'a, A, D> {
     type Ptr = *mut A;
     type Stride = isize;
 
-    #[doc(hidden)]
     fn layout(&self) -> crate::Layout {
         crate::Layout::one_dimensional()
     }
-    #[doc(hidden)]
+
     fn raw_dim(&self) -> Self::Dim {
         Ix1(self.len())
     }
-    #[doc(hidden)]
+
     fn as_ptr(&self) -> Self::Ptr {
         if self.len() > 0 {
             // `self.iter.index` is guaranteed to be in-bounds if any of the
@@ -1131,7 +1130,6 @@ impl<'a, A, D: Dimension> NdProducer for AxisIter<'a, A, D> {
         self.iter.stride
     }
 
-    #[doc(hidden)]
     unsafe fn as_ref(&self, ptr: Self::Ptr) -> Self::Item {
         ArrayView::new_(
             ptr,
@@ -1139,20 +1137,19 @@ impl<'a, A, D: Dimension> NdProducer for AxisIter<'a, A, D> {
             self.iter.inner_strides.clone(),
         )
     }
-    #[doc(hidden)]
+
     unsafe fn uget_ptr(&self, i: &Self::Dim) -> Self::Ptr {
         self.iter.offset(self.iter.index + i[0])
     }
 
-    #[doc(hidden)]
     fn stride_of(&self, _axis: Axis) -> isize {
         self.contiguous_stride()
     }
 
-    #[doc(hidden)]
     fn split_at(self, _axis: Axis, index: usize) -> (Self, Self) {
         self.split_at(index)
     }
+
     private_impl! {}
 }
 
@@ -1162,15 +1159,14 @@ impl<'a, A, D: Dimension> NdProducer for AxisIterMut<'a, A, D> {
     type Ptr = *mut A;
     type Stride = isize;
 
-    #[doc(hidden)]
     fn layout(&self) -> crate::Layout {
         crate::Layout::one_dimensional()
     }
-    #[doc(hidden)]
+
     fn raw_dim(&self) -> Self::Dim {
         Ix1(self.len())
     }
-    #[doc(hidden)]
+
     fn as_ptr(&self) -> Self::Ptr {
         if self.len() > 0 {
             // `self.iter.index` is guaranteed to be in-bounds if any of the
@@ -1188,7 +1184,6 @@ impl<'a, A, D: Dimension> NdProducer for AxisIterMut<'a, A, D> {
         self.iter.stride
     }
 
-    #[doc(hidden)]
     unsafe fn as_ref(&self, ptr: Self::Ptr) -> Self::Item {
         ArrayViewMut::new_(
             ptr,
@@ -1196,20 +1191,19 @@ impl<'a, A, D: Dimension> NdProducer for AxisIterMut<'a, A, D> {
             self.iter.inner_strides.clone(),
         )
     }
-    #[doc(hidden)]
+
     unsafe fn uget_ptr(&self, i: &Self::Dim) -> Self::Ptr {
         self.iter.offset(self.iter.index + i[0])
     }
 
-    #[doc(hidden)]
     fn stride_of(&self, _axis: Axis) -> isize {
         self.contiguous_stride()
     }
 
-    #[doc(hidden)]
     fn split_at(self, _axis: Axis, index: usize) -> (Self, Self) {
         self.split_at(index)
     }
+
     private_impl! {}
 }
 

--- a/src/private.rs
+++ b/src/private.rs
@@ -11,13 +11,13 @@ macro_rules! private_decl {
     () => {
         /// This trait is private to implement; this method exists to make it
         /// impossible to implement outside the crate.
+        #[doc(hidden)]
         fn __private__(&self) -> crate::private::PrivateMarker;
     }
 }
 
 macro_rules! private_impl {
     () => {
-        #[doc(hidden)]
         fn __private__(&self) -> crate::private::PrivateMarker {
             crate::private::PrivateMarker
         }

--- a/src/zip/ndproducer.rs
+++ b/src/zip/ndproducer.rs
@@ -214,37 +214,31 @@ impl<'a, A, D: Dimension> NdProducer for ArrayView<'a, A, D> {
     type Stride = isize;
 
     private_impl! {}
-    #[doc(hidden)]
+
     fn raw_dim(&self) -> Self::Dim {
         self.raw_dim()
     }
 
-    #[doc(hidden)]
     fn equal_dim(&self, dim: &Self::Dim) -> bool {
         self.dim.equal(dim)
     }
 
-    #[doc(hidden)]
     fn as_ptr(&self) -> *mut A {
         self.as_ptr() as _
     }
 
-    #[doc(hidden)]
     fn layout(&self) -> Layout {
         self.layout_impl()
     }
 
-    #[doc(hidden)]
     unsafe fn as_ref(&self, ptr: *mut A) -> Self::Item {
         &*ptr
     }
 
-    #[doc(hidden)]
     unsafe fn uget_ptr(&self, i: &Self::Dim) -> *mut A {
         self.ptr.as_ptr().offset(i.index_unchecked(&self.strides))
     }
 
-    #[doc(hidden)]
     fn stride_of(&self, axis: Axis) -> isize {
         self.stride_of(axis)
     }
@@ -254,7 +248,6 @@ impl<'a, A, D: Dimension> NdProducer for ArrayView<'a, A, D> {
         1
     }
 
-    #[doc(hidden)]
     fn split_at(self, axis: Axis, index: usize) -> (Self, Self) {
         self.split_at(axis, index)
     }
@@ -267,37 +260,31 @@ impl<'a, A, D: Dimension> NdProducer for ArrayViewMut<'a, A, D> {
     type Stride = isize;
 
     private_impl! {}
-    #[doc(hidden)]
+
     fn raw_dim(&self) -> Self::Dim {
         self.raw_dim()
     }
 
-    #[doc(hidden)]
     fn equal_dim(&self, dim: &Self::Dim) -> bool {
         self.dim.equal(dim)
     }
 
-    #[doc(hidden)]
     fn as_ptr(&self) -> *mut A {
         self.as_ptr() as _
     }
 
-    #[doc(hidden)]
     fn layout(&self) -> Layout {
         self.layout_impl()
     }
 
-    #[doc(hidden)]
     unsafe fn as_ref(&self, ptr: *mut A) -> Self::Item {
         &mut *ptr
     }
 
-    #[doc(hidden)]
     unsafe fn uget_ptr(&self, i: &Self::Dim) -> *mut A {
         self.ptr.as_ptr().offset(i.index_unchecked(&self.strides))
     }
 
-    #[doc(hidden)]
     fn stride_of(&self, axis: Axis) -> isize {
         self.stride_of(axis)
     }
@@ -307,7 +294,6 @@ impl<'a, A, D: Dimension> NdProducer for ArrayViewMut<'a, A, D> {
         1
     }
 
-    #[doc(hidden)]
     fn split_at(self, axis: Axis, index: usize) -> (Self, Self) {
         self.split_at(axis, index)
     }
@@ -320,37 +306,31 @@ impl<A, D: Dimension> NdProducer for RawArrayView<A, D> {
     type Stride = isize;
 
     private_impl! {}
-    #[doc(hidden)]
+
     fn raw_dim(&self) -> Self::Dim {
         self.raw_dim()
     }
 
-    #[doc(hidden)]
     fn equal_dim(&self, dim: &Self::Dim) -> bool {
         self.dim.equal(dim)
     }
 
-    #[doc(hidden)]
     fn as_ptr(&self) -> *const A {
         self.as_ptr()
     }
 
-    #[doc(hidden)]
     fn layout(&self) -> Layout {
         self.layout_impl()
     }
 
-    #[doc(hidden)]
     unsafe fn as_ref(&self, ptr: *const A) -> *const A {
         ptr
     }
 
-    #[doc(hidden)]
     unsafe fn uget_ptr(&self, i: &Self::Dim) -> *const A {
         self.ptr.as_ptr().offset(i.index_unchecked(&self.strides))
     }
 
-    #[doc(hidden)]
     fn stride_of(&self, axis: Axis) -> isize {
         self.stride_of(axis)
     }
@@ -360,7 +340,6 @@ impl<A, D: Dimension> NdProducer for RawArrayView<A, D> {
         1
     }
 
-    #[doc(hidden)]
     fn split_at(self, axis: Axis, index: usize) -> (Self, Self) {
         self.split_at(axis, index)
     }
@@ -373,37 +352,31 @@ impl<A, D: Dimension> NdProducer for RawArrayViewMut<A, D> {
     type Stride = isize;
 
     private_impl! {}
-    #[doc(hidden)]
+
     fn raw_dim(&self) -> Self::Dim {
         self.raw_dim()
     }
 
-    #[doc(hidden)]
     fn equal_dim(&self, dim: &Self::Dim) -> bool {
         self.dim.equal(dim)
     }
 
-    #[doc(hidden)]
     fn as_ptr(&self) -> *mut A {
         self.as_ptr() as _
     }
 
-    #[doc(hidden)]
     fn layout(&self) -> Layout {
         self.layout_impl()
     }
 
-    #[doc(hidden)]
     unsafe fn as_ref(&self, ptr: *mut A) -> *mut A {
         ptr
     }
 
-    #[doc(hidden)]
     unsafe fn uget_ptr(&self, i: &Self::Dim) -> *mut A {
         self.ptr.as_ptr().offset(i.index_unchecked(&self.strides))
     }
 
-    #[doc(hidden)]
     fn stride_of(&self, axis: Axis) -> isize {
         self.stride_of(axis)
     }
@@ -413,7 +386,6 @@ impl<A, D: Dimension> NdProducer for RawArrayViewMut<A, D> {
         1
     }
 
-    #[doc(hidden)]
     fn split_at(self, axis: Axis, index: usize) -> (Self, Self) {
         self.split_at(axis, index)
     }


### PR DESCRIPTION
These attributes produce warnings like the following on nightly:

```
warning: `#[doc(hidden)]` is ignored on trait impl items
   --> src/indexes.rs:212:5
    |
212 |     #[doc(hidden)]
    |     ^^^^^^^^^^^^^^ help: remove this attribute
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: whether the impl item is `doc(hidden)` or not entirely depends on the corresponding trait item
```

I verified that these attributes have no effect on stable (1.60.0) or nightly (2022-05-16), so they can be safely removed.