### PR TITLE
Add both approx features to the readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -83,6 +83,14 @@ your `Cargo.toml`.
   - Enables parallel iterators, parallelized methods and ``par_azip!``.
   - Implies std
 
+- ``approx``
+
+  - Implementations of traits from version 0.4 of the [`approx`] crate.
+
+- ``approx-0_5``
+
+  - Implementations of traits from version 0.5 of the [`approx`] crate.
+
 - ``blas``
 
   - Enable transparent BLAS support for matrix multiplication.


### PR DESCRIPTION
`approx` and `approx-0_5` are missing from the readme. They were already present in the [doc](https://docs.rs/ndarray/latest/ndarray/#crate-feature-flags).

This being said, I wonder if the readme should simply link to the documentation instead of having the information in 2 places?

Fixes #789