### PR TITLE
Fixing CI errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.51.0  # MSRV
+          - 1.59.0  # MSRV
 
     steps:
       - uses: actions/checkout@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 name = "ndarray"
 version = "0.15.6"
 edition = "2018"
-rust-version = "1.51"
+rust-version = "1.59"
 authors = [
   "Ulrik Sverdrup \"bluss\"",
   "Jim Turner"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,8 +78,8 @@ matrixmultiply-threading = ["matrixmultiply/threading"]
 debug = true
 
 [workspace]
-members = ["ndarray-rand", "xtest-serialization", "xtest-blas"]
-exclude = ["xtest-numeric"]
+members = ["ndarray-rand", "xtest-serialization", "xtest-blas","xtest-numeric"]
+
 
 [package.metadata.release]
 no-dev-version = true

--- a/examples/life.rs
+++ b/examples/life.rs
@@ -90,5 +90,5 @@ fn main() {
     }
     render(&a);
     let alive = a.iter().filter(|&&x| x > 0).count();
-    println!("After {} steps there are {} cells alive", steps, alive);
+    println!("After {steps} steps there are {alive} cells alive");
 }

--- a/examples/type_conversion.rs
+++ b/examples/type_conversion.rs
@@ -33,7 +33,7 @@ fn main() {
     // can be guaranteed to be lossless at compile time. This is the safest
     // approach.
     let a_u8: Array<u8, _> = array![[1, 2, 3], [4, 5, 6]];
-    let a_f32 = a_u8.mapv(|element| f32::from(element));
+    let a_f32 = a_u8.mapv(f32::from);
     assert_abs_diff_eq!(a_f32, array![[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]);
 
     // Fallible, lossless conversion with `TryFrom`

--- a/examples/zip_many.rs
+++ b/examples/zip_many.rs
@@ -27,7 +27,7 @@ fn main() {
     // and this is how to do the *same thing* with azip!()
     azip!((a in &mut a, &b in &b, &c in c) *a = b + c);
 
-    println!("{:8.4}", a);
+    println!("{a:8.4}");
 
     // sum of each row
     let mut sums = Array::zeros(a.nrows());
@@ -44,5 +44,5 @@ fn main() {
     Zip::from(a.exact_chunks(chunk_sz))
         .and(&mut sums)
         .for_each(|chunk, sum| *sum = chunk.sum());
-    println!("{:8.4}", sums);
+    println!("{sums:8.4}");
 }

--- a/src/array_serde.rs
+++ b/src/array_serde.rs
@@ -27,7 +27,7 @@ where
     E: de::Error,
 {
     if v != ARRAY_FORMAT_VERSION {
-        let err_msg = format!("unknown array version: {}", v);
+        let err_msg = format!("unknown array version: {v}");
         Err(de::Error::custom(err_msg))
     } else {
         Ok(())
@@ -193,7 +193,7 @@ impl<'de> Deserialize<'de> for ArrayField {
                     b"dim" => Ok(ArrayField::Dim),
                     b"data" => Ok(ArrayField::Data),
                     other => Err(de::Error::unknown_field(
-                        &format!("{:?}", other),
+                        &format!("{other:?}"),
                         ARRAY_FIELDS,
                     )),
                 }

--- a/src/arrayformat.rs
+++ b/src/arrayformat.rs
@@ -296,7 +296,7 @@ mod formatting_with_omit {
         // use assert to avoid printing the strings twice on failure
         assert!(
             expected == actual,
-            "formatting assertion failed\nexpected:\n{expected}\nactual:\n{actual}\n",
+            "formatting assertion failed\nexpected:\n{}\nactual:\n{}\n",expected,actual
         );
     }
 

--- a/src/arrayformat.rs
+++ b/src/arrayformat.rs
@@ -164,7 +164,7 @@ where
         shape => {
             let blank_lines = "\n".repeat(shape.len() - 2);
             let indent = " ".repeat(depth + 1);
-            let separator = format!(",\n{}{}", blank_lines, indent);
+            let separator = format!(",\n{blank_lines}{indent}");
 
             f.write_str("[")?;
             let limit = fmt_opt.collapse_limit(full_ndim - depth - 1);
@@ -220,7 +220,7 @@ where
             self.view().layout(),
         )?;
         match D::NDIM {
-            Some(ndim) => write!(f, ", const ndim={}", ndim)?,
+            Some(ndim) => write!(f, ", const ndim={ndim}")?,
             None => write!(f, ", dynamic ndim={}", self.ndim())?,
         }
         Ok(())
@@ -296,9 +296,7 @@ mod formatting_with_omit {
         // use assert to avoid printing the strings twice on failure
         assert!(
             expected == actual,
-            "formatting assertion failed\nexpected:\n{}\nactual:\n{}\n",
-            expected,
-            actual,
+            "formatting assertion failed\nexpected:\n{expected}\nactual:\n{actual}\n",
         );
     }
 
@@ -326,7 +324,7 @@ mod formatting_with_omit {
     #[test]
     fn empty_arrays() {
         let a: Array2<u32> = arr2(&[[], []]);
-        let actual = format!("{}", a);
+        let actual = format!("{a}");
         let expected = "[[]]";
         assert_str_eq(expected, &actual);
     }
@@ -334,7 +332,7 @@ mod formatting_with_omit {
     #[test]
     fn zero_length_axes() {
         let a = Array3::<f32>::zeros((3, 0, 4));
-        let actual = format!("{}", a);
+        let actual = format!("{a}");
         let expected = "[[[]]]";
         assert_str_eq(expected, &actual);
     }
@@ -343,7 +341,7 @@ mod formatting_with_omit {
     fn dim_0() {
         let element = 12;
         let a = arr0(element);
-        let actual = format!("{}", a);
+        let actual = format!("{a}");
         let expected = "12";
         assert_str_eq(expected, &actual);
     }
@@ -352,7 +350,7 @@ mod formatting_with_omit {
     fn dim_1() {
         let overflow: usize = 2;
         let a = Array1::from_elem(ARRAY_MANY_ELEMENT_LIMIT + overflow, 1);
-        let actual = format!("{}", a);
+        let actual = format!("{a}");
         let expected = format!("[{}]", ellipsize(AXIS_LIMIT_ROW, ", ", a.iter()));
         assert_str_eq(&expected, &actual);
     }
@@ -361,7 +359,7 @@ mod formatting_with_omit {
     fn dim_1_alternate() {
         let overflow: usize = 2;
         let a = Array1::from_elem(ARRAY_MANY_ELEMENT_LIMIT + overflow, 1);
-        let actual = format!("{:#}", a);
+        let actual = format!("{a:#}");
         let expected = format!("[{}]", a.iter().format(", "));
         assert_str_eq(&expected, &actual);
     }
@@ -373,7 +371,7 @@ mod formatting_with_omit {
             (AXIS_2D_OVERFLOW_LIMIT, AXIS_2D_OVERFLOW_LIMIT + overflow),
             1,
         );
-        let actual = format!("{}", a);
+        let actual = format!("{a}");
         let expected = "\
 [[1, 1, 1, 1, 1, ..., 1, 1, 1, 1, 1],
  [1, 1, 1, 1, 1, ..., 1, 1, 1, 1, 1],
@@ -392,7 +390,7 @@ mod formatting_with_omit {
     #[test]
     fn dim_2_non_last_axis_overflow() {
         let a = Array2::from_elem((ARRAY_MANY_ELEMENT_LIMIT / 10, 10), 1);
-        let actual = format!("{}", a);
+        let actual = format!("{a}");
         let row = format!("{}", a.row(0));
         let expected = format!(
             "[{}]",
@@ -404,7 +402,7 @@ mod formatting_with_omit {
     #[test]
     fn dim_2_non_last_axis_overflow_alternate() {
         let a = Array2::from_elem((AXIS_LIMIT_COL * 4, 6), 1);
-        let actual = format!("{:#}", a);
+        let actual = format!("{a:#}");
         let row = format!("{}", a.row(0));
         let expected = format!("[{}]", (0..a.nrows()).map(|_| &row).format(",\n "));
         assert_str_eq(&expected, &actual);
@@ -420,7 +418,7 @@ mod formatting_with_omit {
             ),
             1,
         );
-        let actual = format!("{}", a);
+        let actual = format!("{a}");
         let row = format!("[{}]", ellipsize(AXIS_LIMIT_ROW, ", ", a.row(0)));
         let expected = format!(
             "[{}]",
@@ -439,7 +437,7 @@ mod formatting_with_omit {
             ),
             1,
         );
-        let actual = format!("{:#}", a);
+        let actual = format!("{a:#}");
         let row = format!("{}", a.row(0));
         let expected = format!("[{}]", (0..a.nrows()).map(|_| &row).format(",\n "));
         assert_str_eq(&expected, &actual);
@@ -453,7 +451,7 @@ mod formatting_with_omit {
                 1000. + (100. * ((i as f64).sqrt() + (j as f64).sin() + k as f64)).round() / 100.
             },
         );
-        let actual = format!("{:6.1}", a);
+        let actual = format!("{a:6.1}");
         let expected = "\
 [[[1000.0, 1001.0, 1002.0, 1003.0, 1004.0, ..., 1007.0, 1008.0, 1009.0, 1010.0, 1011.0],
   [1000.8, 1001.8, 1002.8, 1003.8, 1004.8, ..., 1007.8, 1008.8, 1009.8, 1010.8, 1011.8],
@@ -534,7 +532,7 @@ mod formatting_with_omit {
     #[test]
     fn dim_4_overflow_outer() {
         let a = Array4::from_shape_fn((10, 10, 3, 3), |(i, j, k, l)| i + j + k + l);
-        let actual = format!("{:2}", a);
+        let actual = format!("{a:2}");
         // Generated using NumPy with:
         // np.set_printoptions(threshold=500, edgeitems=3)
         // np.fromfunction(lambda i, j, k, l: i + j + k + l, (10, 10, 3, 3), dtype=int)

--- a/src/dimension/broadcast.rs
+++ b/src/dimension/broadcast.rs
@@ -104,7 +104,7 @@ mod tests {
             D1: Dimension + DimMax<D2>,
             D2: Dimension,
         {
-            let d = co_broadcast::<D1, D2, <D1 as DimMax<D2>>::Output>(&d1, d2);
+            let d = co_broadcast::<D1, D2, <D1 as DimMax<D2>>::Output>(d1, d2);
             assert_eq!(d, r);
         }
         test_co(&Dim([2, 3]), &Dim([4, 1, 3]), Ok(Dim([4, 2, 3])));

--- a/src/dimension/dimension_trait.rs
+++ b/src/dimension/dimension_trait.rs
@@ -83,7 +83,7 @@ pub trait Dimension:
 
     /// Compute the size of the dimension (number of elements)
     fn size(&self) -> usize {
-        self.slice().iter().fold(1, |s, &a| s * a as usize)
+        self.slice().iter().product()
     }
 
     /// Compute the size while checking for overflow.
@@ -603,7 +603,7 @@ impl Dimension for Dim<[Ix; 2]> {
     fn size_checked(&self) -> Option<usize> {
         let m = get!(self, 0);
         let n = get!(self, 1);
-        (m as usize).checked_mul(n as usize)
+        m.checked_mul(n)
     }
 
     #[inline]
@@ -728,7 +728,7 @@ impl Dimension for Dim<[Ix; 3]> {
         let m = get!(self, 0);
         let n = get!(self, 1);
         let o = get!(self, 2);
-        m as usize * n as usize * o as usize
+        m * n * o
     }
 
     #[inline]

--- a/src/dimension/dynindeximpl.rs
+++ b/src/dimension/dynindeximpl.rs
@@ -96,7 +96,7 @@ impl<T: PartialEq> PartialEq for IxDynRepr<T> {
         match (self, rhs) {
             (&IxDynRepr::Inline(slen, ref sarr), &IxDynRepr::Inline(rlen, ref rarr)) => {
                 slen == rlen
-                    && (0..CAP as usize)
+                    && (0..CAP)
                         .filter(|&i| i < slen as usize)
                         .all(|i| sarr[i] == rarr[i])
             }

--- a/src/dimension/mod.rs
+++ b/src/dimension/mod.rs
@@ -47,7 +47,7 @@ mod sequence;
 /// Calculate offset from `Ix` stride converting sign properly
 #[inline(always)]
 pub fn stride_offset(n: Ix, stride: Ix) -> isize {
-    (n as isize) * ((stride as Ixs) as isize)
+    (n as isize) * (stride as Ixs)
 }
 
 /// Check whether the given `dim` and `stride` lead to overlapping indices

--- a/src/dimension/mod.rs
+++ b/src/dimension/mod.rs
@@ -463,7 +463,7 @@ pub fn do_slice(dim: &mut usize, stride: &mut usize, slice: Slice) -> isize {
     } else {
         let d = m / abs_step;
         let r = m % abs_step;
-        d + if r > 0 { 1 } else { 0 }
+        d + (r>0) as usize
     };
 
     // Update stride. The additional check is necessary to avoid possible
@@ -729,12 +729,12 @@ where
     let merged_len = into_len * take_len;
     if take_len <= 1 {
         dim.set_axis(into, merged_len);
-        dim.set_axis(take, if merged_len == 0 { 0 } else { 1 });
+        dim.set_axis(take, (merged_len != 0) as usize);
         true
     } else if into_len <= 1 {
         strides.set_axis(into, take_stride as usize);
         dim.set_axis(into, merged_len);
-        dim.set_axis(take, if merged_len == 0 { 0 } else { 1 });
+        dim.set_axis(take, (merged_len != 0) as usize);
         true
     } else if take_stride == into_len as isize * into_stride {
         dim.set_axis(into, merged_len);

--- a/src/error.rs
+++ b/src/error.rs
@@ -89,7 +89,7 @@ impl fmt::Display for ShapeError {
 
 impl fmt::Debug for ShapeError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self)
+        write!(f, "{self}")
     }
 }
 

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -1990,7 +1990,7 @@ where
                 let strides = unlimited_transmute::<D, D2>(self.strides);
                 return Ok(ArrayBase::from_data_ptr(self.data, self.ptr)
                             .with_strides_dim(strides, dim));
-            } else if D::NDIM == None || D2::NDIM == None { // one is dynamic dim
+            } else if D::NDIM.is_none() || D2::NDIM.is_none() { // one is dynamic dim
                 // safe because dim, strides are equivalent under a different type
                 if let Some(dim) = D2::from_dimension(&self.dim) {
                     if let Some(strides) = D2::from_dimension(&self.strides) {

--- a/src/indexes.rs
+++ b/src/indexes.rs
@@ -75,7 +75,7 @@ where
                     .slice()
                     .iter()
                     .zip(ix.slice().iter())
-                    .fold(0, |s, (&a, &b)| s + a as usize * b as usize);
+                    .fold(0, |s, (&a, &b)| s + a * b);
                 self.dim.size() - gone
             }
         };
@@ -286,7 +286,7 @@ where
             .slice()
             .iter()
             .zip(self.index.slice().iter())
-            .fold(0, |s, (&a, &b)| s + a as usize * b as usize);
+            .fold(0, |s, (&a, &b)| s + a * b);
         let l = self.dim.size() - gone;
         (l, Some(l))
     }

--- a/src/iterators/mod.rs
+++ b/src/iterators/mod.rs
@@ -114,7 +114,7 @@ impl<A, D: Dimension> ExactSizeIterator for Baseiter<A, D> {
                     .slice()
                     .iter()
                     .zip(ix.slice().iter())
-                    .fold(0, |s, (&a, &b)| s + a as usize * b as usize);
+                    .fold(0, |s, (&a, &b)| s + a * b);
                 self.dim.size() - gone
             }
         }

--- a/src/layout/layoutfmt.rs
+++ b/src/layout/layoutfmt.rs
@@ -19,9 +19,9 @@ impl fmt::Debug for Layout {
         } else {
             (0..32).filter(|&i| self.is(1 << i)).try_fold((), |_, i| {
                 if let Some(name) = LAYOUT_NAMES.get(i) {
-                    write!(f, "{}", name)
+                    write!(f, "{name}")
                 } else {
-                    write!(f, "{:#x}", i)
+                    write!(f, "{i:#x}")
                 }
             })?;
         };

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -149,17 +149,17 @@ impl SliceInfoElem {
 impl fmt::Display for SliceInfoElem {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
-            SliceInfoElem::Index(index) => write!(f, "{}", index)?,
+            SliceInfoElem::Index(index) => write!(f, "{index}")?,
             SliceInfoElem::Slice { start, end, step } => {
                 if start != 0 {
-                    write!(f, "{}", start)?;
+                    write!(f, "{start}")?;
                 }
                 write!(f, "..")?;
                 if let Some(i) = end {
-                    write!(f, "{}", i)?;
+                    write!(f, "{i}")?;
                 }
                 if step != 1 {
-                    write!(f, ";{}", step)?;
+                    write!(f, ";{step}")?;
                 }
             }
             SliceInfoElem::NewAxis => write!(f, stringify!(NewAxis))?,

--- a/tests/append.rs
+++ b/tests/append.rs
@@ -291,7 +291,7 @@ fn test_append_2d() {
     assert_eq!(a.shape(), &[8, 4]);
     for (i, row) in a.rows().into_iter().enumerate() {
         let ones = !(3..5).contains(&i);
-        assert!(row.iter().all(|&x| x == ones as i32 as f64), "failed on lane {i}");
+        assert!(row.iter().all(|&x| x == ones as i32 as f64), "failed on lane {}",i);
     }
 
     let mut a = Array::zeros((0, 4));
@@ -306,7 +306,7 @@ fn test_append_2d() {
 
     for (i, row) in a.columns().into_iter().enumerate() {
         let ones = !(3..5).contains(&i);
-        assert!(row.iter().all(|&x| x == ones as i32 as f64), "failed on lane {i}");
+        assert!(row.iter().all(|&x| x == ones as i32 as f64), "failed on lane {}",i);
     }
 }
 

--- a/tests/append.rs
+++ b/tests/append.rs
@@ -246,14 +246,14 @@ fn append_array_3d() {
     let aa = array![[[51, 52], [53, 54]], [[55, 56], [57, 58]]];
     let av = aa.view();
     println!("Send {:?} to append", av);
-    a.append(Axis(0), av.clone()).unwrap();
+    a.append(Axis(0), av).unwrap();
 
     a.swap_axes(0, 1);
     let aa = array![[[71, 72], [73, 74]], [[75, 76], [77, 78]]];
     let mut av = aa.view();
     av.swap_axes(0, 1);
     println!("Send {:?} to append", av);
-    a.append(Axis(1), av.clone()).unwrap();
+    a.append(Axis(1), av).unwrap();
     println!("{:?}", a);
     let aa = array![[[81, 82], [83, 84]], [[85, 86], [87, 88]]];
     let mut av = aa.view();
@@ -290,7 +290,7 @@ fn test_append_2d() {
     println!("{:?}", a);
     assert_eq!(a.shape(), &[8, 4]);
     for (i, row) in a.rows().into_iter().enumerate() {
-        let ones = i < 3 || i >= 5;
+        let ones = !(3..5).contains(&i);
         assert!(row.iter().all(|&x| x == ones as i32 as f64), "failed on lane {}", i);
     }
 
@@ -305,7 +305,7 @@ fn test_append_2d() {
     assert_eq!(a.shape(), &[4, 8]);
 
     for (i, row) in a.columns().into_iter().enumerate() {
-        let ones = i < 3 || i >= 5;
+        let ones = !(3..5).contains(&i);
         assert!(row.iter().all(|&x| x == ones as i32 as f64), "failed on lane {}", i);
     }
 }

--- a/tests/append.rs
+++ b/tests/append.rs
@@ -73,8 +73,8 @@ fn push_row_neg_stride_1() {
 
     // Changing the memory layout to fit the next append
     let mut a2 = a.clone();
-    println!("a = {:?}", a);
-    println!("a2 = {:?}", a2);
+    println!("a = {a:?}");
+    println!("a2 = {a2:?}");
     a2.push_column(aview1(&[1., 2.])).unwrap();
     assert_eq!(a2,
         array![[4., 5., 6., 7., 1.],
@@ -116,8 +116,8 @@ fn push_row_neg_stride_2() {
 
     // Changing the memory layout to fit the next append
     let mut a2 = a.clone();
-    println!("a = {:?}", a);
-    println!("a2 = {:?}", a2);
+    println!("a = {a:?}");
+    println!("a2 = {a2:?}");
     a2.push_column(aview1(&[1., 2.])).unwrap();
     assert_eq!(a2,
         array![[3., 2., 1., 0., 1.],
@@ -218,9 +218,9 @@ fn push_column() {
 fn append_array1() {
     let mut a = Array::zeros((0, 4));
     a.append(Axis(0), aview2(&[[0., 1., 2., 3.]])).unwrap();
-    println!("{:?}", a);
+    println!("{a:?}");
     a.append(Axis(0), aview2(&[[4., 5., 6., 7.]])).unwrap();
-    println!("{:?}", a);
+    println!("{a:?}");
     //a.push_column(aview1(&[4., 5., 6., 7.])).unwrap();
     //assert_eq!(a.shape(), &[4, 2]);
 
@@ -229,7 +229,7 @@ fn append_array1() {
                [4., 5., 6., 7.]]);
 
     a.append(Axis(0), aview2(&[[5., 5., 4., 4.], [3., 3., 2., 2.]])).unwrap();
-    println!("{:?}", a);
+    println!("{a:?}");
     assert_eq!(a,
         array![[0., 1., 2., 3.],
                [4., 5., 6., 7.],
@@ -241,26 +241,26 @@ fn append_array1() {
 fn append_array_3d() {
     let mut a = Array::zeros((0, 2, 2));
     a.append(Axis(0), array![[[0, 1], [2, 3]]].view()).unwrap();
-    println!("{:?}", a);
+    println!("{a:?}");
 
     let aa = array![[[51, 52], [53, 54]], [[55, 56], [57, 58]]];
     let av = aa.view();
-    println!("Send {:?} to append", av);
+    println!("Send {av:?} to append");
     a.append(Axis(0), av).unwrap();
 
     a.swap_axes(0, 1);
     let aa = array![[[71, 72], [73, 74]], [[75, 76], [77, 78]]];
     let mut av = aa.view();
     av.swap_axes(0, 1);
-    println!("Send {:?} to append", av);
+    println!("Send {av:?} to append");
     a.append(Axis(1), av).unwrap();
-    println!("{:?}", a);
+    println!("{a:?}");
     let aa = array![[[81, 82], [83, 84]], [[85, 86], [87, 88]]];
     let mut av = aa.view();
     av.swap_axes(0, 1);
-    println!("Send {:?} to append", av);
+    println!("Send {av:?} to append");
     a.append(Axis(1), av).unwrap();
-    println!("{:?}", a);
+    println!("{a:?}");
     assert_eq!(a,
         array![[[0, 1],
                 [51, 52],
@@ -287,11 +287,11 @@ fn test_append_2d() {
     a.append(Axis(0), ones).unwrap();
     a.append(Axis(0), zeros).unwrap();
     a.append(Axis(0), ones).unwrap();
-    println!("{:?}", a);
+    println!("{a:?}");
     assert_eq!(a.shape(), &[8, 4]);
     for (i, row) in a.rows().into_iter().enumerate() {
         let ones = !(3..5).contains(&i);
-        assert!(row.iter().all(|&x| x == ones as i32 as f64), "failed on lane {}", i);
+        assert!(row.iter().all(|&x| x == ones as i32 as f64), "failed on lane {i}");
     }
 
     let mut a = Array::zeros((0, 4));
@@ -301,12 +301,12 @@ fn test_append_2d() {
     a.append(Axis(1), ones).unwrap();
     a.append(Axis(1), zeros).unwrap();
     a.append(Axis(1), ones).unwrap();
-    println!("{:?}", a);
+    println!("{a:?}");
     assert_eq!(a.shape(), &[4, 8]);
 
     for (i, row) in a.columns().into_iter().enumerate() {
         let ones = !(3..5).contains(&i);
-        assert!(row.iter().all(|&x| x == ones as i32 as f64), "failed on lane {}", i);
+        assert!(row.iter().all(|&x| x == ones as i32 as f64), "failed on lane {i}");
     }
 }
 
@@ -315,16 +315,16 @@ fn test_append_middle_axis() {
     // ensure we can append to Axis(1) by letting it become outermost
     let mut a = Array::<i32, _>::zeros((3, 0, 2));
     a.append(Axis(1), Array::from_iter(0..12).into_shape((3, 2, 2)).unwrap().view()).unwrap();
-    println!("{:?}", a);
+    println!("{a:?}");
     a.append(Axis(1), Array::from_iter(12..24).into_shape((3, 2, 2)).unwrap().view()).unwrap();
-    println!("{:?}", a);
+    println!("{a:?}");
 
     // ensure we can append to Axis(1) by letting it become outermost
     let mut a = Array::<i32, _>::zeros((3, 1, 2));
     a.append(Axis(1), Array::from_iter(0..12).into_shape((3, 2, 2)).unwrap().view()).unwrap();
-    println!("{:?}", a);
+    println!("{a:?}");
     a.append(Axis(1), Array::from_iter(12..24).into_shape((3, 2, 2)).unwrap().view()).unwrap();
-    println!("{:?}", a);
+    println!("{a:?}");
 }
 
 #[test]

--- a/tests/array-construct.rs
+++ b/tests/array-construct.rs
@@ -153,7 +153,7 @@ fn deny_wraparound_from_vec() {
     let five_large = Array::from_shape_vec((3, 7, 29, 36760123, 823996703), five.clone());
     println!("{:?}", five_large);
     assert!(five_large.is_err());
-    let six = Array::from_shape_vec(6, five.clone());
+    let six = Array::from_shape_vec(6, five);
     assert!(six.is_err());
 }
 

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -9,7 +9,8 @@
 
 use approx::assert_relative_eq;
 use defmac::defmac;
-use itertools::{zip, Itertools};
+use itertools::Itertools;
+use std::iter::zip;
 use ndarray::prelude::*;
 use ndarray::{arr3, rcarr2};
 use ndarray::indices;

--- a/tests/azip.rs
+++ b/tests/azip.rs
@@ -277,9 +277,9 @@ fn test_contiguous_but_not_c_or_f() {
 
     let mut ans = Array::zeros(a.dim().f());
     azip!((ans in &mut ans, &a in &a, &b in &b) *ans = a + b);
-    println!("{:?}", a);
-    println!("{:?}", b);
-    println!("{:?}", ans);
+    println!("{a:?}");
+    println!("{b:?}");
+    println!("{ans:?}");
 
     assert_eq!(ans[[0, 1, 2]], correct_012);
     assert_eq!(ans, correct);

--- a/tests/ixdyn.rs
+++ b/tests/ixdyn.rs
@@ -109,7 +109,7 @@ fn test_ixdyn_uget() {
 fn test_0() {
     let mut a = Array::zeros(vec![]);
     let z = vec![].into_dimension();
-    assert_eq!(a[z.clone()], 0.);
+    assert_eq!(a[z], 0.);
     a[[]] = 1.;
     assert_eq!(a[[]], 1.);
     assert_eq!(a.len(), 1);

--- a/tests/oper.rs
+++ b/tests/oper.rs
@@ -30,7 +30,7 @@ fn test_oper(op: &str, a: &[f32], b: &[f32], c: &[f32]) {
     let aa = aa.reshape(dim);
     let bb = bb.reshape(dim);
     let cc = cc.reshape(dim);
-    test_oper_arr::<f32, _>(op, aa.clone(), bb.clone(), cc.clone());
+    test_oper_arr::<f32, _>(op, aa, bb, cc);
 }
 
 
@@ -170,24 +170,24 @@ fn dot_product() {
     for i in 1..max {
         let a1 = a.slice(s![i..]);
         let b1 = b.slice(s![i..]);
-        assert_abs_diff_eq!(a1.dot(&b1), reference_dot(&a1, &b1), epsilon = 1e-5);
+        assert_abs_diff_eq!(a1.dot(&b1), reference_dot(a1, b1), epsilon = 1e-5);
         let a2 = a.slice(s![..-i]);
         let b2 = b.slice(s![i..]);
-        assert_abs_diff_eq!(a2.dot(&b2), reference_dot(&a2, &b2), epsilon = 1e-5);
+        assert_abs_diff_eq!(a2.dot(&b2), reference_dot(a2, b2), epsilon = 1e-5);
     }
 
-    let a = a.map(|f| *f as f32);
-    let b = b.map(|f| *f as f32);
+    let a = a.map(|f| *f);
+    let b = b.map(|f| *f);
     assert_abs_diff_eq!(a.dot(&b), dot as f32, epsilon = 1e-5);
 
     let max = 8 as Ixs;
     for i in 1..max {
         let a1 = a.slice(s![i..]);
         let b1 = b.slice(s![i..]);
-        assert_abs_diff_eq!(a1.dot(&b1), reference_dot(&a1, &b1), epsilon = 1e-5);
+        assert_abs_diff_eq!(a1.dot(&b1), reference_dot(a1, b1), epsilon = 1e-5);
         let a2 = a.slice(s![..-i]);
         let b2 = b.slice(s![i..]);
-        assert_abs_diff_eq!(a2.dot(&b2), reference_dot(&a2, &b2), epsilon = 1e-5);
+        assert_abs_diff_eq!(a2.dot(&b2), reference_dot(a2, b2), epsilon = 1e-5);
     }
 
     let a = a.map(|f| *f as i32);
@@ -202,17 +202,17 @@ fn dot_product_0() {
     let x = 1.5;
     let b = aview0(&x);
     let b = b.broadcast(a.dim()).unwrap();
-    assert_abs_diff_eq!(a.dot(&b), reference_dot(&a, &b), epsilon = 1e-5);
+    assert_abs_diff_eq!(a.dot(&b), reference_dot(&a, b), epsilon = 1e-5);
 
     // test different alignments
     let max = 8 as Ixs;
     for i in 1..max {
         let a1 = a.slice(s![i..]);
         let b1 = b.slice(s![i..]);
-        assert_abs_diff_eq!(a1.dot(&b1), reference_dot(&a1, &b1), epsilon = 1e-5);
+        assert_abs_diff_eq!(a1.dot(&b1), reference_dot(a1, b1), epsilon = 1e-5);
         let a2 = a.slice(s![..-i]);
         let b2 = b.slice(s![i..]);
-        assert_abs_diff_eq!(a2.dot(&b2), reference_dot(&a2, &b2), epsilon = 1e-5);
+        assert_abs_diff_eq!(a2.dot(&b2), reference_dot(a2, b2), epsilon = 1e-5);
     }
 }
 
@@ -225,13 +225,13 @@ fn dot_product_neg_stride() {
         // both negative
         let a = a.slice(s![..;stride]);
         let b = b.slice(s![..;stride]);
-        assert_abs_diff_eq!(a.dot(&b), reference_dot(&a, &b), epsilon = 1e-5);
+        assert_abs_diff_eq!(a.dot(&b), reference_dot(a, b), epsilon = 1e-5);
     }
     for stride in -10..0 {
         // mixed
         let a = a.slice(s![..;-stride]);
         let b = b.slice(s![..;stride]);
-        assert_abs_diff_eq!(a.dot(&b), reference_dot(&a, &b), epsilon = 1e-5);
+        assert_abs_diff_eq!(a.dot(&b), reference_dot(a, b), epsilon = 1e-5);
     }
 }
 
@@ -478,7 +478,7 @@ fn mat_mul_rev() {
     let mut rev = Array::zeros(b.dim());
     let mut rev = rev.slice_mut(s![..;-1, ..]);
     rev.assign(&b);
-    println!("{:.?}", rev);
+    println!("{:?}", rev);
 
     let c1 = a.dot(&b);
     let c2 = a.dot(&rev);

--- a/tests/oper.rs
+++ b/tests/oper.rs
@@ -478,7 +478,7 @@ fn mat_mul_rev() {
     let mut rev = Array::zeros(b.dim());
     let mut rev = rev.slice_mut(s![..;-1, ..]);
     rev.assign(&b);
-    println!("{:?}", rev);
+    println!("{rev:?}");
 
     let c1 = a.dot(&b);
     let c2 = a.dot(&rev);

--- a/tests/zst.rs
+++ b/tests/zst.rs
@@ -16,6 +16,7 @@ fn test_swap() {
 }
 
 #[test]
+#[allow(clippy::all)] //not sure what lint keeps fixing this, never shows up with clippy , but changes with --fix
 fn test() {
     let c = ArcArray::<(), _>::default((3, 4));
     let mut d = c.clone();

--- a/xtest-numeric/Cargo.toml
+++ b/xtest-numeric/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 approx = "0.4"
-ndarray = { path = "..", features = ["approx"] }
+ndarray = { path = "../", features = ["approx"] }
 ndarray-rand = { path = "../ndarray-rand/" }
 rand_distr = "0.4"
 


### PR DESCRIPTION
I noticed that CI was failing, I figured I'd do a PR to fix issues I'm noticing

the first CI failure is due to use of a deprecated function `itertools::zip` in `test/array.rs`.

switching to `std::iter::zip` requires updating the MSRV in `ci.yml` from 1.51 to 1.59, I went ahead and changed my copy to that rust version, but I don't know if there is any specific reason why 1.51 was set as the minimum. If there is, what would be the best alternative to using either version of zip?

the second error seems to be due to a duplicate mount point for the i686 cross-test, still working on that one.

the third error is for the clippy lints, I fixed two by running `cargo clippy --fix --no-deps`, but the third is less straight forward. 


EDIT: 
the second error I believe is caused by the layout of the project, with ndarray and ndarray-rand both being dependencies with relative imports. because ndarray is in the parent directory, and ndarray-rand is a child directory, this creates duplicate mountpoints. I could fix this by moving ndarray into it's own directory and keeping the top level parent for project specs but I should probably confirm that is the direction you guys would like to go first. There may be a way to fix it by providing some info to cross via an env variable or CLI flag, still looking through the repo for cross to figure out if that's the case

EDIT2: I fixed this by adding xtest-numeric to the list of workspace members, which makes all the CI test pass, but has the downside of making the CI test [run for around 20 minutes](https://github.com/skewballfox/ndarray/actions/runs/3768904426). Before the test from `all-test.sh` were finishing pretty quickly. Is there anything else I need to change when adding `xtest-numeric` to the list of workspace-members?