### PR TITLE
Make compatible with thumbv6m-none-eabi

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,6 +42,27 @@ jobs:
           components: rustfmt
       - run: cargo fmt --all --check
 
+  nostd-build:
+    runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental }}
+    strategy:
+      matrix:
+        include:
+          - rust: stable
+            experimental: false
+            target: thumbv6m-none-eabi
+
+    name: nostd-build/${{ matrix.target }}/${{ matrix.rust }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ matrix.rust }}
+          targets: ${{ matrix.target }}
+      - name: Tests
+        run: |
+          cargo rustc "--target=${{ matrix.target }}" --no-default-features --features portable-atomic-critical-section
+
   tests:
     runs-on: ubuntu-latest
     strategy:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ matrixmultiply = { version = "0.3.2", default-features = false, features=["cgemm
 serde = { version = "1.0", optional = true, default-features = false, features = ["alloc"] }
 rawpointer = { version = "0.2" }
 
+
 [dev-dependencies]
 defmac = "0.2"
 quickcheck = { version = "1.0", default-features = false }
@@ -70,7 +71,13 @@ docs = ["approx", "serde", "rayon"]
 std = ["num-traits/std", "matrixmultiply/std"]
 rayon = ["dep:rayon", "std"]
 
+portable-atomic-critical-section = ["portable-atomic/critical-section"]
+
 matrixmultiply-threading = ["matrixmultiply/threading"]
+
+[target.'cfg(not(target_has_atomic = "ptr"))'.dependencies]
+portable-atomic = { version = "1.6.0" }
+portable-atomic-util = { version = "0.2.0", features = [ "alloc" ] }
 
 [profile.bench]
 debug = true

--- a/README.rst
+++ b/README.rst
@@ -97,6 +97,10 @@ your `Cargo.toml`.
 
   - Enable the ``threading`` feature in the matrixmultiply package
 
+- ``portable-atomic-critical-section``
+
+  - Whether ``portable-atomic`` should use ``critical-section``
+
 How to use with cargo
 ---------------------
 

--- a/src/data_traits.rs
+++ b/src/data_traits.rs
@@ -11,7 +11,12 @@
 #[allow(unused_imports)]
 use rawpointer::PointerExt;
 
+#[cfg(target_has_atomic = "ptr")]
 use alloc::sync::Arc;
+
+#[cfg(not(target_has_atomic = "ptr"))]
+use portable_atomic_util::Arc;
+
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 use std::mem::MaybeUninit;

--- a/src/impl_arc_array.rs
+++ b/src/impl_arc_array.rs
@@ -7,7 +7,12 @@
 // except according to those terms.
 
 use crate::imp_prelude::*;
+
+#[cfg(target_has_atomic = "ptr")]
 use alloc::sync::Arc;
+
+#[cfg(not(target_has_atomic = "ptr"))]
+use portable_atomic_util::Arc;
 
 /// Methods specific to `ArcArray`.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,7 +123,12 @@ extern crate cblas_sys;
 #[cfg(feature = "docs")]
 pub mod doc;
 
+#[cfg(target_has_atomic = "ptr")]
 use alloc::sync::Arc;
+
+#[cfg(not(target_has_atomic = "ptr"))]
+use portable_atomic_util::Arc;
+
 use std::marker::PhantomData;
 
 pub use crate::dimension::dim::*;


### PR DESCRIPTION
### Changes
Add the crates `portable-atomic` and `portable-atomic-util` to make the Arc used in the code compatible with the `thumbv6m-none-eabi` target. Also note that this change will probably make `ndarray` work on more targets than just the `thumbv6m-none-eabi` target.

### Considerations
Those two crates are imported from a GitHub revision. It might be best to wait for an official release to crates.io, but I'm not sure if that's important.

This has also been tested and confirmed to work on a Raspberry Pi Pico.