### PR TITLE
Make Clippy happy and fix MSRV build

### DIFF
--- a/scripts/all-tests.sh
+++ b/scripts/all-tests.sh
@@ -9,6 +9,10 @@ CHANNEL=$2
 if [ "$CHANNEL" = "1.51.0" ]; then
     cargo update --package rayon --precise 1.5.3
     cargo update --package rayon-core --precise 1.9.3
+    cargo update --package quote --precise 1.0.30
+    cargo update --package proc-macro2 --precise 1.0.65
+    cargo update --package rmp --precise 0.8.11
+    cargo update --package serde_json --precise 1.0.99
     cargo update --package serde --precise 1.0.156
     cargo update --package thiserror --precise 1.0.39
     cargo update --package once_cell --precise 1.14.0

--- a/src/dimension/dimension_trait.rs
+++ b/src/dimension/dimension_trait.rs
@@ -90,7 +90,7 @@ pub trait Dimension:
     fn size_checked(&self) -> Option<usize> {
         self.slice()
             .iter()
-            .fold(Some(1), |s, &a| s.and_then(|s_| s_.checked_mul(a)))
+            .try_fold(1_usize, |s, &a| s.checked_mul(a))
     }
 
     #[doc(hidden)]

--- a/src/zip/ndproducer.rs
+++ b/src/zip/ndproducer.rs
@@ -1,7 +1,7 @@
 use crate::imp_prelude::*;
 use crate::Layout;
 use crate::NdIndex;
-#[cfg(not(features = "std"))]
+#[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
 /// Argument conversion into a producer.


### PR DESCRIPTION
The [`arc_with_non_send_sync`](https://rust-lang.github.io/rust-clippy/master/index.html#arc_with_non_send_sync) issues are already gone on nightly Clippy. So either we wait this out or switch our CI from using beta to nightly Clippy.