### PR TITLE
Fix comparison of slicing with negative step in `ndarray` with that i…

### DIFF
--- a/src/doc/ndarray_for_numpy_users/mod.rs
+++ b/src/doc/ndarray_for_numpy_users/mod.rs
@@ -111,8 +111,8 @@
 //! When slicing in `ndarray`, the axis is first sliced with `start..end`. Then if
 //! `step` is positive, the first index is the front of the slice; if `step` is
 //! negative, the first index is the back of the slice. This means that the
-//! behavior is the same as NumPy except when `step < -1`. See the docs for the
-//! [`s![]` macro][s!] for more details.
+//! behavior is the same as in NumPy when `step` is positive, but different when
+//! `step` is negative. See the docs for the [`s![]` macro][s!] for more details.
 //!
 //! </td>
 //! </tr>
@@ -246,8 +246,8 @@
 //!   methods [`.slice_mut()`][.slice_mut()], [`.slice_move()`][.slice_move()], and
 //!   [`.slice_collapse()`][.slice_collapse()].
 //!
-//! * The behavior of slicing is slightly different from NumPy for slices with
-//!   `step < -1`. See the docs for the [`s![]` macro][s!] for more details.
+//! * The behavior of slicing is different from that in NumPy for slices with
+//!   `step < 0`. See the docs for the [`s![]` macro][s!] for more details.
 //!
 //! NumPy | `ndarray` | Notes
 //! ------|-----------|------


### PR DESCRIPTION
…n NumPy

The existing text implies that `ndarray` and NumPy behave the same way when `step = -1`. However this is not the case. The behavior of NumPy is illustrated below:

In [1]: import numpy as np
In [2]: x = np.arange(10)
In [3]: print(x[1:5:-1])
[]
In [4]: print(x[5:1:-1])
[5 4 3 2]

The analogous results in `ndarray` would be `array![4, 3, 2, 1]` and `array![]`, respectively.