### PR TITLE
Prepare 0.15.5 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "ndarray"
-version = "0.15.4"
+version = "0.15.5"
 edition = "2018"
 authors = [
   "Ulrik Sverdrup \"bluss\"",

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -366,7 +366,7 @@ API changes
 -----------
 
 - New constructors `Array::from_iter` and `Array::from_vec` by [@bluss].
-  No new functionality, just that these constructors are avaiable without trait
+  No new functionality, just that these constructors are available without trait
   imports.
 
   https://github.com/rust-ndarray/ndarray/pull/921
@@ -545,7 +545,7 @@ New features
 Enhancements
 ------------
 
-- Handle inhomogenous shape inputs better in Zip, in practice: guess better whether
+- Handle inhomogeneous shape inputs better in Zip, in practice: guess better whether
   to prefer c- or f-order for the inner loop by [@bluss]
   https://github.com/rust-ndarray/ndarray/pull/809
 
@@ -978,7 +978,7 @@ Earlier releases
 
   - Add `Zip::indexed`
   - New methods `genrows/_mut, gencolumns/_mut, lanes/_mut` that
-    return iterable producers (producer means `Zip` compatibile).
+    return iterable producers (producer means `Zip` compatible).
   - New method `.windows()` by @Robbepop, returns an iterable producer
   - New function `general_mat_vec_mul` (with fast default and blas acceleration)
   - `Zip::apply` and `fold_while` now take `self` as the first argument

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,22 @@
+Version 0.15.5 (2022-07-30)
+===========================
+
+Enhancements
+------------
+
+- The `s!` macro now works in `no_std` environments, by [@makotokato].
+
+  https://github.com/rust-ndarray/ndarray/pull/1154
+
+Other changes
+-------------
+
+- Improve docs and fix typos, by [@steffahn] and [@Rikorose].
+
+  https://github.com/rust-ndarray/ndarray/pull/1134
+  https://github.com/rust-ndarray/ndarray/pull/1164
+
+
 Version 0.15.4 (2021-11-23)
 ===========================
 
@@ -1562,14 +1581,17 @@ Earlier releases
 [@LeSeulArtichaut]: https://github.com/LeSeulArtichaut
 [@lifuyang]: https://github.com/liufuyang
 [@kdubovikov]: https://github.com/kdubovikov
+[@makotokato]: https://github.com/makotokato
 [@max-sixty]: https://github.com/max-sixty
 [@mneumann]: https://github.com/mneumann
 [@mockersf]: https://github.com/mockersf
 [@nilgoyette]: https://github.com/nilgoyette
 [@nitsky]: https://github.com/nitsky
+[@Rikorose]: https://github.com/Rikorose
 [@rth]: https://github.com/rth
 [@sebasv]: https://github.com/sebasv
 [@SparrowLii]: https://github.com/SparrowLii
+[@steffahn]: https://github.com/steffahn
 [@stokhos]: https://github.com/stokhos
 [@termoshtt]: https://github.com/termoshtt
 [@TheLortex]: https://github.com/TheLortex

--- a/examples/axis_ops.rs
+++ b/examples/axis_ops.rs
@@ -11,7 +11,7 @@ use ndarray::prelude::*;
 /// make sure axes are in positive stride direction, and merge adjacent
 /// axes if possible.
 ///
-/// This changes the logical order of the elments in the
+/// This changes the logical order of the elements in the
 /// array, so that if we read them in row-major order after regularization,
 /// it corresponds to their order in memory.
 ///

--- a/src/arraytraits.rs
+++ b/src/arraytraits.rs
@@ -303,7 +303,7 @@ where
 pub const ARRAY_FORMAT_VERSION: u8 = 1u8;
 
 // use "raw" form instead of type aliases here so that they show up in docs
-/// Implementation of `ArrayView::from(&S)` where `S` is a slice or slicable.
+/// Implementation of `ArrayView::from(&S)` where `S` is a slice or sliceable.
 impl<'a, A, Slice: ?Sized> From<&'a Slice> for ArrayView<'a, A, Ix1>
 where
     Slice: AsRef<[A]>,
@@ -335,7 +335,7 @@ where
     }
 }
 
-/// Implementation of `ArrayViewMut::from(&mut S)` where `S` is a slice or slicable.
+/// Implementation of `ArrayViewMut::from(&mut S)` where `S` is a slice or sliceable.
 impl<'a, A, Slice: ?Sized> From<&'a mut Slice> for ArrayViewMut<'a, A, Ix1>
 where
     Slice: AsMut<[A]>,

--- a/src/impl_1d.rs
+++ b/src/impl_1d.rs
@@ -42,7 +42,7 @@ where
         let mut dst = if let Some(dst) = lane_iter.next() { dst } else { return };
 
         // Logically we do a circular swap here, all elements in a chain
-        // Using MaybeUninit to avoid unecessary writes in the safe swap solution
+        // Using MaybeUninit to avoid unnecessary writes in the safe swap solution
         //
         //  for elt in lane_iter {
         //      std::mem::swap(dst, elt);

