### PR TITLE
Add generic initializers for statically-dimensioned array types

### DIFF
--- a/src/aliases.rs
+++ b/src/aliases.rs
@@ -4,6 +4,13 @@
 use crate::dimension::Dim;
 use crate::{ArcArray, Array, ArrayView, ArrayViewMut, Ix, IxDynImpl};
 
+/// Create a static-dimensional index
+#[allow(non_snake_case)]
+#[inline(always)]
+pub fn IxD<const D: usize>(ix: [Ix; D]) -> IxD<D>
+{
+    Dim::new(ix)
+}
 /// Create a zero-dimensional index
 #[allow(non_snake_case)]
 #[inline(always)]
@@ -62,23 +69,19 @@ pub fn IxDyn(ix: &[Ix]) -> IxDyn
     Dim(ix)
 }
 
-/// Create a static-dimensional index
-#[allow(non_snake_case)]
-#[inline(always)]
-pub fn IxD<const D: usize>(ix: [Ix; D]) -> IxD<D> {
-    Dim::new(ix)
-}
-
-impl<const D: usize> IxD<D> {
+impl<const D: usize> IxD<D>
+{
     /// Create a static-dimensional index, repeating a single index value
-    #[allow(non_snake_case)]
     #[inline(always)]
     pub fn repeating(i: Ix) -> Self {
         Dim::new([i; D])
     }
 }
 
-
+/// static-dimensional
+///
+/// Static generic to create arrays of any supported dimensionality (up to 6)
+pub type IxD<const D: usize> = Dim<[Ix; D]>;
 /// zero-dimensionial
 pub type Ix0 = Dim<[Ix; 0]>;
 /// one-dimensional
@@ -122,10 +125,6 @@ pub type Ix6 = Dim<[Ix; 6]>;
 /// let arrays = vec![a, b];
 /// ```
 pub type IxDyn = Dim<IxDynImpl>;
-/// static-dimensional
-/// 
-/// Static generic to create arrays of any dimensionality up to 6
-pub type IxD<const D: usize> = Dim<[Ix; D]>;
 
 /// zero-dimensional array
 pub type Array0<A> = Array<A, Ix0>;

--- a/src/aliases.rs
+++ b/src/aliases.rs
@@ -62,6 +62,23 @@ pub fn IxDyn(ix: &[Ix]) -> IxDyn
     Dim(ix)
 }
 
+/// Create a static-dimensional index
+#[allow(non_snake_case)]
+#[inline(always)]
+pub fn IxD<const D: usize>(ix: [Ix; D]) -> IxD<D> {
+    Dim::new(ix)
+}
+
+impl<const D: usize> IxD<D> {
+    /// Create a static-dimensional index, repeating a single index value
+    #[allow(non_snake_case)]
+    #[inline(always)]
+    pub fn repeating(i: Ix) -> Self {
+        Dim::new([i; D])
+    }
+}
+
+
 /// zero-dimensionial
 pub type Ix0 = Dim<[Ix; 0]>;
 /// one-dimensional
@@ -105,6 +122,10 @@ pub type Ix6 = Dim<[Ix; 6]>;
 /// let arrays = vec![a, b];
 /// ```
 pub type IxDyn = Dim<IxDynImpl>;
+/// static-dimensional
+/// 
+/// Static generic to create arrays of any dimensionality up to 6
+pub type IxD<const D: usize> = Dim<[Ix; D]>;
 
 /// zero-dimensional array
 pub type Array0<A> = Array<A, Ix0>;

--- a/src/dimension/broadcast.rs
+++ b/src/dimension/broadcast.rs
@@ -1,5 +1,5 @@
 use crate::error::*;
-use crate::{Dimension, Ix0, Ix1, Ix2, Ix3, Ix4, Ix5, Ix6, IxDyn};
+use crate::{Dimension, IxD, Ix0, Ix1, Ix2, Ix3, Ix4, Ix5, Ix6, IxDyn};
 
 /// Calculate the common shape for a pair of array shapes, that they can be broadcasted
 /// to. Return an error if the shapes are not compatible.
@@ -48,6 +48,20 @@ impl<D: Dimension> DimMax<D> for D
     type Output = D;
 }
 
