### PR TITLE
Fix using BLAS for all compatible cases of memory layout

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,7 @@ members = [
 default-members = [
     ".",
     "ndarray-rand",
+    "crates/ndarray-gen",
     "crates/numeric-tests",
     "crates/serialization-tests",
     # exclude blas-tests that depends on BLAS install
@@ -93,6 +94,7 @@ default-members = [
 [workspace.dependencies]
 ndarray = { version = "0.16", path = "." }
 ndarray-rand = { path = "ndarray-rand" }
+ndarray-gen = { path = "crates/ndarray-gen" }
 
 num-integer = { version = "0.1.39", default-features = false }
 num-traits = { version = "0.2", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ defmac = "0.2"
 quickcheck = { workspace = true }
 approx = { workspace = true, default-features = true }
 itertools = { workspace = true }
+ndarray-gen = { workspace = true }
 
 [features]
 default = ["std"]
@@ -93,7 +94,7 @@ default-members = [
 ]
 
 [workspace.dependencies]
-ndarray = { version = "0.16", path = "." }
+ndarray = { version = "0.16", path = ".", default-features = false }
 ndarray-rand = { path = "ndarray-rand" }
 ndarray-gen = { path = "crates/ndarray-gen" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ rawpointer = { version = "0.2" }
 defmac = "0.2"
 quickcheck = { workspace = true }
 approx = { workspace = true, default-features = true }
-itertools = { version = "0.13.0", default-features = false, features = ["use_std"] }
+itertools = { workspace = true }
 
 [features]
 default = ["std"]
@@ -72,6 +72,7 @@ rayon = ["dep:rayon", "std"]
 matrixmultiply-threading = ["matrixmultiply/threading"]
 
 portable-atomic-critical-section = ["portable-atomic/critical-section"]
+
 
 [target.'cfg(not(target_has_atomic = "ptr"))'.dependencies]
 portable-atomic = { version = "1.6.0" }
@@ -103,6 +104,7 @@ approx = { version = "0.5", default-features = false }
 quickcheck = { version = "1.0", default-features = false }
 rand = { version = "0.8.0", features = ["small_rng"] }
 rand_distr = { version = "0.4.0" }
+itertools = { version = "0.13.0", default-features = false, features = ["use_std"] }
 
 [profile.bench]
 debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ approx = { workspace = true, optional = true }
 rayon = { version = "1.10.0", optional = true }
 
 # Use via the `blas` crate feature
-cblas-sys = { version = "0.1.4", optional = true, default-features = false }
+cblas-sys = { workspace = true, optional = true }
 libc = { version = "0.2.82", optional = true }
 
 matrixmultiply = { version = "0.3.2", default-features = false, features=["cgemm"] }
@@ -90,7 +90,7 @@ default-members = [
     "crates/ndarray-gen",
     "crates/numeric-tests",
     "crates/serialization-tests",
-    # exclude blas-tests that depends on BLAS install
+    # exclude blas-tests and blas-mock-tests that activate "blas" feature
 ]
 
 [workspace.dependencies]
@@ -106,6 +106,7 @@ quickcheck = { version = "1.0", default-features = false }
 rand = { version = "0.8.0", features = ["small_rng"] }
 rand_distr = { version = "0.4.0" }
 itertools = { version = "0.13.0", default-features = false, features = ["use_std"] }
+cblas-sys = { version = "0.1.4", default-features = false }
 
 [profile.bench]
 debug = true

--- a/crates/blas-mock-tests/Cargo.toml
+++ b/crates/blas-mock-tests/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "blas-mock-tests"
+version = "0.1.0"
+edition = "2018"
+publish = false
+
+[lib]
+test = false
+doc = false
+doctest = false
+
+[dependencies]
+ndarray = { workspace = true, features = ["approx", "blas"] }
+ndarray-gen = { workspace = true }
+cblas-sys = { workspace = true }
+
+[dev-dependencies]
+itertools = { workspace = true }

--- a/crates/blas-mock-tests/src/lib.rs
+++ b/crates/blas-mock-tests/src/lib.rs
@@ -1,0 +1,100 @@
+//! Mock interfaces to BLAS
+
+use core::cell::RefCell;
+use core::ffi::{c_double, c_float, c_int};
+use std::thread_local;
+
+use cblas_sys::{c_double_complex, c_float_complex, CBLAS_LAYOUT, CBLAS_TRANSPOSE};
+
+thread_local! {
+    /// This counter is incremented every time a gemm function is called
+    pub static CALL_COUNT: RefCell<usize> = RefCell::new(0);
+}
+
+#[rustfmt::skip]
+#[no_mangle]
+#[allow(unused)]
+pub unsafe extern "C" fn cblas_sgemm(
+    layout: CBLAS_LAYOUT,
+    transa: CBLAS_TRANSPOSE,
+    transb: CBLAS_TRANSPOSE,
+    m: c_int,
+    n: c_int,
+    k: c_int,
+    alpha: c_float,
+    a: *const c_float,
+    lda: c_int,
+    b: *const c_float,
+    ldb: c_int,
+    beta: c_float,
+    c: *mut c_float,
+    ldc: c_int
+) {
+    CALL_COUNT.with(|ctx| *ctx.borrow_mut() += 1);
+}
+
+#[rustfmt::skip]
+#[no_mangle]
+#[allow(unused)]
+pub unsafe extern "C" fn cblas_dgemm(
+    layout: CBLAS_LAYOUT,
+    transa: CBLAS_TRANSPOSE,
+    transb: CBLAS_TRANSPOSE,
+    m: c_int,
+    n: c_int,
+    k: c_int,
+    alpha: c_double,
+    a: *const c_double,
+    lda: c_int,
+    b: *const c_double,
+    ldb: c_int,
+    beta: c_double,
+    c: *mut c_double,
+    ldc: c_int
+) {
+    CALL_COUNT.with(|ctx| *ctx.borrow_mut() += 1);
+}
+
+#[rustfmt::skip]
+#[no_mangle]
+#[allow(unused)]
+pub unsafe extern "C" fn cblas_cgemm(
+    layout: CBLAS_LAYOUT,
+    transa: CBLAS_TRANSPOSE,
+    transb: CBLAS_TRANSPOSE,
+    m: c_int,
+    n: c_int,
+    k: c_int,
+    alpha: *const c_float_complex,
+    a: *const c_float_complex,
+    lda: c_int,
+    b: *const c_float_complex,
+    ldb: c_int,
+    beta: *const c_float_complex,
+    c: *mut c_float_complex,
+    ldc: c_int
+) {
+    CALL_COUNT.with(|ctx| *ctx.borrow_mut() += 1);
+}
+
+#[rustfmt::skip]
+#[no_mangle]
+#[allow(unused)]
+pub unsafe extern "C" fn cblas_zgemm(
+    layout: CBLAS_LAYOUT,
+    transa: CBLAS_TRANSPOSE,
+    transb: CBLAS_TRANSPOSE,
+    m: c_int,
+    n: c_int,
+    k: c_int,
+    alpha: *const c_double_complex,
+    a: *const c_double_complex,
+    lda: c_int,
+    b: *const c_double_complex,
+    ldb: c_int,
+    beta: *const c_double_complex,
+    c: *mut c_double_complex,
+    ldc: c_int
+) {
+    CALL_COUNT.with(|ctx| *ctx.borrow_mut() += 1);
+}

--- a/crates/blas-mock-tests/tests/use-blas.rs
+++ b/crates/blas-mock-tests/tests/use-blas.rs
@@ -1,0 +1,88 @@
+extern crate ndarray;
+
+use ndarray::prelude::*;
+
+use blas_mock_tests::CALL_COUNT;
+use ndarray::linalg::general_mat_mul;
+use ndarray::Order;
+use ndarray_gen::array_builder::ArrayBuilder;
+
+use itertools::iproduct;
+
+#[test]
+fn test_gen_mat_mul_uses_blas()
+{
+    let alpha = 1.0;
+    let beta = 0.0;
+
+    let sizes = vec![
+        (8, 8, 8),
+        (10, 10, 10),
+        (8, 8, 1),
+        (1, 10, 10),
+        (10, 1, 10),
+        (10, 10, 1),
+        (1, 10, 1),
+        (10, 1, 1),
+        (1, 1, 10),
+        (4, 17, 3),
+        (17, 3, 22),
+        (19, 18, 2),
+        (16, 17, 15),
+        (15, 16, 17),
+        (67, 63, 62),
+    ];
+    let strides = &[1, 2, -1, -2];
+    let cf_order = [Order::C, Order::F];
+
+    // test different strides and memory orders
+    for &(m, k, n) in &sizes {
+        for (&s1, &s2) in iproduct!(strides, strides) {
+            for (ord1, ord2, ord3) in iproduct!(cf_order, cf_order, cf_order) {
+                println!("Case s1={}, s2={}, orders={:?}, {:?}, {:?}", s1, s2, ord1, ord2, ord3);
+
+                let a = ArrayBuilder::new((m, k)).memory_order(ord1).build();
+                let b = ArrayBuilder::new((k, n)).memory_order(ord2).build();
+                let mut c = ArrayBuilder::new((m, n)).memory_order(ord3).build();
+
+                {
+                    let av;
+                    let bv;
+                    let mut cv;
+
+                    if s1 != 1 || s2 != 1 {
+                        av = a.slice(s![..;s1, ..;s2]);
+                        bv = b.slice(s![..;s2, ..;s2]);
+                        cv = c.slice_mut(s![..;s1, ..;s2]);
+                    } else {
+                        // different stride cases for slicing versus not sliced (for axes of
+                        // len=1); so test not sliced here.
+                        av = a.view();
+                        bv = b.view();
+                        cv = c.view_mut();
+                    }
+
+                    let pre_count = CALL_COUNT.with(|ctx| *ctx.borrow());
+                    general_mat_mul(alpha, &av, &bv, beta, &mut cv);
+                    let after_count = CALL_COUNT.with(|ctx| *ctx.borrow());
+                    let ncalls = after_count - pre_count;
+                    debug_assert!(ncalls <= 1);
+
+                    let always_uses_blas = s1 == 1 && s2 == 1;
+
+                    if always_uses_blas {
+                        assert_eq!(ncalls, 1, "Contiguous arrays should use blas, orders={:?}", (ord1, ord2, ord3));
+                    }
+
+                    let should_use_blas = av.strides().iter().all(|&s| s > 0)
+                        && bv.strides().iter().all(|&s| s > 0)
+                        && cv.strides().iter().all(|&s| s > 0)
+                        && av.strides().iter().any(|&s| s == 1)
+                        && bv.strides().iter().any(|&s| s == 1)
+                        && cv.strides().iter().any(|&s| s == 1);
+                    assert_eq!(should_use_blas, ncalls > 0);
+                }
+            }
+        }
+    }
+}

--- a/crates/blas-tests/Cargo.toml
+++ b/crates/blas-tests/Cargo.toml
@@ -12,6 +12,7 @@ doctest = false
 
 [dependencies]
 ndarray = { workspace = true, features = ["approx", "blas"] }
+ndarray-gen = { workspace = true }
 
 blas-src = { version = "0.10", optional = true }
 openblas-src = { version = "0.10", optional = true }
@@ -23,6 +24,7 @@ defmac = "0.2"
 approx = { workspace = true }
 num-traits = { workspace = true }
 num-complex = { workspace = true }
+itertools = { workspace = true }
 
 [features]
 # Just for making an example and to help testing, , multiple different possible

--- a/crates/blas-tests/Cargo.toml
+++ b/crates/blas-tests/Cargo.toml
@@ -11,7 +11,7 @@ doc = false
 doctest = false
 
 [dependencies]
-ndarray = { workspace = true, features = ["approx"] }
+ndarray = { workspace = true, features = ["approx", "blas"] }
 
 blas-src = { version = "0.10", optional = true }
 openblas-src = { version = "0.10", optional = true }

--- a/crates/blas-tests/tests/oper.rs
+++ b/crates/blas-tests/tests/oper.rs
@@ -253,7 +253,7 @@ fn gen_mat_mul()
         for &(m, k, n) in &sizes {
             for (ord1, ord2, ord3) in iproduct!(cf_order, cf_order, cf_order) {
                 println!("Case s1={}, s2={}, orders={:?}, {:?}, {:?}", s1, s2, ord1, ord2, ord3);
-                let a = ArrayBuilder::new((m, k)).memory_order(ord1).build();
+                let a = ArrayBuilder::new((m, k)).memory_order(ord1).build() * 0.5;
                 let b = ArrayBuilder::new((k, n)).memory_order(ord2).build();
                 let mut c = ArrayBuilder::new((m, n)).memory_order(ord3).build();
 

--- a/crates/ndarray-gen/Cargo.toml
+++ b/crates/ndarray-gen/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2018"
 publish = false
 
 [dependencies]
-ndarray = { workspace = true }
+ndarray = { workspace = true, default-features = false }
 num-traits = { workspace = true }

--- a/crates/ndarray-gen/Cargo.toml
+++ b/crates/ndarray-gen/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "ndarray-gen"
+version = "0.1.0"
+edition = "2018"
+publish = false
+
+[dependencies]
+ndarray = { workspace = true }
+num-traits = { workspace = true }

--- a/crates/ndarray-gen/README.md
+++ b/crates/ndarray-gen/README.md
@@ -1,0 +1,4 @@
+
+## ndarray-gen
+
+Array generation functions, used for testing.

--- a/crates/ndarray-gen/src/array_builder.rs
+++ b/crates/ndarray-gen/src/array_builder.rs
@@ -1,0 +1,97 @@
+// Copyright 2024 bluss and ndarray developers.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use ndarray::Array;
+use ndarray::Dimension;
+use ndarray::IntoDimension;
+use ndarray::Order;
+
+use num_traits::Num;
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct ArrayBuilder<D: Dimension>
+{
+    dim: D,
+    memory_order: Order,
+    generator: ElementGenerator,
+}
+
+/// How to generate elements
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum ElementGenerator
+{
+    Sequential,
+    Zero,
+}
+
+impl<D: Dimension> Default for ArrayBuilder<D>
+{
+    fn default() -> Self
+    {
+        Self::new(D::zeros(D::NDIM.unwrap_or(1)))
+    }
+}
+
+impl<D> ArrayBuilder<D>
+where D: Dimension
+{
+    pub fn new(dim: impl IntoDimension<Dim = D>) -> Self
+    {
+        ArrayBuilder {
+            dim: dim.into_dimension(),
+            memory_order: Order::C,
+            generator: ElementGenerator::Sequential,
+        }
+    }
+
+    pub fn memory_order(mut self, order: Order) -> Self
+    {
+        self.memory_order = order;
+        self
+    }
+
+    pub fn generator(mut self, generator: ElementGenerator) -> Self
+    {
+        self.generator = generator;
+        self
+    }
+
+    pub fn build<T>(self) -> Array<T, D>
+    where T: Num + Clone
+    {
+        let mut current = T::zero();
+        let size = self.dim.size();
+        let use_zeros = self.generator == ElementGenerator::Zero;
+        Array::from_iter((0..size).map(|_| {
+            let ret = current.clone();
+            if !use_zeros {
+                current = ret.clone() + T::one();
+            }
+            ret
+        }))
+        .into_shape_with_order((self.dim, self.memory_order))
+        .unwrap()
+    }
+}
+
+#[test]
+fn test_order()
+{
+    let (m, n) = (12, 13);
+    let c = ArrayBuilder::new((m, n))
+        .memory_order(Order::C)
+        .build::<i32>();
+    let f = ArrayBuilder::new((m, n))
+        .memory_order(Order::F)
+        .build::<i32>();
+
+    assert_eq!(c.shape(), &[m, n]);
+    assert_eq!(f.shape(), &[m, n]);
+    assert_eq!(c.strides(), &[n as isize, 1]);
+    assert_eq!(f.strides(), &[1, m as isize]);
+}

--- a/crates/ndarray-gen/src/lib.rs
+++ b/crates/ndarray-gen/src/lib.rs
@@ -1,0 +1,11 @@
+// Copyright 2024 bluss and ndarray developers.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+/// Build ndarray arrays for test purposes
+
+pub mod array_builder;

--- a/crates/ndarray-gen/src/lib.rs
+++ b/crates/ndarray-gen/src/lib.rs
@@ -1,3 +1,4 @@
+#![no_std]
 // Copyright 2024 bluss and ndarray developers.
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or

--- a/scripts/all-tests.sh
+++ b/scripts/all-tests.sh
@@ -20,6 +20,7 @@ cargo test -v -p ndarray -p ndarray-rand --release --features "$FEATURES" $QC_FE
 
 # BLAS tests
 cargo test -p ndarray --lib -v --features blas
+cargo test -p blas-mock-tests -v
 cargo test -p blas-tests -v --features blas-tests/openblas-system
 cargo test -p numeric-tests -v --features numeric-tests/test_blas
 

--- a/scripts/all-tests.sh
+++ b/scripts/all-tests.sh
@@ -19,6 +19,7 @@ cargo test -v --features "$FEATURES" $QC_FEAT
 cargo test -v -p ndarray -p ndarray-rand --release --features "$FEATURES" $QC_FEAT --lib --tests
 
 # BLAS tests
+cargo test -p ndarray --lib -v --features blas
 cargo test -p blas-tests -v --features blas-tests/openblas-system
 cargo test -p numeric-tests -v --features numeric-tests/test_blas
 

--- a/tests/oper.rs
+++ b/tests/oper.rs
@@ -5,13 +5,17 @@
 use ndarray::linalg::general_mat_mul;
 use ndarray::linalg::kron;
 use ndarray::prelude::*;
+#[cfg(feature = "approx")]
+use ndarray::Order;
 use ndarray::{rcarr1, rcarr2};
 use ndarray::{Data, LinalgScalar};
 use ndarray::{Ix, Ixs};
-use num_traits::Zero;
+use ndarray_gen::array_builder::ArrayBuilder;
 
 use approx::assert_abs_diff_eq;
 use defmac::defmac;
+use num_traits::Num;
+use num_traits::Zero;
 
 fn test_oper(op: &str, a: &[f32], b: &[f32], c: &[f32])
 {
@@ -271,31 +275,20 @@ fn product()
     }
 }
 
-fn range_mat(m: Ix, n: Ix) -> Array2<f32>
+fn range_mat<A: Num + Copy>(m: Ix, n: Ix) -> Array2<A>
 {
-    Array::linspace(0., (m * n) as f32 - 1., m * n)
-        .into_shape_with_order((m, n))
-        .unwrap()
-}
-
-fn range_mat64(m: Ix, n: Ix) -> Array2<f64>
-{
-    Array::linspace(0., (m * n) as f64 - 1., m * n)
-        .into_shape_with_order((m, n))
-        .unwrap()
+    ArrayBuilder::new((m, n)).build()
 }
 
 #[cfg(feature = "approx")]
 fn range1_mat64(m: Ix) -> Array1<f64>
 {
-    Array::linspace(0., m as f64 - 1., m)
+    ArrayBuilder::new(m).build()
 }
 
 fn range_i32(m: Ix, n: Ix) -> Array2<i32>
 {
-    Array::from_iter(0..(m * n) as i32)
-        .into_shape_with_order((m, n))
-        .unwrap()
+    ArrayBuilder::new((m, n)).build()
 }
 
 // simple, slow, correct (hopefully) mat mul
@@ -332,8 +325,8 @@ where
 fn mat_mul()
 {
     let (m, n, k) = (8, 8, 8);
-    let a = range_mat(m, n);
-    let b = range_mat(n, k);
+    let a = range_mat::<f32>(m, n);
+    let b = range_mat::<f32>(n, k);
     let mut b = b / 4.;
     {
         let mut c = b.column_mut(0);
@@ -351,8 +344,8 @@ fn mat_mul()
     assert_eq!(ab, af.dot(&bf));
 
     let (m, n, k) = (10, 5, 11);
-    let a = range_mat(m, n);
-    let b = range_mat(n, k);
+    let a = range_mat::<f32>(m, n);
+    let b = range_mat::<f32>(n, k);
     let mut b = b / 4.;
     {
         let mut c = b.column_mut(0);
@@ -370,8 +363,8 @@ fn mat_mul()
     assert_eq!(ab, af.dot(&bf));
 
     let (m, n, k) = (10, 8, 1);
-    let a = range_mat(m, n);
-    let b = range_mat(n, k);
+    let a = range_mat::<f32>(m, n);
+    let b = range_mat::<f32>(n, k);
     let mut b = b / 4.;
     {
         let mut c = b.column_mut(0);
@@ -395,8 +388,8 @@ fn mat_mul()
 fn mat_mul_order()
 {
     let (m, n, k) = (8, 8, 8);
-    let a = range_mat(m, n);
-    let b = range_mat(n, k);
+    let a = range_mat::<f32>(m, n);
+    let b = range_mat::<f32>(n, k);
     let mut af = Array::zeros(a.dim().f());
     let mut bf = Array::zeros(b.dim().f());
     af.assign(&a);
@@ -415,8 +408,8 @@ fn mat_mul_order()
 fn mat_mul_shape_mismatch()
 {
     let (m, k, k2, n) = (8, 8, 9, 8);
-    let a = range_mat(m, k);
-    let b = range_mat(k2, n);
+    let a = range_mat::<f32>(m, k);
+    let b = range_mat::<f32>(k2, n);
     a.dot(&b);
 }
 
@@ -426,9 +419,9 @@ fn mat_mul_shape_mismatch()
 fn mat_mul_shape_mismatch_2()
 {
     let (m, k, k2, n) = (8, 8, 8, 8);
-    let a = range_mat(m, k);
-    let b = range_mat(k2, n);
-    let mut c = range_mat(m, n + 1);
+    let a = range_mat::<f32>(m, k);
+    let b = range_mat::<f32>(k2, n);
+    let mut c = range_mat::<f32>(m, n + 1);
     general_mat_mul(1., &a, &b, 1., &mut c);
 }
 
@@ -438,7 +431,7 @@ fn mat_mul_shape_mismatch_2()
 fn mat_mul_broadcast()
 {
     let (m, n, k) = (16, 16, 16);
-    let a = range_mat(m, n);
+    let a = range_mat::<f32>(m, n);
     let x1 = 1.;
     let x = Array::from(vec![x1]);
     let b0 = x.broadcast((n, k)).unwrap();
@@ -458,8 +451,8 @@ fn mat_mul_broadcast()
 fn mat_mul_rev()
 {
     let (m, n, k) = (16, 16, 16);
-    let a = range_mat(m, n);
-    let b = range_mat(n, k);
+    let a = range_mat::<f32>(m, n);
+    let b = range_mat::<f32>(n, k);
     let mut rev = Array::zeros(b.dim());
     let mut rev = rev.slice_mut(s![..;-1, ..]);
     rev.assign(&b);
@@ -488,8 +481,8 @@ fn mat_mut_zero_len()
             }
         }
     });
-    mat_mul_zero_len!(range_mat);
-    mat_mul_zero_len!(range_mat64);
+    mat_mul_zero_len!(range_mat::<f32>);
+    mat_mul_zero_len!(range_mat::<f64>);
     mat_mul_zero_len!(range_i32);
 }
 
@@ -528,9 +521,9 @@ fn scaled_add_2()
     for &s1 in &[1, 2, -1, -2] {
         for &s2 in &[1, 2, -1, -2] {
             for &(m, k, n, q) in &sizes {
-                let mut a = range_mat64(m, k);
+                let mut a = range_mat::<f64>(m, k);
                 let mut answer = a.clone();
-                let c = range_mat64(n, q);
+                let c = range_mat::<f64>(n, q);
 
                 {
                     let mut av = a.slice_mut(s![..;s1, ..;s2]);
@@ -570,7 +563,7 @@ fn scaled_add_3()
     for &s1 in &[1, 2, -1, -2] {
         for &s2 in &[1, 2, -1, -2] {
             for &(m, k, n, q) in &sizes {
-                let mut a = range_mat64(m, k);
+                let mut a = range_mat::<f64>(m, k);
                 let mut answer = a.clone();
                 let cdim = if n == 1 { vec![q] } else { vec![n, q] };
                 let cslice: Vec<SliceInfoElem> = if n == 1 {
@@ -582,7 +575,7 @@ fn scaled_add_3()
                     ]
                 };
 
-                let c = range_mat64(n, q).into_shape_with_order(cdim).unwrap();
+                let c = range_mat::<f64>(n, q).into_shape_with_order(cdim).unwrap();
 
                 {
                     let mut av = a.slice_mut(s![..;s1, ..;s2]);
@@ -619,9 +612,9 @@ fn gen_mat_mul()
     for &s1 in &[1, 2, -1, -2] {
         for &s2 in &[1, 2, -1, -2] {
             for &(m, k, n) in &sizes {
-                let a = range_mat64(m, k);
-                let b = range_mat64(k, n);
-                let mut c = range_mat64(m, n);
+                let a = range_mat::<f64>(m, k);
+                let b = range_mat::<f64>(k, n);
+                let mut c = range_mat::<f64>(m, n);
                 let mut answer = c.clone();
 
                 {
@@ -645,11 +638,11 @@ fn gen_mat_mul()
 #[test]
 fn gemm_64_1_f()
 {
-    let a = range_mat64(64, 64).reversed_axes();
+    let a = range_mat::<f64>(64, 64).reversed_axes();
     let (m, n) = a.dim();
     // m x n  times n x 1  == m x 1
-    let x = range_mat64(n, 1);
-    let mut y = range_mat64(m, 1);
+    let x = range_mat::<f64>(n, 1);
+    let mut y = range_mat::<f64>(m, 1);
     let answer = reference_mat_mul(&a, &x) + &y;
     general_mat_mul(1.0, &a, &x, 1.0, &mut y);
     approx::assert_relative_eq!(y, answer, epsilon = 1e-12, max_relative = 1e-7);
@@ -728,11 +721,8 @@ fn gen_mat_vec_mul()
     for &s1 in &[1, 2, -1, -2] {
         for &s2 in &[1, 2, -1, -2] {
             for &(m, k) in &sizes {
-                for &rev in &[false, true] {
-                    let mut a = range_mat64(m, k);
-                    if rev {
-                        a = a.reversed_axes();
-                    }
+                for order in [Order::C, Order::F] {
+                    let a = ArrayBuilder::new((m, k)).memory_order(order).build();
                     let (m, k) = a.dim();
                     let b = range1_mat64(k);
                     let mut c = range1_mat64(m);
@@ -794,11 +784,8 @@ fn vec_mat_mul()
     for &s1 in &[1, 2, -1, -2] {
         for &s2 in &[1, 2, -1, -2] {
             for &(m, n) in &sizes {
-                for &rev in &[false, true] {
-                    let mut b = range_mat64(m, n);
-                    if rev {
-                        b = b.reversed_axes();
-                    }
+                for order in [Order::C, Order::F] {
+                    let b = ArrayBuilder::new((m, n)).memory_order(order).build();
                     let (m, n) = b.dim();
                     let a = range1_mat64(m);
                     let mut c = range1_mat64(n);


### PR DESCRIPTION
With the blas (cblas) interface it supports matrices that adhere to certain
criteria. They should be contiguous on one dimension (stride=1).

We glance a little [at how numpy does this](https://github.com/numpy/numpy/blob/5cec054581bdb1cd6a0440b579ab680ed0e8afc5/numpy/_core/src/umath/matmul.c.src) to try to catch all cases.

Compute A B -> C We require for BLAS compatibility that: A, B, C are
"weakly" contiguous (stride=1) in their fastest dimension, but it can be
either first or second axis (either rowmajor/"c" or colmajor/"f").

The "normal case" is CblasRowMajor for cblas. Select CblasRowMajor,
CblasColMajor to fit C's memory order.

Apply transpose to A, B as needed if they differ from the normal case. If C
is CblasColMajor then transpose both A, B (again!)

(Weakly = contiguous with stride=1 on that fastest axis, but stride for the
other axis can be arbitrary large; to differentiate from strictly whole
array contiguous.)

A first commit simplified and corrected the logic, while still using
ndarray's reversed axes. But a further commit simplified it even further, to
a satisfying little function in `mat_mul_impl` as the final result.

I have kept both states (both commits) because I think the first version is
a useful guide if we would ever go to use plain BLAS instead of CBLAS(?).

Fixes #1278