--- a/src/impl_2d.rs
+++ b/src/impl_2d.rs
@@ -125,13 +125,13 @@ where
     /// Return true if the array is square, false otherwise.
     ///
     /// # Examples
-    /// Sqaure:
+    /// Square:
     /// ```
     /// use ndarray::array;
     /// let array = array![[1., 2.], [3., 4.]];
     /// assert!(array.is_square());
     /// ```
-    /// Not sqaure:
+    /// Not square:
     /// ```
     /// use ndarray::array;
     /// let array = array![[1., 2., 5.], [3., 4., 6.]];

--- a/src/impl_constructors.rs
+++ b/src/impl_constructors.rs
@@ -540,7 +540,7 @@ where
     }
 
 
-    /// Create an array with uninitalized elements, shape `shape`.
+    /// Create an array with uninitialized elements, shape `shape`.
     ///
     /// The uninitialized elements of type `A` are represented by the type `MaybeUninit<A>`,
     /// an easier way to handle uninit values correctly.
@@ -598,7 +598,7 @@ where
         }
     }
 
-    /// Create an array with uninitalized elements, shape `shape`.
+    /// Create an array with uninitialized elements, shape `shape`.
     ///
     /// The uninitialized elements of type `A` are represented by the type `MaybeUninit<A>`,
     /// an easier way to handle uninit values correctly.
@@ -634,7 +634,7 @@ where
 
     #[deprecated(note = "This method is hard to use correctly. Use `uninit` instead.",
                  since = "0.15.0")]
-    /// Create an array with uninitalized elements, shape `shape`.
+    /// Create an array with uninitialized elements, shape `shape`.
     ///
     /// Prefer to use [`uninit()`](ArrayBase::uninit) if possible, because it is
     /// easier to use correctly.
@@ -643,7 +643,7 @@ where
     ///
     /// ### Safety
     ///
-    /// Accessing uninitalized values is undefined behaviour. You must overwrite *all* the elements
+    /// Accessing uninitialized values is undefined behaviour. You must overwrite *all* the elements
     /// in the array after it is created; for example using
     /// [`raw_view_mut`](ArrayBase::raw_view_mut) or other low-level element access.
     ///
