### PR TITLE
Simplify `s![]`

### DIFF
--- a/src/slice.rs
+++ b/src/slice.rs
@@ -844,9 +844,11 @@ macro_rules! s(
     // empty call, i.e. `s![]`
     (@parse $in_dim:expr, $out_dim:expr, []) => {
         {
+            let in_dim = $in_dim;
+            let out_dim = $out_dim;
             #[allow(unsafe_code)]
             unsafe {
-                $crate::SliceInfo::new_unchecked([], $in_dim, $out_dim)
+                $crate::SliceInfo::new_unchecked([], in_dim, out_dim)
             }
         }
     };

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -842,15 +842,11 @@ macro_rules! s(
         }
     };
     // empty call, i.e. `s![]`
-    (@parse ::core::marker::PhantomData::<$crate::Ix0>, ::core::marker::PhantomData::<$crate::Ix0>, []) => {
+    (@parse $in_dim:expr, $out_dim:expr, []) => {
         {
             #[allow(unsafe_code)]
             unsafe {
-                $crate::SliceInfo::new_unchecked(
-                    [],
-                    ::core::marker::PhantomData::<$crate::Ix0>,
-                    ::core::marker::PhantomData::<$crate::Ix0>,
-                )
+                $crate::SliceInfo::new_unchecked([], $in_dim, $out_dim)
             }
         }
     };


### PR DESCRIPTION
Fixes #1194 with a very slight generalization to make this arm more similar to the other arms.