### PR TITLE
Make iterators covariant in element type

### DIFF
--- a/src/data_repr.rs
+++ b/src/data_repr.rs
@@ -59,11 +59,6 @@ impl<A> OwnedRepr<A>
         self.ptr.as_ptr()
     }
 
-    pub(crate) fn as_ptr_mut(&self) -> *mut A
-    {
-        self.ptr.as_ptr()
-    }
-
     pub(crate) fn as_nonnull_mut(&mut self) -> NonNull<A>
     {
         self.ptr

--- a/src/impl_owned_array.rs
+++ b/src/impl_owned_array.rs
@@ -3,7 +3,7 @@ use alloc::vec::Vec;
 use std::mem;
 use std::mem::MaybeUninit;
 
-#[allow(unused_imports)]
+#[allow(unused_imports)] // Needed for Rust 1.64
 use rawpointer::PointerExt;
 
 use crate::imp_prelude::*;
@@ -907,7 +907,7 @@ where D: Dimension
 
     // iter is a raw pointer iterator traversing the array in memory order now with the
     // sorted axes.
-    let mut iter = Baseiter::new(self_.ptr.as_ptr(), self_.dim, self_.strides);
+    let mut iter = Baseiter::new(self_.ptr, self_.dim, self_.strides);
     let mut dropped_elements = 0;
 
     let mut last_ptr = data_ptr;

--- a/src/impl_owned_array.rs
+++ b/src/impl_owned_array.rs
@@ -1,5 +1,6 @@
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
+use core::ptr::NonNull;
 use std::mem;
 use std::mem::MaybeUninit;
 
@@ -435,7 +436,7 @@ where D: Dimension
         // "deconstruct" self; the owned repr releases ownership of all elements and we
         // carry on with raw view methods
         let data_len = self.data.len();
-        let data_ptr = self.data.as_nonnull_mut().as_ptr();
+        let data_ptr = self.data.as_nonnull_mut();
 
         unsafe {
             // Safety: self.data releases ownership of the elements. Any panics below this point
@@ -866,8 +867,9 @@ where D: Dimension
 ///
 /// This is an internal function for use by move_into and IntoIter only, safety invariants may need
 /// to be upheld across the calls from those implementations.
-pub(crate) unsafe fn drop_unreachable_raw<A, D>(mut self_: RawArrayViewMut<A, D>, data_ptr: *mut A, data_len: usize)
-where D: Dimension
+pub(crate) unsafe fn drop_unreachable_raw<A, D>(
+    mut self_: RawArrayViewMut<A, D>, data_ptr: NonNull<A>, data_len: usize,
+) where D: Dimension
 {
     let self_len = self_.len();
 
@@ -878,7 +880,7 @@ where D: Dimension
     }
     sort_axes_in_default_order(&mut self_);
     // with uninverted axes this is now the element with lowest address
-    let array_memory_head_ptr = self_.ptr.as_ptr();
+    let array_memory_head_ptr = self_.ptr;
     let data_end_ptr = data_ptr.add(data_len);
     debug_assert!(data_ptr <= array_memory_head_ptr);
     debug_assert!(array_memory_head_ptr <= data_end_ptr);
@@ -917,7 +919,7 @@ where D: Dimension
         // should now be dropped. This interval may be empty, then we just skip this loop.
         while last_ptr != elem_ptr {
             debug_assert!(last_ptr < data_end_ptr);
-            std::ptr::drop_in_place(last_ptr);
+            std::ptr::drop_in_place(last_ptr.as_mut());
             last_ptr = last_ptr.add(1);
             dropped_elements += 1;
         }
@@ -926,7 +928,7 @@ where D: Dimension
     }
 
     while last_ptr < data_end_ptr {
-        std::ptr::drop_in_place(last_ptr);
+        std::ptr::drop_in_place(last_ptr.as_mut());
         last_ptr = last_ptr.add(1);
         dropped_elements += 1;
     }

--- a/src/impl_views/conversions.rs
+++ b/src/impl_views/conversions.rs
@@ -199,7 +199,7 @@ where D: Dimension
     #[inline]
     pub(crate) fn into_base_iter(self) -> Baseiter<A, D>
     {
-        unsafe { Baseiter::new(self.ptr.as_ptr(), self.dim, self.strides) }
+        unsafe { Baseiter::new(self.ptr, self.dim, self.strides) }
     }
 }
 
@@ -209,7 +209,7 @@ where D: Dimension
     #[inline]
     pub(crate) fn into_base_iter(self) -> Baseiter<A, D>
     {
-        unsafe { Baseiter::new(self.ptr.as_ptr(), self.dim, self.strides) }
+        unsafe { Baseiter::new(self.ptr, self.dim, self.strides) }
     }
 }
 
@@ -220,7 +220,7 @@ where D: Dimension
     #[inline]
     pub(crate) fn into_base_iter(self) -> Baseiter<A, D>
     {
-        unsafe { Baseiter::new(self.ptr.as_ptr(), self.dim, self.strides) }
+        unsafe { Baseiter::new(self.ptr, self.dim, self.strides) }
     }
 
     #[inline]
