### PR TITLE
Fix CI failures (mostly linting with clippy)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@
 name = "ndarray"
 version = "0.15.5"
 edition = "2018"
+rust-version = "1.51"
 authors = [
   "Ulrik Sverdrup \"bluss\"",
   "Jim Turner"

--- a/src/arrayformat.rs
+++ b/src/arrayformat.rs
@@ -217,7 +217,7 @@ where
             ", shape={:?}, strides={:?}, layout={:?}",
             self.shape(),
             self.strides(),
-            layout = self.view().layout()
+            self.view().layout(),
         )?;
         match D::NDIM {
             Some(ndim) => write!(f, ", const ndim={}", ndim)?,

--- a/src/arrayformat.rs
+++ b/src/arrayformat.rs
@@ -189,7 +189,7 @@ where
 /// to each element.
 ///
 /// The array is shown in multiline style.
-impl<'a, A: fmt::Display, S, D: Dimension> fmt::Display for ArrayBase<S, D>
+impl<A: fmt::Display, S, D: Dimension> fmt::Display for ArrayBase<S, D>
 where
     S: Data<Elem = A>,
 {
@@ -203,7 +203,7 @@ where
 /// to each element.
 ///
 /// The array is shown in multiline style.
-impl<'a, A: fmt::Debug, S, D: Dimension> fmt::Debug for ArrayBase<S, D>
+impl<A: fmt::Debug, S, D: Dimension> fmt::Debug for ArrayBase<S, D>
 where
     S: Data<Elem = A>,
 {
@@ -231,7 +231,7 @@ where
 /// to each element.
 ///
 /// The array is shown in multiline style.
-impl<'a, A: fmt::LowerExp, S, D: Dimension> fmt::LowerExp for ArrayBase<S, D>
+impl<A: fmt::LowerExp, S, D: Dimension> fmt::LowerExp for ArrayBase<S, D>
 where
     S: Data<Elem = A>,
 {
@@ -245,7 +245,7 @@ where
 /// to each element.
 ///
 /// The array is shown in multiline style.
-impl<'a, A: fmt::UpperExp, S, D: Dimension> fmt::UpperExp for ArrayBase<S, D>
+impl<A: fmt::UpperExp, S, D: Dimension> fmt::UpperExp for ArrayBase<S, D>
 where
     S: Data<Elem = A>,
 {
@@ -258,7 +258,7 @@ where
 /// to each element.
 ///
 /// The array is shown in multiline style.
-impl<'a, A: fmt::LowerHex, S, D: Dimension> fmt::LowerHex for ArrayBase<S, D>
+impl<A: fmt::LowerHex, S, D: Dimension> fmt::LowerHex for ArrayBase<S, D>
 where
     S: Data<Elem = A>,
 {
@@ -272,7 +272,7 @@ where
 /// to each element.
 ///
 /// The array is shown in multiline style.
-impl<'a, A: fmt::Binary, S, D: Dimension> fmt::Binary for ArrayBase<S, D>
+impl<A: fmt::Binary, S, D: Dimension> fmt::Binary for ArrayBase<S, D>
 where
     S: Data<Elem = A>,
 {

--- a/src/arraytraits.rs
+++ b/src/arraytraits.rs
@@ -252,7 +252,7 @@ where
     }
 }
 
-impl<'a, S, D> hash::Hash for ArrayBase<S, D>
+impl<S, D> hash::Hash for ArrayBase<S, D>
 where
     D: Dimension,
     S: Data,

--- a/src/data_traits.rs
+++ b/src/data_traits.rs
@@ -162,6 +162,7 @@ pub unsafe trait DataMut: Data + RawDataMut {
     /// Returns whether the array has unique access to its data.
     #[doc(hidden)]
     #[inline]
+    #[allow(clippy::wrong_self_convention)]  // mut needed for Arc types
     fn is_unique(&mut self) -> bool {
         self.try_is_unique().unwrap()
     }

--- a/src/dimension/dimension_trait.rs
+++ b/src/dimension/dimension_trait.rs
@@ -293,7 +293,7 @@ pub trait Dimension:
         let mut cstride = 1;
         for &i in order.slice() {
             // a dimension of length 1 can have unequal strides
-            if dim_slice[i] != 1 && (strides[i] as isize).abs() as usize != cstride {
+            if dim_slice[i] != 1 && (strides[i] as isize).unsigned_abs() != cstride {
                 return false;
             }
             cstride *= dim_slice[i];

--- a/src/dimension/dynindeximpl.rs
+++ b/src/dimension/dynindeximpl.rs
@@ -21,7 +21,7 @@ impl<T> Deref for IxDynRepr<T> {
                 debug_assert!(len as usize <= ar.len());
                 unsafe { ar.get_unchecked(..len as usize) }
             }
-            IxDynRepr::Alloc(ref ar) => &*ar,
+            IxDynRepr::Alloc(ref ar) => ar,
         }
     }
 }
@@ -33,7 +33,7 @@ impl<T> DerefMut for IxDynRepr<T> {
                 debug_assert!(len as usize <= ar.len());
                 unsafe { ar.get_unchecked_mut(..len as usize) }
             }
-            IxDynRepr::Alloc(ref mut ar) => &mut *ar,
+            IxDynRepr::Alloc(ref mut ar) => ar,
         }
     }
 }

--- a/src/dimension/mod.rs
+++ b/src/dimension/mod.rs
@@ -185,7 +185,7 @@ where
         .try_fold(0usize, |acc, (&d, &s)| {
             let s = s as isize;
             // Calculate maximum possible absolute movement along this axis.
-            let off = d.saturating_sub(1).checked_mul(s.abs() as usize)?;
+            let off = d.saturating_sub(1).checked_mul(s.unsigned_abs())?;
             acc.checked_add(off)
         })
         .ok_or_else(|| from_kind(ErrorKind::Overflow))?;
@@ -457,7 +457,7 @@ pub fn do_slice(dim: &mut usize, stride: &mut usize, slice: Slice) -> isize {
     };
 
     // Update dimension.
-    let abs_step = step.abs() as usize;
+    let abs_step = step.unsigned_abs();
     *dim = if abs_step == 1 {
         m
     } else {
@@ -651,7 +651,7 @@ pub fn slices_intersect<D: Dimension>(
                     Some(m) => m,
                     None => return false,
                 };
-                if ind < min || ind > max || (ind - min) % step.abs() as usize != 0 {
+                if ind < min || ind > max || (ind - min) % step.unsigned_abs() != 0 {
                     return false;
                 }
             }

--- a/src/dimension/mod.rs
+++ b/src/dimension/mod.rs
@@ -333,7 +333,7 @@ where
     }
 }
 
-impl<'a> DimensionExt for [Ix] {
+impl DimensionExt for [Ix] {
     #[inline]
     fn axis(&self, axis: Axis) -> Ix {
         self[axis.index()]

--- a/src/dimension/ndindex.rs
+++ b/src/dimension/ndindex.rs
@@ -230,7 +230,7 @@ unsafe impl<'a> NdIndex<IxDyn> for &'a IxDyn {
 
 unsafe impl<'a> NdIndex<IxDyn> for &'a [Ix] {
     fn index_checked(&self, dim: &IxDyn, strides: &IxDyn) -> Option<isize> {
-        stride_offset_checked(dim.ix(), strides.ix(), *self)
+        stride_offset_checked(dim.ix(), strides.ix(), self)
     }
     fn index_unchecked(&self, strides: &IxDyn) -> isize {
         zip(strides.ix(), *self)

--- a/src/impl_constructors.rs
+++ b/src/impl_constructors.rs
@@ -634,6 +634,7 @@ where
 
     #[deprecated(note = "This method is hard to use correctly. Use `uninit` instead.",
                  since = "0.15.0")]
+    #[allow(clippy::uninit_vec)]  // this is explicitly intended to create uninitialized memory
     /// Create an array with uninitialized elements, shape `shape`.
     ///
     /// Prefer to use [`uninit()`](ArrayBase::uninit) if possible, because it is

--- a/src/iterators/lanes.rs
+++ b/src/iterators/lanes.rs
@@ -39,17 +39,16 @@ impl<'a, A, D: Dimension> Lanes<'a, A, D> {
         let ndim = v.ndim();
         let len;
         let stride;
-        let iter_v;
-        if ndim == 0 {
+        let iter_v = if ndim == 0 {
             len = 1;
             stride = 1;
-            iter_v = v.try_remove_axis(Axis(0))
+            v.try_remove_axis(Axis(0))
         } else {
             let i = axis.index();
             len = v.dim[i];
             stride = v.strides[i] as isize;
-            iter_v = v.try_remove_axis(axis)
-        }
+            v.try_remove_axis(axis)
+        };
         Lanes {
             inner_len: len,
             inner_stride: stride,
@@ -108,17 +107,16 @@ impl<'a, A, D: Dimension> LanesMut<'a, A, D> {
         let ndim = v.ndim();
         let len;
         let stride;
-        let iter_v;
-        if ndim == 0 {
+        let iter_v = if ndim == 0 {
             len = 1;
             stride = 1;
-            iter_v = v.try_remove_axis(Axis(0))
+            v.try_remove_axis(Axis(0))
         } else {
             let i = axis.index();
             len = v.dim[i];
             stride = v.strides[i] as isize;
-            iter_v = v.try_remove_axis(axis)
-        }
+            v.try_remove_axis(axis)
+        };
         LanesMut {
             inner_len: len,
             inner_stride: stride,

--- a/src/iterators/mod.rs
+++ b/src/iterators/mod.rs
@@ -103,7 +103,7 @@ impl<A, D: Dimension> Iterator for Baseiter<A, D> {
     }
 }
 
-impl<'a, A, D: Dimension> ExactSizeIterator for Baseiter<A, D> {
+impl<A, D: Dimension> ExactSizeIterator for Baseiter<A, D> {
     fn len(&self) -> usize {
         match self.index {
             None => 0,

--- a/src/itertools.rs
+++ b/src/itertools.rs
@@ -86,7 +86,8 @@ where
 /// **Note:** To enable the macros in this crate, use the `#[macro_use]`
 /// attribute when importing the crate:
 ///
-/// ```
+/// ```no_run
+/// # #[allow(unused_imports)]
 /// #[macro_use] extern crate itertools;
 /// # fn main() { }
 /// ```


### PR DESCRIPTION
Hello - I noticed CI has been consistently failing for some time, so this PR is meant to bring it back to green. I think it was mostly (all?) clippy lints that were blocking it. The way the GitHub Actions are set up now this could break again (mostly for more clippy lints) with new versions of Rust. I think it's still good to test like this against new/current versions, and I'm happy to keep an eye out for similar issues in the future.

The most frequent was a lint related to `#[doc(hidden)]` which (according to clippy) does not work within Trait impl blocks. I basically just deleted all of them and also combined the `private_decl` and `private_impl` macros - it seems to me the `private_decl` can serve the full purpose of making the Trait private and providing a default implementation. Please let me know if I got this wrong or you'd like to take a different track.