### PR TITLE
Use the stable toolchain to run clippy

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - beta
+          - stable
     name: clippy/${{ matrix.rust }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
As discussed in #1396 