### PR TITLE
Further ci updates - numeric tests, and run all tests on PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,7 @@ jobs:
       matrix:
         rust:
           - beta
+    name: clippy/${{ matrix.rust }}
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
@@ -26,7 +27,6 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo clippy --features docs
   tests:
-    if: ${{ github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,7 +54,7 @@ jobs:
       matrix:
         include:
           - rust: stable
-            target: powerpc-unknown-linux-gnu
+            target: s390x-unknown-linux-gnu
           - rust: stable
             target: i686-unknown-linux-gnu
 

--- a/scripts/cross-tests.sh
+++ b/scripts/cross-tests.sh
@@ -11,4 +11,4 @@ cross build -v --features="$FEATURES" --target=$TARGET
 cross test -v --no-fail-fast --features="$FEATURES" --target=$TARGET
 cross test -v --no-fail-fast --target=$TARGET --manifest-path=ndarray-rand/Cargo.toml --features quickcheck
 cross test -v --no-fail-fast --target=$TARGET --manifest-path=xtest-serialization/Cargo.toml --verbose
-cross test -v --no-fail-fast --target=$TARGET --manifest-path=xtest-numeric/Cargo.toml
+cross test -v --no-fail-fast --target=$TARGET --manifest-path=xtest-numeric/Cargo.toml --release


### PR DESCRIPTION
Somehow, numeric test take 30m on powerpc, which is too slow (much slower than anything else.)
Now use s390x instead for big endian coverage, and release mode, which seems to use 15 minutes.

All the regular tests move back to PR checks to give contributors feedback on their PRs. It is more productive if contributors get access to the Rust 1.51 buildbot results immediately themselves.