+/// Any static type dimension can be broadcast to a dynamic dimension
+impl<const D: usize> DimMax<IxDyn> for IxD<D>
+where IxD<D>: Dimension
+{
+    type Output = IxDyn;
+}
+
+/// Any static type dimension can be broadcast to a dynamic dimension
+impl<const D: usize> DimMax<IxD<D>> for IxDyn
+where IxD<D>: Dimension
+{
+    type Output = IxDyn;
+}
+
 macro_rules! impl_broadcast_distinct_fixed {
     ($smaller:ty, $larger:ty) => {
         impl DimMax<$larger> for $smaller {
@@ -81,13 +95,6 @@ impl_broadcast_distinct_fixed!(Ix3, Ix6);
 impl_broadcast_distinct_fixed!(Ix4, Ix5);
 impl_broadcast_distinct_fixed!(Ix4, Ix6);
 impl_broadcast_distinct_fixed!(Ix5, Ix6);
-impl_broadcast_distinct_fixed!(Ix0, IxDyn);
-impl_broadcast_distinct_fixed!(Ix1, IxDyn);
-impl_broadcast_distinct_fixed!(Ix2, IxDyn);
-impl_broadcast_distinct_fixed!(Ix3, IxDyn);
-impl_broadcast_distinct_fixed!(Ix4, IxDyn);
-impl_broadcast_distinct_fixed!(Ix5, IxDyn);
-impl_broadcast_distinct_fixed!(Ix6, IxDyn);
 
 #[cfg(test)]
 #[cfg(feature = "std")]

--- a/src/dimension/conversion.rs
+++ b/src/dimension/conversion.rs
@@ -13,7 +13,7 @@ use alloc::vec::Vec;
 use num_traits::Zero;
 use std::ops::{Index, IndexMut};
 
-use crate::{Dim, Dimension, Ix, Ix1, IxD, IxDyn, IxDynImpl};
+use crate::{Dim, Dimension, Ix, Ix1, IxDyn, IxDynImpl};
 
 /// $m: macro callback
 /// $m is called with $arg and then the indices corresponding to the size argument
@@ -88,39 +88,48 @@ impl IntoDimension for Vec<Ix>
 }
 
 impl<const D: usize> IntoDimension for [Ix; D]
-where Dim<[Ix; D]> : Dimension {
+where Dim<[Ix; D]> : Dimension
+{
     type Dim = Dim<[Ix; D]>;
     #[inline(always)]
-    fn into_dimension(self) -> Self::Dim {
+    fn into_dimension(self) -> Self::Dim
+    {
         Dim::new(self)
     }
 }
 
 impl<const D: usize> Index<usize> for Dim<[Ix; D]>
-where Dim<[Ix; D]>: Dimension {
+where Dim<[Ix; D]>: Dimension
+{
     type Output = usize;
     #[inline(always)]
-    fn index(&self, index: usize) -> &Self::Output {
+    fn index(&self, index: usize) -> &Self::Output
+    {
         &self.ix()[index]
     }
 }
 
 impl<const D: usize> IndexMut<usize> for Dim<[Ix; D]>
-where Dim<[Ix; D]>: Dimension {
+where Dim<[Ix; D]>: Dimension
+{
     #[inline(always)]
-    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output
+    {
         &mut self.ixm()[index]
     }
 }
 
 impl<const D: usize> Zero for Dim<[Ix; D]>
-where Dim<[Ix; D]>: Dimension {
+where Dim<[Ix; D]>: Dimension
+{
     #[inline]
-    fn zero() -> Self {
-        IxD::repeating(0)
+    fn zero() -> Self
+    {
+        Self::repeating(0)
     }
 
-    fn is_zero(&self) -> bool {
+    fn is_zero(&self) -> bool
+    {
         self.slice().iter().all(|x| *x == 0)
     }
 }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -42,7 +42,7 @@ pub use crate::{
 };
 
 #[doc(no_inline)]
-pub use crate::{Ix0, Ix1, Ix2, Ix3, Ix4, Ix5, Ix6, IxDyn};
+pub use crate::{IxD, Ix0, Ix1, Ix2, Ix3, Ix4, Ix5, Ix6, IxDyn};
 
 #[doc(no_inline)]
 pub use crate::{arr0, arr1, arr2, aview0, aview1, aview2, aview_mut1};

--- a/tests/ixd.rs
+++ b/tests/ixd.rs
@@ -1,0 +1,36 @@
+#![allow(
+    clippy::many_single_char_names, clippy::deref_addrof, clippy::unreadable_literal, clippy::many_single_char_names,
+    clippy::float_cmp
+)]
+
+use ndarray::Array;
+use ndarray::IxD;
+use ndarray::Ix2;
+
+#[test]
+fn test_ixd()
+{
+    // Check that IxD creats a static index based on the provided array size
+    let mut a = Array::zeros(IxD([2, 3]));
+    assert_eq!(a.raw_dim(), Ix2(2, 3));
+
+    assert_eq!(a[(1, 1)], 0.);
+
+    a[(1, 1)] = 3.;
+    assert_eq!(a[(1, 1)], 3.);
+
+    // Wrong index dimension is caught by the type checker
+    // a[(1, 1, 1)] = 4.;
+}
+
+#[test]
+fn test_ixd_repeating()
+{
+    // Check that repeating creates an array of a specified dimension
+    let mut a = Array::zeros(IxD::<2>::repeating(2));
+    assert_eq!(a.raw_dim(), Ix2(2, 2));
+
+    a[(1, 1)] = 2.;
+    assert_eq!(a[(1, 1)], 2.);
+}
+


### PR DESCRIPTION
This takes advantage of const generics to provide general initializers for the statically-dimensioned array types. (2-6 dimensions, with the current implementations). This reduces the reliance on macros for array initialization, and enables other crates to operate more succinctly when working with an unknown-dimension static array type. I'm unsure how well this fits with the existence of the dynamic array index implementation, and the name of the new type alias `IxD` is open for discussion. No additional test cases have been implemented for this functionality yet.