### PR TITLE
Fix comparison with NumPy of slicing with negative step

### DIFF
--- a/src/doc/ndarray_for_numpy_users/mod.rs
+++ b/src/doc/ndarray_for_numpy_users/mod.rs
@@ -111,7 +111,7 @@
 //! When slicing in `ndarray`, the axis is first sliced with `start..end`. Then if
 //! `step` is positive, the first index is the front of the slice; if `step` is
 //! negative, the first index is the back of the slice. This means that the
-//! behavior is the same as NumPy except when `step < -1`. See the docs for the
+//! behavior is different from NumPy when `step < 0`. See the docs for the
 //! [`s![]` macro][s!] for more details.
 //!
 //! </td>
@@ -246,8 +246,8 @@
 //!   methods [`.slice_mut()`][.slice_mut()], [`.slice_move()`][.slice_move()], and
 //!   [`.slice_collapse()`][.slice_collapse()].
 //!
-//! * The behavior of slicing is slightly different from NumPy for slices with
-//!   `step < -1`. See the docs for the [`s![]` macro][s!] for more details.
+//! * The behavior of slicing is different from NumPy for slices with
+//!   `step < 0`. See the docs for the [`s![]` macro][s!] for more details.
 //!
 //! NumPy | `ndarray` | Notes
 //! ------|-----------|------


### PR DESCRIPTION
The existing documentation states that the behavior of slicing is the same as in NumPy except when `step < -1`, implying that the behavior is the same when `step = -1`. But this is not true:

In [1]: import numpy as np

In [2]: x = np.arange(10)

In [3]: x[2 : 5 : -1]  # Analogous slice in `ndarray`: `array![4, 3, 2]`
Out[3]: array([], dtype=int32)

In [4]: x[5 : 2 : -1]  # Analogous slice in `ndarray`: `array![]`
Out[4]: array([5, 4, 3])

So `step < -1` should be replaced by `step < 0` in the documentation.

There are some further differences in slicing behavior with negative step, having to do with the default values for `start` and `end`:

In [5]: x[: 7 : -1]  # Analogous slice in `ndarray`: `array![6, 5, 4, 3, 2, 1, 0]`
Out[5]: array([9, 8])

In [6]: x[7 : : -1]  # Analogous slice in `ndarray`: `array![9, 8, 7]`
Out[6]: array([7, 6, 5, 4, 3, 2, 1, 0])