### PR TITLE
Increase MSRV to Rust 1.64 and bump some internal dependencies

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,7 +50,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.57.0  # MSRV
+          - 1.64.0  # MSRV
 
     name: tests/${{ matrix.rust }}
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ rawpointer = { version = "0.2" }
 defmac = "0.2"
 quickcheck = { version = "1.0", default-features = false }
 approx = "0.5"
-itertools = { version = "0.10.0", default-features = false, features = ["use_std"] }
+itertools = { version = "0.13.0", default-features = false, features = ["use_std"] }
 
 [features]
 default = ["std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 name = "ndarray"
 version = "0.15.6"
 edition = "2018"
-rust-version = "1.57"
+rust-version = "1.64"
 authors = [
   "Ulrik Sverdrup \"bluss\"",
   "Jim Turner"

--- a/scripts/all-tests.sh
+++ b/scripts/all-tests.sh
@@ -6,25 +6,6 @@ set -e
 FEATURES=$1
 CHANNEL=$2
 
-if [ "$CHANNEL" = "1.57.0" ]; then
-    cargo update --package openblas-src --precise 0.10.5
-    cargo update --package openblas-build --precise 0.10.5
-    cargo update --package once_cell --precise 1.14.0
-    cargo update --package byteorder --precise 1.4.3
-    cargo update --package rayon --precise 1.5.3
-    cargo update --package rayon-core --precise 1.9.3
-    cargo update --package crossbeam-channel --precise 0.5.8
-    cargo update --package crossbeam-deque --precise 0.8.3
-    cargo update --package crossbeam-epoch --precise 0.9.15
-    cargo update --package crossbeam-utils --precise 0.8.16
-    cargo update --package rmp --precise 0.8.11
-    cargo update --package serde_json --precise 1.0.99
-    cargo update --package serde --precise 1.0.156
-    cargo update --package thiserror --precise 1.0.39
-    cargo update --package quote --precise 1.0.30
-    cargo update --package proc-macro2 --precise 1.0.65
-fi
-
 cargo build --verbose --no-default-features
 # Testing both dev and release profiles helps find bugs, especially in low level code
 cargo test --verbose --no-default-features

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -2623,7 +2623,7 @@ where
         let dim = self.raw_dim();
         Zip::from(LanesMut::new(self.view_mut(), Axis(n - 1)))
             .and(Lanes::new(rhs.broadcast_assume(dim), Axis(n - 1)))
-            .for_each(move |s_row, r_row| Zip::from(s_row).and(r_row).for_each(|a, b| f(a, b)));
+            .for_each(move |s_row, r_row| Zip::from(s_row).and(r_row).for_each(&mut f));
     }
 
     fn zip_mut_with_elem<B, F>(&mut self, rhs_elem: &B, mut f: F)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,8 @@
 //!     needs matching memory layout to be efficient (with some exceptions).
 //!   + Efficient floating point matrix multiplication even for very large
 //!     matrices; can optionally use BLAS to improve it further.
-//! - **Requires Rust 1.57 or later**
+//!
+//! - **MSRV: Requires Rust 1.64 or later**
 //!
 //! ## Crate Feature Flags
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,13 +10,10 @@
 #![doc(html_logo_url = "https://rust-ndarray.github.io/images/rust-ndarray_logo.svg")]
 #![allow(
     unstable_name_collisions, // our `PointerExt` collides with upcoming inherent methods on `NonNull`
-    clippy::many_single_char_names,
     clippy::deref_addrof,
-    clippy::unreadable_literal,
     clippy::manual_map, // is not an error
     clippy::while_let_on_iterator, // is not an error
     clippy::from_iter_instead_of_collect, // using from_iter is good style
-    clippy::redundant_closure, // false positives clippy #7812
     clippy::incompatible_msrv, // false positive PointerExt::offset
 )]
 #![doc(test(attr(deny(warnings))))]

--- a/src/linalg/impl_linalg.rs
+++ b/src/linalg/impl_linalg.rs
@@ -823,11 +823,11 @@ where
     if !same_type::<A, S::Elem>() {
         return false;
     }
-    if a.len() > blas_index::max_value() as usize {
+    if a.len() > blas_index::MAX as usize {
         return false;
     }
     let stride = a.strides()[0];
-    if stride == 0 || stride > blas_index::max_value() as isize || stride < blas_index::min_value() as isize {
+    if stride == 0 || stride > blas_index::MAX as isize || stride < blas_index::MIN as isize {
         return false;
     }
     true
@@ -882,12 +882,12 @@ fn is_blas_2d(dim: &Ix2, stride: &Ix2, order: MemoryOrder) -> bool
     if s0 < 1 || s1 < 1 {
         return false;
     }
-    if (s0 > blas_index::max_value() as isize || s0 < blas_index::min_value() as isize)
-        || (s1 > blas_index::max_value() as isize || s1 < blas_index::min_value() as isize)
+    if (s0 > blas_index::MAX as isize || s0 < blas_index::MIN as isize)
+        || (s1 > blas_index::MAX as isize || s1 < blas_index::MIN as isize)
     {
         return false;
     }
-    if m > blas_index::max_value() as usize || n > blas_index::max_value() as usize {
+    if m > blas_index::MAX as usize || n > blas_index::MAX as usize {
         return false;
     }
     true

--- a/xtest-blas/Cargo.toml
+++ b/xtest-blas/Cargo.toml
@@ -3,6 +3,7 @@ name = "blas-tests"
 version = "0.1.0"
 authors = ["bluss"]
 publish = false
+edition = "2018"
 
 [lib]
 test = false
@@ -16,7 +17,7 @@ num-complex = { version = "0.4", default-features = false }
 [dependencies]
 ndarray = { path = "..", features = ["approx", "blas"] }
 
-blas-src = { version = "0.8", optional = true }
+blas-src = { version = "0.10", optional = true }
 
 openblas-src = { version = "0.10", optional = true }
 netlib-src = { version = "0.8", optional = true }

--- a/xtest-numeric/Cargo.toml
+++ b/xtest-numeric/Cargo.toml
@@ -11,7 +11,7 @@ ndarray = { path = "..", features = ["approx"] }
 ndarray-rand = { path = "../ndarray-rand" }
 rand_distr = "0.4"
 
-blas-src = { optional = true, version = "0.8", default-features = false, features = ["openblas"] }
+blas-src = { optional = true, version = "0.10", default-features = false, features = ["openblas"] }
 openblas-src = { optional = true, version = "0.10", default-features = false, features = ["cblas", "system"] }
 
 [dependencies.rand]

--- a/xtest-serialization/Cargo.toml
+++ b/xtest-serialization/Cargo.toml
@@ -3,6 +3,7 @@ name = "serialization-tests"
 version = "0.1.0"
 authors = ["bluss"]
 publish = false
+edition = "2018"
 
 [lib]
 test = false

--- a/xtest-serialization/Cargo.toml
+++ b/xtest-serialization/Cargo.toml
@@ -20,9 +20,14 @@ default-features = false
 [dev-dependencies.serde_json]
 version = "1.0.40"
 
+[dev-dependencies.rmp]
+# Old version to work with Rust 1.64+
+version = "=0.8.10"
+
 [dev-dependencies.rmp-serde]
-version = "0.14.0"
+# Old version to work with Rust 1.64+
+version = "0.14"
 
 [dependencies.ron]
-version = "0.5.1"
+version = "0.8.1"
 optional = true


### PR DESCRIPTION
To Prepare for 0.16. Using Rust 1.64 as MSRV is still quite careful I think.


PyO3 is 1.63. But we need the workspace = true feature for sane organization, which is Rust 1.64.