### PR TITLE
fix workaround false positive clippy lint `reversed_empty_ranges`

### DIFF
--- a/src/slice.rs
+++ b/src/slice.rs
@@ -867,12 +867,17 @@ macro_rules! s(
         )
     };
     ($($t:tt)*) => {
-        $crate::s![@parse
-              ::core::marker::PhantomData::<$crate::Ix0>,
-              ::core::marker::PhantomData::<$crate::Ix0>,
-              []
-              $($t)*
-        ]
+        {
+            #[allow(clippy::reversed_empty_ranges)]
+            {
+                $crate::s![@parse
+                    ::core::marker::PhantomData::<$crate::Ix0>,
+                    ::core::marker::PhantomData::<$crate::Ix0>,
+                    []
+                    $($t)*
+                ]
+            }
+        }
     };
 );
 


### PR DESCRIPTION
As the `rust-clippy` issue https://github.com/rust-lang/rust-clippy/issues/5808 doesn't seam to make much progress I propose to just `allow` the lint for `s![]` macro invocations for now.

The `let = ...` is necessary, because attributes are not allowed on expressions
currently (https://github.com/rust-lang/rust/issues/15701).
