### PR TITLE
Fix minimum rust version mismatch in lib.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,7 @@
 //!     needs matching memory layout to be efficient (with some exceptions).
 //!   + Efficient floating point matrix multiplication even for very large
 //!     matrices; can optionally use BLAS to improve it further.
-//! - **Requires Rust 1.49 or later**
+//! - **Requires Rust 1.51 or later**
 //!
 //! ## Crate Feature Flags
 //!


### PR DESCRIPTION
This PR fixes a minimum rust version mismatch between `/Cargo.toml` and `/src/lib.rs`.

### Expected Rust Version
https://github.com/rust-ndarray/ndarray/blob/8d91bc263bce94c9da8d1f205f423f83cb59e7c8/Cargo.toml#L6

Expected: `1.51`.

### Rust Version in `docs.rs`
https://github.com/rust-ndarray/ndarray/blob/8d91bc263bce94c9da8d1f205f423f83cb59e7c8/src/lib.rs#L74

Fixed: `1.49` -> `1.51`
