### PR TITLE
Fix contig check for single element arrays

### DIFF
--- a/src/array_serde.rs
+++ b/src/array_serde.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::fmt;
 use std::marker::PhantomData;
 use alloc::format;
+#[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
 use crate::imp_prelude::*;

--- a/src/arrayformat.rs
+++ b/src/arrayformat.rs
@@ -285,8 +285,9 @@ where
 #[cfg(test)]
 mod formatting_with_omit {
     use itertools::Itertools;
-    use std::fmt;
+    #[cfg(not(feature = "std"))]
     use alloc::string::String;
+    #[cfg(not(feature = "std"))]
     use alloc::vec::Vec;
 
     use super::*;

--- a/src/arraytraits.rs
+++ b/src/arraytraits.rs
@@ -6,9 +6,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[cfg(not(feature = "std"))]
 use alloc::boxed::Box;
+#[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
-use std::iter::IntoIterator;
 use std::mem;
 use std::ops::{Index, IndexMut};
 use std::{hash, mem::size_of};
@@ -115,6 +116,7 @@ where
 
 /// Return `true` if the array shapes and all elements of `self` and
 /// `rhs` are equal. Return `false` otherwise.
+#[allow(clippy::unconditional_recursion)] // false positive
 impl<'a, A, B, S, S2, D> PartialEq<&'a ArrayBase<S2, D>> for ArrayBase<S, D>
 where
     A: PartialEq<B>,
@@ -129,6 +131,7 @@ where
 
 /// Return `true` if the array shapes and all elements of `self` and
 /// `rhs` are equal. Return `false` otherwise.
+#[allow(clippy::unconditional_recursion)] // false positive
 impl<'a, A, B, S, S2, D> PartialEq<ArrayBase<S2, D>> for &'a ArrayBase<S, D>
 where
     A: PartialEq<B>,

--- a/src/data_repr.rs
+++ b/src/data_repr.rs
@@ -2,7 +2,9 @@ use std::mem;
 use std::mem::ManuallyDrop;
 use std::ptr::NonNull;
 use alloc::slice;
+#[cfg(not(feature = "std"))]
 use alloc::borrow::ToOwned;
+#[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 use crate::extension::nonnull;
 

--- a/src/data_traits.rs
+++ b/src/data_traits.rs
@@ -14,6 +14,7 @@ use std::mem::{self, size_of};
 use std::mem::MaybeUninit;
 use std::ptr::NonNull;
 use alloc::sync::Arc;
+#[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
 use crate::{

--- a/src/dimension/axes.rs
+++ b/src/dimension/axes.rs
@@ -143,7 +143,6 @@ where
 
 trait IncOps: Copy {
     fn post_inc(&mut self) -> Self;
-    fn post_dec(&mut self) -> Self;
     fn pre_dec(&mut self) -> Self;
 }
 
@@ -152,12 +151,6 @@ impl IncOps for usize {
     fn post_inc(&mut self) -> Self {
         let x = *self;
         *self += 1;
-        x
-    }
-    #[inline(always)]
-    fn post_dec(&mut self) -> Self {
-        let x = *self;
-        *self -= 1;
         x
     }
     #[inline(always)]

--- a/src/dimension/conversion.rs
+++ b/src/dimension/conversion.rs
@@ -10,6 +10,7 @@
 
 use num_traits::Zero;
 use std::ops::{Index, IndexMut};
+#[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
 use crate::{Dim, Dimension, Ix, Ix1, IxDyn, IxDynImpl};

--- a/src/dimension/dimension_trait.rs
+++ b/src/dimension/dimension_trait.rs
@@ -9,6 +9,7 @@
 use std::fmt::Debug;
 use std::ops::{Add, AddAssign, Mul, MulAssign, Sub, SubAssign};
 use std::ops::{Index, IndexMut};
+#[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
 use super::axes_of;

--- a/src/dimension/dynindeximpl.rs
+++ b/src/dimension/dynindeximpl.rs
@@ -2,7 +2,9 @@ use crate::imp_prelude::*;
 use std::hash::{Hash, Hasher};
 use std::ops::{Deref, DerefMut, Index, IndexMut};
 use alloc::vec;
+#[cfg(not(feature = "std"))]
 use alloc::boxed::Box;
+#[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 const CAP: usize = 4;
 

--- a/src/extension/nonnull.rs
+++ b/src/extension/nonnull.rs
@@ -1,4 +1,5 @@
 use std::ptr::NonNull;
+#[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
 /// Return a NonNull<T> pointer to the vector's data

--- a/src/free_functions.rs
+++ b/src/free_functions.rs
@@ -7,6 +7,7 @@
 // except according to those terms.
 
 use alloc::vec;
+#[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 use std::mem::{forget, size_of};
 

--- a/src/impl_1d.rs
+++ b/src/impl_1d.rs
@@ -7,6 +7,7 @@
 // except according to those terms.
 
 //! Methods for one-dimensional arrays.
+#[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 use std::mem::MaybeUninit;
 

--- a/src/impl_constructors.rs
+++ b/src/impl_constructors.rs
@@ -17,6 +17,7 @@ use num_traits::{One, Zero};
 use std::mem;
 use std::mem::MaybeUninit;
 use alloc::vec;
+#[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
 use crate::dimension;

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -9,6 +9,7 @@
 use std::mem::{size_of, ManuallyDrop};
 use alloc::slice;
 use alloc::vec;
+#[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 use rawpointer::PointerExt;
 

--- a/src/impl_ops.rs
+++ b/src/impl_ops.rs
@@ -288,7 +288,6 @@ mod arithmetic_ops {
     use super::*;
     use crate::imp_prelude::*;
 
-    use num_complex::Complex;
     use std::ops::*;
 
     fn clone_opf<A: Clone, B: Clone, C>(f: impl Fn(A, B) -> C) -> impl FnMut(&A, &B) -> C {

--- a/src/impl_owned_array.rs
+++ b/src/impl_owned_array.rs
@@ -1,4 +1,5 @@
 
+#[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 use std::mem;
 use std::mem::MaybeUninit;

--- a/src/iterators/mod.rs
+++ b/src/iterators/mod.rs
@@ -17,6 +17,7 @@ mod windows;
 use std::iter::FromIterator;
 use std::marker::PhantomData;
 use std::ptr;
+#[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
 use crate::Ix1;

--- a/src/linalg/impl_linalg.rs
+++ b/src/linalg/impl_linalg.rs
@@ -16,6 +16,7 @@ use crate::{LinalgScalar, Zip};
 
 use std::any::TypeId;
 use std::mem::MaybeUninit;
+#[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
 use num_complex::Complex;

--- a/src/numeric/impl_numeric.rs
+++ b/src/numeric/impl_numeric.rs
@@ -8,7 +8,7 @@
 
 #[cfg(feature = "std")]
 use num_traits::Float;
-use num_traits::{self, FromPrimitive, Zero};
+use num_traits::{FromPrimitive, Zero};
 use std::ops::{Add, Div, Mul};
 
 use crate::imp_prelude::*;

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -8,6 +8,7 @@
 use crate::dimension::slices_intersect;
 use crate::error::{ErrorKind, ShapeError};
 use crate::{ArrayViewMut, DimAdd, Dimension, Ix0, Ix1, Ix2, Ix3, Ix4, Ix5, Ix6, IxDyn};
+#[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 use std::convert::TryFrom;
 use std::fmt;

--- a/src/split_at.rs
+++ b/src/split_at.rs
@@ -7,6 +7,7 @@ pub(crate) trait SplitAt  {
 }
 
 pub(crate) trait SplitPreference : SplitAt {
+    #[allow(dead_code)] // used only when Rayon support is enabled
     fn can_split(&self) -> bool;
     fn split_preference(&self) -> (Axis, usize);
     fn split(self) -> (Self, Self) where Self: Sized {

--- a/src/stacking.rs
+++ b/src/stacking.rs
@@ -6,6 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
 use crate::dimension;

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -1958,6 +1958,22 @@ fn test_contiguous() {
 }
 
 #[test]
+fn test_contiguous_single_element()
+{
+    assert_matches!(array![1].as_slice_memory_order(), Some(&[1]));
+
+    let arr1 = array![1, 2, 3];
+    assert_matches!(arr1.slice(s![0..1]).as_slice_memory_order(), Some(&[1]));
+    assert_matches!(arr1.slice(s![1..2]).as_slice_memory_order(), Some(&[2]));
+    assert_matches!(arr1.slice(s![2..3]).as_slice_memory_order(), Some(&[3]));
+    assert_matches!(arr1.slice(s![0..0]).as_slice_memory_order(), Some(&[]));
+
+    let arr2 = array![[1, 2, 3], [4, 5, 6]];
+    assert_matches!(arr2.slice(s![.., 2..3]).as_slice_memory_order(), None);
+    assert_matches!(arr2.slice(s![1, 2..3]).as_slice_memory_order(), Some(&[6]));
+}
+
+#[test]
 fn test_contiguous_neg_strides() {
     let s = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13];
     let a = ArrayView::from_shape((2, 3, 2).strides((1, 4, 2)), &s).unwrap();

--- a/tests/iterators.rs
+++ b/tests/iterators.rs
@@ -6,7 +6,7 @@
 )]
 
 use ndarray::prelude::*;
-use ndarray::{arr3, aview1, indices, s, Axis, Slice, Zip};
+use ndarray::{arr3, indices, s, Slice, Zip};
 
 use itertools::assert_equal;
 use itertools::enumerate;


### PR DESCRIPTION
When an array has 0 or 1 elements, strides don't matter anymore. The general case of this function handled this correctly, but the special case for ndim == 1 did not.

Fixes #1359