### PR TITLE
Removed typo

### DIFF
--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -1030,7 +1030,7 @@ where
     }
 
     /// Along `axis`, select arbitrary subviews corresponding to `indices`
-    /// and and copy them into a new array.
+    /// and copy them into a new array.
     ///
     /// **Panics** if `axis` or an element of `indices` is out of bounds.
     ///


### PR DESCRIPTION
Tiny fix to remove a double and in the documentation of `select`.