### PR TITLE
Allow aliasing in ArrayView::from_shape

### DIFF
--- a/src/impl_constructors.rs
+++ b/src/impl_constructors.rs
@@ -20,8 +20,8 @@ use num_traits::{One, Zero};
 use std::mem;
 use std::mem::MaybeUninit;
 
-use crate::dimension;
 use crate::dimension::offset_from_low_addr_ptr_to_logical_ptr;
+use crate::dimension::{self, CanIndexCheckMode};
 use crate::error::{self, ShapeError};
 use crate::extension::nonnull::nonnull_from_vec_data;
 use crate::imp_prelude::*;
@@ -466,7 +466,7 @@ where
     {
         let dim = shape.dim;
         let is_custom = shape.strides.is_custom();
-        dimension::can_index_slice_with_strides(&v, &dim, &shape.strides)?;
+        dimension::can_index_slice_with_strides(&v, &dim, &shape.strides, dimension::CanIndexCheckMode::OwnedMutable)?;
         if !is_custom && dim.size() != v.len() {
             return Err(error::incompatible_shapes(&Ix1(v.len()), &dim));
         }
@@ -510,7 +510,7 @@ where
     unsafe fn from_vec_dim_stride_unchecked(dim: D, strides: D, mut v: Vec<A>) -> Self
     {
         // debug check for issues that indicates wrong use of this constructor
-        debug_assert!(dimension::can_index_slice(&v, &dim, &strides).is_ok());
+        debug_assert!(dimension::can_index_slice(&v, &dim, &strides, CanIndexCheckMode::OwnedMutable).is_ok());
 
         let ptr = nonnull_from_vec_data(&mut v).add(offset_from_low_addr_ptr_to_logical_ptr(&dim, &strides));
         ArrayBase::from_data_ptr(DataOwned::new(v), ptr).with_strides_dim(strides, dim)

--- a/src/impl_views/constructors.rs
+++ b/src/impl_views/constructors.rs
@@ -8,8 +8,8 @@
 
 use std::ptr::NonNull;
 
-use crate::dimension;
 use crate::dimension::offset_from_low_addr_ptr_to_logical_ptr;
+use crate::dimension::{self, CanIndexCheckMode};
 use crate::error::ShapeError;
 use crate::extension::nonnull::nonnull_debug_checked_from_ptr;
 use crate::imp_prelude::*;
@@ -54,7 +54,7 @@ where D: Dimension
     fn from_shape_impl(shape: StrideShape<D>, xs: &'a [A]) -> Result<Self, ShapeError>
     {
         let dim = shape.dim;
-        dimension::can_index_slice_with_strides(xs, &dim, &shape.strides)?;
+        dimension::can_index_slice_with_strides(xs, &dim, &shape.strides, CanIndexCheckMode::ReadOnly)?;
         let strides = shape.strides.strides_for_dim(&dim);
         unsafe {
             Ok(Self::new_(
@@ -157,7 +157,7 @@ where D: Dimension
     fn from_shape_impl(shape: StrideShape<D>, xs: &'a mut [A]) -> Result<Self, ShapeError>
     {
         let dim = shape.dim;
-        dimension::can_index_slice_with_strides(xs, &dim, &shape.strides)?;
+        dimension::can_index_slice_with_strides(xs, &dim, &shape.strides, CanIndexCheckMode::OwnedMutable)?;
         let strides = shape.strides.strides_for_dim(&dim);
         unsafe {
             Ok(Self::new_(

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -10,6 +10,7 @@ use defmac::defmac;
 use itertools::{zip, Itertools};
 use ndarray::indices;
 use ndarray::prelude::*;
+use ndarray::ErrorKind;
 use ndarray::{arr3, rcarr2};
 use ndarray::{Slice, SliceInfo, SliceInfoElem};
 use num_complex::Complex;
@@ -2058,6 +2059,22 @@ fn test_view_from_shape()
     let a = ArrayView::from_shape((2, 3, 2).strides((6, (-2isize) as usize, 1)), &s).unwrap();
     answer.invert_axis(Axis(1));
     assert_eq!(a, answer);
+}
+
+#[test]
+fn test_view_from_shape_allow_overlap()
+{
+    let data = [0, 1, 2];
+    let view = ArrayView::from_shape((2, 3).strides((0, 1)), &data).unwrap();
+    assert_eq!(view, aview2(&[data; 2]));
+}
+
+#[test]
+fn test_view_mut_from_shape_deny_overlap()
+{
+    let mut data = [0, 1, 2];
+    let result = ArrayViewMut::from_shape((2, 3).strides((0, 1)), &mut data);
+    assert_matches!(result.map_err(|e| e.kind()), Err(ErrorKind::Unsupported));
 }
 
 #[test]


### PR DESCRIPTION
Changes the checks in the ArrayView::from_shape constructor so that it allows a few more cases: custom strides that lead to overlapping are allowed.

Before, both ArrayViewMut and ArrayView applied the same check, that the dimensions and strides must be such that no elements can be reached by more than one index.

However, this rule only applies for mutable data, for ArrayView we can allow this kind of aliasing. This is in fact how broadcasting works, where we use strides to repeat the same array data multiple times.

Fixes the second point in #919