@@ -676,7 +676,7 @@ where
     S: DataOwned<Elem = MaybeUninit<A>>,
     D: Dimension,
 {
-    /// Create an array with uninitalized elements, shape `shape`.
+    /// Create an array with uninitialized elements, shape `shape`.
     ///
     /// This method has been renamed to `uninit`
     #[deprecated(note = "Renamed to `uninit`", since = "0.15.0")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,8 +40,8 @@
 //! ## Highlights
 //!
 //! - Generic *n*-dimensional array
-//! - Slicing, also with arbitrary step size, and negative indices to mean
-//!   elements from the end of the axis.
+//! - [Slicing](ArrayBase#slicing), also with arbitrary step size, and negative
+//!   indices to mean elements from the end of the axis.
 //! - Views and subviews of arrays; iterators that yield subviews.
 //! - Higher order operations and arithmetic are performant
 //! - Array views can be used to slice and mutate any `[T]` data using

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -710,7 +710,7 @@ pub type Ixs = isize;
 /// The trait [`ScalarOperand`] marks types that can be used in arithmetic
 /// with arrays directly. For a scalar `K` the following combinations of operands
 /// are supported (scalar can be on either the left or right side, but
-/// `ScalarOperand` docs has the detailed condtions).
+/// `ScalarOperand` docs has the detailed conditions).
 ///
 /// - `&A @ K` or `K @ &A` which produces a new `Array`
 /// - `B @ K` or `K @ B` which consumes `B`, updates it with the result and returns it

--- a/src/linalg/impl_linalg.rs
+++ b/src/linalg/impl_linalg.rs
@@ -677,7 +677,7 @@ pub fn general_mat_vec_mul<A, S1, S2, S3>(
 
 /// General matrix-vector multiplication
 ///
-/// Use a raw view for the destination vector, so that it can be uninitalized.
+/// Use a raw view for the destination vector, so that it can be uninitialized.
 ///
 /// ## Safety
 ///

--- a/src/parallel/impl_par_methods.rs
+++ b/src/parallel/impl_par_methods.rs
@@ -94,7 +94,7 @@ macro_rules! zip_impl {
                 -> Array<R, D>
                 where R: Send
             {
-                let mut output = self.uninitalized_for_current_layout::<R>();
+                let mut output = self.uninitialized_for_current_layout::<R>();
                 let total_len = output.len();
 
                 // Create a parallel iterator that produces chunks of the zip with the output
@@ -191,7 +191,7 @@ macro_rules! zip_impl {
             /// Note that it is often more efficient to parallelize not per-element but rather
             /// based on larger chunks of an array like generalized rows and operating on each chunk
             /// using a sequential variant of the accumulation.
-            /// For example, sum each row sequentially and in parallel, taking advatange of locality
+            /// For example, sum each row sequentially and in parallel, taking advantage of locality
             /// and vectorization within each task, and then reduce their sums to the sum of the matrix.
             ///
             /// Also note that the splitting of the producer into multiple tasks is _not_ deterministic

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -842,14 +842,14 @@ macro_rules! s(
         }
     };
     // empty call, i.e. `s![]`
-    (@parse ::std::marker::PhantomData::<$crate::Ix0>, ::std::marker::PhantomData::<$crate::Ix0>, []) => {
+    (@parse ::core::marker::PhantomData::<$crate::Ix0>, ::core::marker::PhantomData::<$crate::Ix0>, []) => {
         {
             #[allow(unsafe_code)]
             unsafe {
                 $crate::SliceInfo::new_unchecked(
                     [],
-                    ::std::marker::PhantomData::<$crate::Ix0>,
-                    ::std::marker::PhantomData::<$crate::Ix0>,
+                    ::core::marker::PhantomData::<$crate::Ix0>,
+                    ::core::marker::PhantomData::<$crate::Ix0>,
                 )
             }
         }
@@ -858,18 +858,18 @@ macro_rules! s(
     (@parse $($t:tt)*) => { compile_error!("Invalid syntax in s![] call.") };
     // convert range/index/new-axis into SliceInfoElem
     (@convert $r:expr) => {
-        <$crate::SliceInfoElem as ::std::convert::From<_>>::from($r)
+        <$crate::SliceInfoElem as ::core::convert::From<_>>::from($r)
     };
     // convert range/index/new-axis and step into SliceInfoElem
     (@convert $r:expr, $s:expr) => {
-        <$crate::SliceInfoElem as ::std::convert::From<_>>::from(
-            <$crate::Slice as ::std::convert::From<_>>::from($r).step_by($s as isize)
+        <$crate::SliceInfoElem as ::core::convert::From<_>>::from(
+            <$crate::Slice as ::core::convert::From<_>>::from($r).step_by($s as isize)
         )
     };
     ($($t:tt)*) => {
         $crate::s![@parse
-              ::std::marker::PhantomData::<$crate::Ix0>,
-              ::std::marker::PhantomData::<$crate::Ix0>,
+              ::core::marker::PhantomData::<$crate::Ix0>,
+              ::core::marker::PhantomData::<$crate::Ix0>,
               []
               $($t)*
         ]

--- a/src/zip/mod.rs
+++ b/src/zip/mod.rs
@@ -426,7 +426,7 @@ where
     }
 
     #[cfg(feature = "rayon")]
-    pub(crate) fn uninitalized_for_current_layout<T>(&self) -> Array<MaybeUninit<T>, D>
+    pub(crate) fn uninitialized_for_current_layout<T>(&self) -> Array<MaybeUninit<T>, D>
     {
         let is_f = self.prefer_f();
         Array::uninit(self.dimension.clone().set_f(is_f))

--- a/src/zip/ndproducer.rs
+++ b/src/zip/ndproducer.rs
@@ -44,7 +44,7 @@ where
 /// Most `NdProducers` are *iterable* (implement `IntoIterator`) but not directly
 /// iterators. This separation is needed because the producer represents
 /// a multidimensional set of items, it can be split along a particular axis for
-/// parallelization, and it has no fixed correspondance to a sequence.
+/// parallelization, and it has no fixed correspondence to a sequence.
 ///
 /// The natural exception is one dimensional producers, like `AxisIter`, which
 /// implement `Iterator` directly

--- a/tests/iterators.rs
+++ b/tests/iterators.rs
@@ -532,8 +532,8 @@ fn axis_iter_mut_zip_partially_consumed_discontiguous() {
 fn axis_chunks_iter_corner_cases() {
     // examples provided by @bluss in PR #65
     // these tests highlight corner cases of the axis_chunks_iter implementation
-    // and enable checking if no pointer offseting is out of bounds. However
-    // checking the absence of of out of bounds offseting cannot (?) be
+    // and enable checking if no pointer offsetting is out of bounds. However
+    // checking the absence of of out of bounds offsetting cannot (?) be
     // done automatically, so one has to launch this test in a debugger.
     let a = ArcArray::<f32, _>::linspace(0., 7., 8).reshape((8, 1));
     let it = a.axis_chunks_iter(Axis(0), 4);

--- a/tests/windows.rs
+++ b/tests/windows.rs
@@ -116,7 +116,7 @@ fn test_window_zip() {
     }
 }
 
-/// Test verifies that non existant Axis results in panic
+/// Test verifies that non existent Axis results in panic
 #[test]
 #[should_panic]
 fn axis_windows_outofbound() {


### PR DESCRIPTION
Multiple users have requested a release with #1154. This PR prepares for a minimal 0.15.5 release. The `master` branch has some breaking changes, so I've cherry-picked the non-breaking changes to the 0.15.x branch.

- Cherry-pick non-breaking changes from master to 0.15.x.
- Update `RELEASES.md`.