@@ -262,7 +262,7 @@ where D: Dimension
     #[inline]
     pub(crate) fn into_base_iter(self) -> Baseiter<A, D>
     {
-        unsafe { Baseiter::new(self.ptr.as_ptr(), self.dim, self.strides) }
+        unsafe { Baseiter::new(self.ptr, self.dim, self.strides) }
     }
 
     #[inline]

--- a/src/iterators/chunks.rs
+++ b/src/iterators/chunks.rs
@@ -204,7 +204,7 @@ impl_iterator! {
 
         fn item(&mut self, ptr) {
             unsafe {
-                ArrayView::new_(
+                ArrayView::new(
                     ptr,
                     self.chunk.clone(),
                     self.inner_strides.clone())
@@ -226,7 +226,7 @@ impl_iterator! {
 
         fn item(&mut self, ptr) {
             unsafe {
-                ArrayViewMut::new_(
+                ArrayViewMut::new(
                     ptr,
                     self.chunk.clone(),
                     self.inner_strides.clone())

--- a/src/iterators/into_iter.rs
+++ b/src/iterators/into_iter.rs
@@ -33,16 +33,15 @@ impl<A, D> IntoIter<A, D>
 where D: Dimension
 {
     /// Create a new by-value iterator that consumes `array`
-    pub(crate) fn new(mut array: Array<A, D>) -> Self
+    pub(crate) fn new(array: Array<A, D>) -> Self
     {
         unsafe {
             let array_head_ptr = array.ptr;
-            let ptr = array.as_mut_ptr();
             let mut array_data = array.data;
             let data_len = array_data.release_all_elements();
             debug_assert!(data_len >= array.dim.size());
             let has_unreachable_elements = array.dim.size() != data_len;
-            let inner = Baseiter::new(ptr, array.dim, array.strides);
+            let inner = Baseiter::new(array_head_ptr, array.dim, array.strides);
 
             IntoIter {
                 array_data,

--- a/src/iterators/into_iter.rs
+++ b/src/iterators/into_iter.rs
@@ -61,7 +61,7 @@ impl<A, D: Dimension> Iterator for IntoIter<A, D>
     #[inline]
     fn next(&mut self) -> Option<A>
     {
-        self.inner.next().map(|p| unsafe { p.read() })
+        self.inner.next().map(|p| unsafe { p.as_ptr().read() })
     }
 
     fn size_hint(&self) -> (usize, Option<usize>)
@@ -91,7 +91,7 @@ where D: Dimension
         while let Some(_) = self.next() {}
 
         unsafe {
-            let data_ptr = self.array_data.as_ptr_mut();
+            let data_ptr = self.array_data.as_nonnull_mut();
             let view = RawArrayViewMut::new(self.array_head_ptr, self.inner.dim.clone(), self.inner.strides.clone());
             debug_assert!(self.inner.dim.size() < self.data_len, "data_len {} and dim size {}",
                           self.data_len, self.inner.dim.size());

--- a/src/iterators/windows.rs
+++ b/src/iterators/windows.rs
@@ -115,7 +115,7 @@ impl_iterator! {
 
         fn item(&mut self, ptr) {
             unsafe {
-                ArrayView::new_(
+                ArrayView::new(
                     ptr,
                     self.window.clone(),
                     self.strides.clone())

--- a/tests/iterators.rs
+++ b/tests/iterators.rs
@@ -1,6 +1,4 @@
-#![allow(
-    clippy::many_single_char_names, clippy::deref_addrof, clippy::unreadable_literal, clippy::many_single_char_names
-)]
+#![allow(clippy::deref_addrof, clippy::unreadable_literal)]
 
 use ndarray::prelude::*;
 use ndarray::{arr3, indices, s, Slice, Zip};
@@ -1054,4 +1052,34 @@ impl Drop for DropCount<'_>
         self.my_drops += 1;
         self.drops.set(self.drops.get() + 1);
     }
+}
+
+#[test]
+fn test_impl_iter_compiles()
+{
+    // Requires that the iterators are covariant in the element type
+
+    // base case: std
+    fn slice_iter_non_empty_indices<'s, 'a>(array: &'a Vec<&'s str>) -> impl Iterator<Item = usize> + 'a
+    {
+        array
+            .iter()
+            .enumerate()
+            .filter(|(_index, elem)| !elem.is_empty())
+            .map(|(index, _elem)| index)
+    }
+
+    let _ = slice_iter_non_empty_indices;
+
+    // ndarray case
+    fn array_iter_non_empty_indices<'s, 'a>(array: &'a Array<&'s str, Ix1>) -> impl Iterator<Item = usize> + 'a
+    {
+        array
+            .iter()
+            .enumerate()
+            .filter(|(_index, elem)| !elem.is_empty())
+            .map(|(index, _elem)| index)
+    }
+
+    let _ = array_iter_non_empty_indices;
 }


### PR DESCRIPTION
The internal Baseiter type underlies most of the ndarray iterators, and it used `*mut A` for element type A. Update it to use `NonNull<A>` which behaves identically except it's guaranteed to be non-null and is covariant w.r.t the parameter A.

Add compile test from the issue.
The second commit continues the "conversion", using NonNull more consistently
in Baseiter's Iterator impl.

Fixes #1290