### PR TITLE
Add rustfmt commit to ignored revisions for git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# rustfmt codebase (gh-1375)
+d07f5f33800e5240e7edb02bdbc4815ab30ef37e


### PR DESCRIPTION
This will automatically ignore the commit through GitHub's blame interface, addressing @nilgoyette's concern in gh-1292.

cc @bluss 