### PR TITLE
Organize dependencies with workspace = true (cont.)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,13 +27,12 @@ bench = false
 test = true
 
 [dependencies]
-num-integer = { version = "0.1.39", default-features = false }
-num-traits = { version = "0.2", default-features = false }
-num-complex = { version = "0.4", default-features = false }
+num-integer = { workspace = true }
+num-traits = { workspace = true }
+num-complex = { workspace = true }
 
+approx = { workspace = true, optional = true }
 rayon = { version = "1.10.0", optional = true }
-
-approx = { version = "0.5", optional = true , default-features = false }
 
 # Use via the `blas` crate feature
 cblas-sys = { version = "0.1.4", optional = true, default-features = false }
@@ -44,11 +43,10 @@ matrixmultiply = { version = "0.3.2", default-features = false, features=["cgemm
 serde = { version = "1.0", optional = true, default-features = false, features = ["alloc"] }
 rawpointer = { version = "0.2" }
 
-
 [dev-dependencies]
 defmac = "0.2"
-quickcheck = { version = "1.0", default-features = false }
-approx = "0.5"
+quickcheck = { workspace = true }
+approx = { workspace = true, default-features = true }
 itertools = { version = "0.13.0", default-features = false, features = ["use_std"] }
 
 [features]
@@ -71,20 +69,13 @@ docs = ["approx", "serde", "rayon"]
 std = ["num-traits/std", "matrixmultiply/std"]
 rayon = ["dep:rayon", "std"]
 
-portable-atomic-critical-section = ["portable-atomic/critical-section"]
-
 matrixmultiply-threading = ["matrixmultiply/threading"]
+
+portable-atomic-critical-section = ["portable-atomic/critical-section"]
 
 [target.'cfg(not(target_has_atomic = "ptr"))'.dependencies]
 portable-atomic = { version = "1.6.0" }
 portable-atomic-util = { version = "0.2.0", features = [ "alloc" ] }
-
-[profile.bench]
-debug = true
-[profile.dev.package.numeric-tests]
-opt-level = 2
-[profile.test.package.numeric-tests]
-opt-level = 2
 
 [workspace]
 members = [
@@ -95,10 +86,24 @@ members = [
 ]
 
 [workspace.dependencies]
-ndarray = { path = "." }
+ndarray = { version = "0.15", path = "." }
+ndarray-rand = { path = "ndarray-rand" }
+
+num-integer = { version = "0.1.39", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 num-complex = { version = "0.4", default-features = false }
-ndarray-rand = { path = "./ndarray-rand" }
+approx = { version = "0.5", default-features = false }
+quickcheck = { version = "1.0", default-features = false }
+rand = { version = "0.8.0", features = ["small_rng"] }
+rand_distr = { version = "0.4.0" }
+
+[profile.bench]
+debug = true
+
+[profile.test.package.numeric-tests]
+opt-level = 2
+[profile.test.package.blas-tests]
+opt-level = 2
 
 [package.metadata.release]
 no-dev-version = true

--- a/extra-tests/blas/Cargo.toml
+++ b/extra-tests/blas/Cargo.toml
@@ -8,20 +8,19 @@ edition = "2018"
 [lib]
 test = false
 
-[dev-dependencies]
-approx = "0.5"
-defmac = "0.2"
-num-traits = { workspace = true }
-num-complex = { workspace = true }
-
 [dependencies]
 ndarray = { workspace = true, features = ["approx"] }
 
 blas-src = { version = "0.10", optional = true }
-
 openblas-src = { version = "0.10", optional = true }
 netlib-src = { version = "0.8", optional = true }
 blis-src = { version = "0.2", features = ["system"], optional = true }
+
+[dev-dependencies]
+defmac = "0.2"
+approx = { workspace = true }
+num-traits = { workspace = true }
+num-complex = { workspace = true }
 
 [features]
 # Just for making an example and to help testing, , multiple different possible

--- a/extra-tests/numeric/Cargo.toml
+++ b/extra-tests/numeric/Cargo.toml
@@ -5,25 +5,23 @@ authors = ["bluss"]
 publish = false
 edition = "2018"
 
+[lib]
+test = false
+
 [dependencies]
-approx = "0.5"
 ndarray = { workspace = true, features = ["approx"] }
 ndarray-rand = { workspace = true }
-rand_distr = "0.4"
+
+approx = { workspace = true }
+rand = { workspace = true }
+rand_distr = { workspace = true }
 
 blas-src = { optional = true, version = "0.10", default-features = false, features = ["openblas"] }
 openblas-src = { optional = true, version = "0.10", default-features = false, features = ["cblas", "system"] }
 
-[dependencies.rand]
-version = "0.8.0"
-features = ["small_rng"]
-
 [dev-dependencies]
 num-traits = { workspace = true }
 num-complex = { workspace = true }
-
-[lib]
-test = false
 
 [features]
 test_blas = ["ndarray/blas", "blas-src", "openblas-src"]

--- a/extra-tests/serialization/Cargo.toml
+++ b/extra-tests/serialization/Cargo.toml
@@ -11,24 +11,16 @@ test = false
 [dependencies]
 ndarray = { workspace = true, features = ["serde"] }
 
+serde = { version = "1.0.100", default-features = false }
+ron = { version = "0.8.1", optional = true }
+
+[dev-dependencies]
+serde_json = { version = "1.0.40" }
+# Old version to work with Rust 1.64+
+rmp = { version = "=0.8.10" }
+# Old version to work with Rust 1.64+
+rmp-serde = { version = "0.14" }
+
 [features]
 default = ["ron"]
 
-[dev-dependencies.serde]
-version = "1.0.100"
-default-features = false
-
-[dev-dependencies.serde_json]
-version = "1.0.40"
-
-[dev-dependencies.rmp]
-# Old version to work with Rust 1.64+
-version = "=0.8.10"
-
-[dev-dependencies.rmp-serde]
-# Old version to work with Rust 1.64+
-version = "0.14"
-
-[dependencies.ron]
-version = "0.8.1"
-optional = true

--- a/ndarray-rand/Cargo.toml
+++ b/ndarray-rand/Cargo.toml
@@ -14,17 +14,15 @@ description = "Constructors for randomized arrays. `rand` integration for `ndarr
 keywords = ["multidimensional", "matrix", "rand", "ndarray"]
 
 [dependencies]
-ndarray = { version = "0.15", path = ".." }
-rand_distr = "0.4.0"
-quickcheck = { version = "1.0", default-features = false, optional = true }
+ndarray = { workspace = true }
 
-[dependencies.rand]
-version = "0.8.0"
-features = ["small_rng"]
+rand = { workspace = true }
+rand_distr = { workspace = true }
+quickcheck = { workspace = true, optional = true }
 
 [dev-dependencies]
 rand_isaac = "0.3.0"
-quickcheck = { version = "1.0", default-features = false }
+quickcheck = { workspace = true }
 
 [package.metadata.release]
 no-dev-version = true


### PR DESCRIPTION
Continued cleanup using workspace = true and more uniformity in dependency listings among all crates.
No functional changes.