### PR TITLE
implement DoubleEndedIterator for 1d `LanesIter`

### DIFF
--- a/src/iterators/mod.rs
+++ b/src/iterators/mod.rs
@@ -732,6 +732,15 @@ where
     }
 }
 
+impl<'a, A> DoubleEndedIterator for LanesIter<'a, A, Ix1>
+{
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.iter.next_back().map(|ptr| unsafe {
+            ArrayView::new_(ptr, Ix1(self.inner_len), Ix1(self.inner_stride as Ix))
+        })
+    }
+}
+
 // NOTE: LanesIterMut is a mutable iterator and must not expose aliasing
 // pointers. Due to this we use an empty slice for the raw data (it's unused
 // anyway).
@@ -769,6 +778,15 @@ where
 {
     fn len(&self) -> usize {
         self.iter.len()
+    }
+}
+
+impl<'a, A> DoubleEndedIterator for LanesIterMut<'a, A, Ix1>
+{
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.iter.next_back().map(|ptr| unsafe {
+            ArrayViewMut::new_(ptr, Ix1(self.inner_len), Ix1(self.inner_stride as Ix))
+        })
     }
 }
 

--- a/tests/iterators.rs
+++ b/tests/iterators.rs
@@ -40,6 +40,22 @@ fn double_ended() {
 }
 
 #[test]
+fn double_ended_rows() {
+    let a = ArcArray::from_iter(0..8).into_shape_clone((4, 2)).unwrap();
+    let mut row_it = a.rows().into_iter();
+    assert_equal(row_it.next_back().unwrap(), &[6, 7]);
+    assert_equal(row_it.next().unwrap(), &[0, 1]);
+    assert_equal(row_it.next_back().unwrap(), &[4, 5]);
+    assert_equal(row_it.next_back().unwrap(), &[2, 3]);
+    assert!(row_it.next().is_none());
+    assert!(row_it.next_back().is_none());
+
+    for (row, check) in a.rows().into_iter().rev().zip(&[[6, 7], [4, 5], [2, 3], [0, 1]]) {
+        assert_equal(row, check);
+    }
+}
+
+#[test]
 fn iter_size_hint() {
     // Check that the size hint is correctly computed
     let a = ArcArray::from_iter(0..24).into_shape_with_order((2, 3, 4)).unwrap();


### PR DESCRIPTION
In a project I wanted to iterate over the rows and columns of a 2d array in reverse but while `rows` and `columns` exist, the resulting `LanesIter` does not implement `DoubleEndedIterator` as of yet. It is possible to use indexing via `row` with reversed indices but that is less ergonomic.

This PR fixes this at least for 1d `LanesIter` and now allows one to do:
```
let a = ArcArray::from_iter(0..8).reshape((4, 2));
for (row, check) in a.rows().into_iter().rev().zip(&[[6, 7], [4, 5], [2, 3], [0, 1]]) {
    assert_equal(row, check);
}
```

The implementation just delegates to the underlying 1d `Baseiter` which implements `DoubleEndedIterator`.
The trait is not implemented for higher dimensions however, which would need some additional work.