### PR TITLE
Update to use dep: for features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,12 +31,11 @@ num-integer = { version = "0.1.39", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 num-complex = { version = "0.4", default-features = false }
 
-# Use via the `rayon` crate feature!
-rayon_ = { version = "1.0.3", optional = true, package = "rayon" }
+rayon = { version = "1.10.0", optional = true }
 
 approx = { version = "0.5", optional = true , default-features = false }
 
-# Use via the `blas` crate feature!
+# Use via the `blas` crate feature
 cblas-sys = { version = "0.1.4", optional = true, default-features = false }
 libc = { version = "0.2.82", optional = true }
 
@@ -56,10 +55,11 @@ default = ["std"]
 
 # Enable blas usage
 # See README for more instructions
-blas = ["cblas-sys", "libc"]
+blas = ["dep:cblas-sys", "dep:libc"]
 
+serde = ["dep:serde"]
 # Old name for the serde feature
-serde-1 = ["serde"]
+serde-1 = ["dep:serde"]
 
 # These features are used for testing
 test = []
@@ -68,7 +68,7 @@ test = []
 docs = ["approx", "serde", "rayon"]
 
 std = ["num-traits/std", "matrixmultiply/std"]
-rayon = ["rayon_", "std"]
+rayon = ["dep:rayon", "std"]
 
 matrixmultiply-threading = ["matrixmultiply/threading"]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1583,8 +1583,6 @@ where
 
 // parallel methods
 #[cfg(feature = "rayon")]
-extern crate rayon_ as rayon;
-#[cfg(feature = "rayon")]
 pub mod parallel;
 
 mod impl_1d;


### PR DESCRIPTION
From Rust 1.60, now we can use this to bring order to the rayon situation (previously renamed to rayon_).