### PR TITLE
Update to Approx 0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,7 @@ num-complex = { version = "0.4", default-features = false }
 # Use via the `rayon` crate feature!
 rayon_ = { version = "1.0.3", optional = true, package = "rayon" }
 
-approx = { version = "0.4", optional = true , default-features = false }
-approx-0_5 = { package = "approx", version = "0.5", optional = true , default-features = false }
+approx = { version = "0.5", optional = true , default-features = false }
 
 # Use via the `blas` crate feature!
 cblas-sys = { version = "0.1.4", optional = true, default-features = false }
@@ -49,7 +48,7 @@ rawpointer = { version = "0.2" }
 [dev-dependencies]
 defmac = "0.2"
 quickcheck = { version = "1.0", default-features = false }
-approx = "0.4"
+approx = "0.5"
 itertools = { version = "0.10.0", default-features = false, features = ["use_std"] }
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ serde-1 = ["serde"]
 test = []
 
 # This feature is used for docs
-docs = ["approx", "approx-0_5", "serde", "rayon"]
+docs = ["approx", "serde", "rayon"]
 
 std = ["num-traits/std", "matrixmultiply/std"]
 rayon = ["rayon_", "std"]

--- a/README.rst
+++ b/README.rst
@@ -85,10 +85,6 @@ your `Cargo.toml`.
 
 - ``approx``
 
-  - Implementations of traits from version 0.4 of the [`approx`] crate.
-
-- ``approx-0_5``
-
   - Implementations of traits from version 0.5 of the [`approx`] crate.
 
 - ``blas``

--- a/src/array_approx.rs
+++ b/src/array_approx.rs
@@ -193,6 +193,3 @@ macro_rules! impl_approx_traits {
 
 #[cfg(feature = "approx")]
 impl_approx_traits!(approx, "**Requires crate feature `\"approx\"`.**");
-
-#[cfg(feature = "approx-0_5")]
-impl_approx_traits!(approx_0_5, "**Requires crate feature `\"approx-0_5\"`.**");

--- a/src/doc/crate_feature_flags.rs
+++ b/src/doc/crate_feature_flags.rs
@@ -19,10 +19,7 @@
 //!   - Implies std
 //!
 //! ## `approx`
-//!   - Enables implementations of traits from version 0.4 of the [`approx`] crate.
-//!
-//! ## `approx-0_5`
-//!   - Enables implementations of traits from version 0.5 of the [`approx`] crate.
+//!   - Enables implementations of traits of the [`approx`] crate.
 //!
 //! ## `blas`
 //!   - Enable transparent BLAS support for matrix multiplication.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,8 +81,7 @@
 //! - `std`: Rust standard library-using functionality (enabled by default)
 //! - `serde`: serialization support for serde 1.x
 //! - `rayon`: Parallel iterators, parallelized methods, the [`parallel`] module and [`par_azip!`].
-//! - `approx` Implementations of traits from version 0.4 of the [`approx`] crate.
-//! - `approx-0_5`: Implementations of traits from version 0.5 of the [`approx`] crate.
+//! - `approx` Implementations of traits from the [`approx`] crate.
 //! - `blas`: transparent BLAS support for matrix multiplication, needs configuration.
 //! - `matrixmultiply-threading`: Use threading from `matrixmultiply`.
 //!
@@ -1600,7 +1599,7 @@ pub mod linalg;
 mod impl_ops;
 pub use crate::impl_ops::ScalarOperand;
 
-#[cfg(any(feature = "approx", feature = "approx-0_5"))]
+#[cfg(feature = "approx")]
 mod array_approx;
 
 // Array view methods

--- a/xtest-blas/Cargo.toml
+++ b/xtest-blas/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 test = false
 
 [dev-dependencies]
-approx = "0.4"
+approx = "0.5"
 defmac = "0.2"
 num-traits = "0.2"
 num-complex = { version = "0.4", default-features = false }

--- a/xtest-numeric/Cargo.toml
+++ b/xtest-numeric/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
-approx = "0.4"
+approx = "0.5"
 ndarray = { path = "..", features = ["approx"] }
 ndarray-rand = { path = "../ndarray-rand" }
 rand_distr = "0.4"


### PR DESCRIPTION
Old approx-0_5 feature is removed, the approx feature points to approx 0.5

Uses and supersedes #1063. Closes #1063