### PR TITLE
Fixes no_std + approx combination

### DIFF
--- a/crates/serialization-tests/tests/serialize.rs
+++ b/crates/serialization-tests/tests/serialize.rs
@@ -45,13 +45,13 @@ fn serial_many_dim_serde()
 
     {
         // Test a sliced array.
-        let mut a = ArcArray::linspace(0., 31., 32)
+        let mut a = ArcArray::from_iter(0..32)
             .into_shape_with_order((2, 2, 2, 4))
             .unwrap();
         a.slice_collapse(s![..;-1, .., .., ..2]);
         let serial = serde_json::to_string(&a).unwrap();
         println!("Encode {:?} => {:?}", a, serial);
-        let res = serde_json::from_str::<ArcArray<f32, _>>(&serial);
+        let res = serde_json::from_str::<ArcArray<i32, _>>(&serial);
         println!("{:?}", res);
         assert_eq!(a, res.unwrap());
     }
@@ -160,7 +160,7 @@ fn serial_many_dim_serde_msgpack()
 
     {
         // Test a sliced array.
-        let mut a = ArcArray::linspace(0., 31., 32)
+        let mut a = ArcArray::from_iter(0..32)
             .into_shape_with_order((2, 2, 2, 4))
             .unwrap();
         a.slice_collapse(s![..;-1, .., .., ..2]);
@@ -171,7 +171,7 @@ fn serial_many_dim_serde_msgpack()
             .unwrap();
 
         let mut deserializer = rmp_serde::Deserializer::new(&buf[..]);
-        let a_de: ArcArray<f32, _> = serde::Deserialize::deserialize(&mut deserializer).unwrap();
+        let a_de: ArcArray<i32, _> = serde::Deserialize::deserialize(&mut deserializer).unwrap();
 
         assert_eq!(a, a_de);
     }
@@ -215,14 +215,14 @@ fn serial_many_dim_ron()
 
     {
         // Test a sliced array.
-        let mut a = ArcArray::linspace(0., 31., 32)
+        let mut a = ArcArray::from_iter(0..32)
             .into_shape_with_order((2, 2, 2, 4))
             .unwrap();
         a.slice_collapse(s![..;-1, .., .., ..2]);
 
         let a_s = ron_serialize(&a).unwrap();
 
-        let a_de: ArcArray<f32, _> = ron_deserialize(&a_s).unwrap();
+        let a_de: ArcArray<i32, _> = ron_deserialize(&a_s).unwrap();
 
         assert_eq!(a, a_de);
     }

--- a/scripts/all-tests.sh
+++ b/scripts/all-tests.sh
@@ -13,6 +13,8 @@ cargo build -v --no-default-features
 
 # ndarray with no features
 cargo test -p ndarray -v --no-default-features
+# ndarray with no_std-compatible features
+cargo test -p ndarray -v --no-default-features --features approx
 # all with features
 cargo test -v --features "$FEATURES" $QC_FEAT
 # all with features and release (ignore test crates which is already optimized)

--- a/tests/azip.rs
+++ b/tests/azip.rs
@@ -232,7 +232,7 @@ fn test_azip3_slices()
         *a += b / 10.;
         *c = a.sin();
     });
-    let res = Array::linspace(0., 3.1, 32).mapv_into(f32::sin);
+    let res = Array::from_iter(0..32).mapv(|x| f32::sin(x as f32 / 10.));
     assert_abs_diff_eq!(res, ArrayView::from(&c), epsilon = 1e-4);
 }
 

--- a/tests/numeric.rs
+++ b/tests/numeric.rs
@@ -163,6 +163,7 @@ fn std_empty_arr()
 
 #[test]
 #[cfg(feature = "approx")]
+#[cfg(feature = "std")]
 fn var_axis()
 {
     use ndarray::{aview0, aview2};
@@ -222,6 +223,7 @@ fn var_axis()
 
 #[test]
 #[cfg(feature = "approx")]
+#[cfg(feature = "std")]
 fn std_axis()
 {
     use ndarray::aview2;


### PR DESCRIPTION
These two features can coexist; fixing them included:
- Slightly altering tests to avoid `std` fns
- Adding `feature = "std"` on some "approx" tests
- Adding a line to the test script to catch this in the future

Closes #1447 