### PR TITLE
Fixes a variety of lifetime elision warnings in CI/CD

### DIFF
--- a/crates/ndarray-gen/src/lib.rs
+++ b/crates/ndarray-gen/src/lib.rs
@@ -8,5 +8,4 @@
 // except according to those terms.
 
 /// Build ndarray arrays for test purposes
-
 pub mod array_builder;

--- a/examples/bounds_check_elim.rs
+++ b/examples/bounds_check_elim.rs
@@ -57,7 +57,7 @@ pub fn test1d_single_mut(a: &mut Array1<f64>, i: usize) -> f64
 #[no_mangle]
 pub fn test1d_len_of(a: &Array1<f64>) -> f64
 {
-    let a = &*a;
+    let a = a;
     let mut sum = 0.;
     for i in 0..a.len_of(Axis(0)) {
         sum += a[i];

--- a/ndarray-rand/tests/tests.rs
+++ b/ndarray-rand/tests/tests.rs
@@ -122,7 +122,7 @@ fn sampling_works(a: &Array2<f64>, strategy: SamplingStrategy, axis: Axis, n_sam
     let samples = a.sample_axis(axis, n_samples, strategy);
     samples
         .axis_iter(axis)
-        .all(|lane| is_subset(&a, &lane, axis))
+        .all(|lane| is_subset(a, &lane, axis))
 }
 
 // Check if, when sliced along `axis`, there is at least one lane in `a` equal to `b`

--- a/src/argument_traits.rs
+++ b/src/argument_traits.rs
@@ -11,7 +11,7 @@ pub trait AssignElem<T>
 }
 
 /// Assignable element, simply `*self = input`.
-impl<'a, T> AssignElem<T> for &'a mut T
+impl<T> AssignElem<T> for &mut T
 {
     fn assign_elem(self, input: T)
     {
@@ -20,7 +20,7 @@ impl<'a, T> AssignElem<T> for &'a mut T
 }
 
 /// Assignable element, simply `self.set(input)`.
-impl<'a, T> AssignElem<T> for &'a Cell<T>
+impl<T> AssignElem<T> for &Cell<T>
 {
     fn assign_elem(self, input: T)
     {
@@ -29,7 +29,7 @@ impl<'a, T> AssignElem<T> for &'a Cell<T>
 }
 
 /// Assignable element, simply `self.set(input)`.
-impl<'a, T> AssignElem<T> for &'a MathCell<T>
+impl<T> AssignElem<T> for &MathCell<T>
 {
     fn assign_elem(self, input: T)
     {
@@ -39,7 +39,7 @@ impl<'a, T> AssignElem<T> for &'a MathCell<T>
 
 /// Assignable element, the item in the MaybeUninit is overwritten (prior value, if any, is not
 /// read or dropped).
-impl<'a, T> AssignElem<T> for &'a mut MaybeUninit<T>
+impl<T> AssignElem<T> for &mut MaybeUninit<T>
 {
     fn assign_elem(self, input: T)
     {

--- a/src/array_serde.rs
+++ b/src/array_serde.rs
@@ -98,7 +98,7 @@ where
 // private iterator wrapper
 struct Sequence<'a, A, D>(Iter<'a, A, D>);
 
-impl<'a, A, D> Serialize for Sequence<'a, A, D>
+impl<A, D> Serialize for Sequence<'_, A, D>
 where
     A: Serialize,
     D: Dimension + Serialize,
@@ -162,7 +162,7 @@ impl<'de> Deserialize<'de> for ArrayField
     {
         struct ArrayFieldVisitor;
 
-        impl<'de> Visitor<'de> for ArrayFieldVisitor
+        impl Visitor<'_> for ArrayFieldVisitor
         {
             type Value = ArrayField;
 

--- a/src/arraytraits.rs
+++ b/src/arraytraits.rs
@@ -128,7 +128,7 @@ where
 /// Return `true` if the array shapes and all elements of `self` and
 /// `rhs` are equal. Return `false` otherwise.
 #[allow(clippy::unconditional_recursion)] // false positive
-impl<'a, A, B, S, S2, D> PartialEq<&'a ArrayBase<S2, D>> for ArrayBase<S, D>
+impl<A, B, S, S2, D> PartialEq<&ArrayBase<S2, D>> for ArrayBase<S, D>
 where
     A: PartialEq<B>,
     S: Data<Elem = A>,
@@ -144,7 +144,7 @@ where
 /// Return `true` if the array shapes and all elements of `self` and
 /// `rhs` are equal. Return `false` otherwise.
 #[allow(clippy::unconditional_recursion)] // false positive
-impl<'a, A, B, S, S2, D> PartialEq<ArrayBase<S2, D>> for &'a ArrayBase<S, D>
+impl<A, B, S, S2, D> PartialEq<ArrayBase<S2, D>> for &ArrayBase<S, D>
 where
     A: PartialEq<B>,
     S: Data<Elem = A>,

--- a/src/data_traits.rs
+++ b/src/data_traits.rs
@@ -407,7 +407,7 @@ where A: Clone
     }
 }
 
-unsafe impl<'a, A> RawData for ViewRepr<&'a A>
+unsafe impl<A> RawData for ViewRepr<&A>
 {
     type Elem = A;
 
@@ -420,7 +420,7 @@ unsafe impl<'a, A> RawData for ViewRepr<&'a A>
     private_impl! {}
 }
 
-unsafe impl<'a, A> Data for ViewRepr<&'a A>
+unsafe impl<A> Data for ViewRepr<&A>
 {
     fn into_owned<D>(self_: ArrayBase<Self, D>) -> Array<Self::Elem, D>
     where
@@ -437,7 +437,7 @@ unsafe impl<'a, A> Data for ViewRepr<&'a A>
     }
 }
 
-unsafe impl<'a, A> RawDataClone for ViewRepr<&'a A>
+unsafe impl<A> RawDataClone for ViewRepr<&A>
 {
     unsafe fn clone_with_ptr(&self, ptr: NonNull<Self::Elem>) -> (Self, NonNull<Self::Elem>)
     {
@@ -445,7 +445,7 @@ unsafe impl<'a, A> RawDataClone for ViewRepr<&'a A>
     }
 }
 
-unsafe impl<'a, A> RawData for ViewRepr<&'a mut A>
+unsafe impl<A> RawData for ViewRepr<&mut A>
 {
     type Elem = A;
 
@@ -458,7 +458,7 @@ unsafe impl<'a, A> RawData for ViewRepr<&'a mut A>
     private_impl! {}
 }
 
-unsafe impl<'a, A> RawDataMut for ViewRepr<&'a mut A>
+unsafe impl<A> RawDataMut for ViewRepr<&mut A>
 {
     #[inline]
     fn try_ensure_unique<D>(_: &mut ArrayBase<Self, D>)
@@ -475,7 +475,7 @@ unsafe impl<'a, A> RawDataMut for ViewRepr<&'a mut A>
     }
 }
 
-unsafe impl<'a, A> Data for ViewRepr<&'a mut A>
+unsafe impl<A> Data for ViewRepr<&mut A>
 {
     fn into_owned<D>(self_: ArrayBase<Self, D>) -> Array<Self::Elem, D>
     where
@@ -492,7 +492,7 @@ unsafe impl<'a, A> Data for ViewRepr<&'a mut A>
     }
 }
 
-unsafe impl<'a, A> DataMut for ViewRepr<&'a mut A> {}
+unsafe impl<A> DataMut for ViewRepr<&mut A> {}
 
 /// Array representation trait.
 ///
@@ -533,7 +533,7 @@ pub unsafe trait DataOwned: Data
 pub unsafe trait DataShared: Clone + Data + RawDataClone {}
 
 unsafe impl<A> DataShared for OwnedArcRepr<A> {}
-unsafe impl<'a, A> DataShared for ViewRepr<&'a A> {}
+unsafe impl<A> DataShared for ViewRepr<&A> {}
 
 unsafe impl<A> DataOwned for OwnedRepr<A>
 {
@@ -571,7 +571,7 @@ unsafe impl<A> DataOwned for OwnedArcRepr<A>
     }
 }
 
-unsafe impl<'a, A> RawData for CowRepr<'a, A>
+unsafe impl<A> RawData for CowRepr<'_, A>
 {
     type Elem = A;
 
@@ -587,7 +587,7 @@ unsafe impl<'a, A> RawData for CowRepr<'a, A>
     private_impl! {}
 }
 
-unsafe impl<'a, A> RawDataMut for CowRepr<'a, A>
+unsafe impl<A> RawDataMut for CowRepr<'_, A>
 where A: Clone
 {
     #[inline]
@@ -615,7 +615,7 @@ where A: Clone
     }
 }
 
-unsafe impl<'a, A> RawDataClone for CowRepr<'a, A>
+unsafe impl<A> RawDataClone for CowRepr<'_, A>
 where A: Clone
 {
     unsafe fn clone_with_ptr(&self, ptr: NonNull<Self::Elem>) -> (Self, NonNull<Self::Elem>)
@@ -681,7 +681,7 @@ unsafe impl<'a, A> Data for CowRepr<'a, A>
     }
 }
 
-unsafe impl<'a, A> DataMut for CowRepr<'a, A> where A: Clone {}
+unsafe impl<A> DataMut for CowRepr<'_, A> where A: Clone {}
 
 unsafe impl<'a, A> DataOwned for CowRepr<'a, A>
 {

--- a/src/dimension/axes.rs
+++ b/src/dimension/axes.rs
@@ -60,7 +60,7 @@ pub struct AxisDescription
 copy_and_clone!(AxisDescription);
 copy_and_clone!(['a, D] Axes<'a, D>);
 
-impl<'a, D> Iterator for Axes<'a, D>
+impl<D> Iterator for Axes<'_, D>
 where D: Dimension
 {
     /// Description of the axis, its length and its stride.
@@ -99,7 +99,7 @@ where D: Dimension
     }
 }
 
-impl<'a, D> DoubleEndedIterator for Axes<'a, D>
+impl<D> DoubleEndedIterator for Axes<'_, D>
 where D: Dimension
 {
     fn next_back(&mut self) -> Option<Self::Item>

--- a/src/dimension/ndindex.rs
+++ b/src/dimension/ndindex.rs
@@ -255,7 +255,7 @@ unsafe impl<const N: usize> NdIndex<IxDyn> for [Ix; N]
     }
 }
 
-impl<'a> IntoDimension for &'a [Ix]
+impl IntoDimension for &[Ix]
 {
     type Dim = IxDyn;
     fn into_dimension(self) -> Self::Dim
@@ -264,7 +264,7 @@ impl<'a> IntoDimension for &'a [Ix]
     }
 }
 
-unsafe impl<'a> NdIndex<IxDyn> for &'a IxDyn
+unsafe impl NdIndex<IxDyn> for &IxDyn
 {
     fn index_checked(&self, dim: &IxDyn, strides: &IxDyn) -> Option<isize>
     {
@@ -276,7 +276,7 @@ unsafe impl<'a> NdIndex<IxDyn> for &'a IxDyn
     }
 }
 
-unsafe impl<'a> NdIndex<IxDyn> for &'a [Ix]
+unsafe impl NdIndex<IxDyn> for &[Ix]
 {
     fn index_checked(&self, dim: &IxDyn, strides: &IxDyn) -> Option<isize>
     {

--- a/src/impl_cow.rs
+++ b/src/impl_cow.rs
@@ -11,7 +11,7 @@ use crate::imp_prelude::*;
 /// Methods specific to `CowArray`.
 ///
 /// ***See also all methods for [`ArrayBase`]***
-impl<'a, A, D> CowArray<'a, A, D>
+impl<A, D> CowArray<'_, A, D>
 where D: Dimension
 {
     /// Returns `true` iff the array is the view (borrowed) variant.

--- a/src/impl_views/constructors.rs
+++ b/src/impl_views/constructors.rs
@@ -230,7 +230,7 @@ where D: Dimension
 }
 
 /// Private array view methods
-impl<'a, A, D> ArrayView<'a, A, D>
+impl<A, D> ArrayView<'_, A, D>
 where D: Dimension
 {
     /// Create a new `ArrayView`
@@ -254,7 +254,7 @@ where D: Dimension
     }
 }
 
-impl<'a, A, D> ArrayViewMut<'a, A, D>
+impl<A, D> ArrayViewMut<'_, A, D>
 where D: Dimension
 {
     /// Create a new `ArrayView`

--- a/src/impl_views/indexing.rs
+++ b/src/impl_views/indexing.rs
@@ -100,7 +100,7 @@ pub trait IndexLonger<I>
     unsafe fn uget(self, index: I) -> Self::Output;
 }
 
-impl<'a, 'b, I, A, D> IndexLonger<I> for &'b ArrayView<'a, A, D>
+impl<'a, I, A, D> IndexLonger<I> for &ArrayView<'a, A, D>
 where
     I: NdIndex<D>,
     D: Dimension,

--- a/src/impl_views/splitting.rs
+++ b/src/impl_views/splitting.rs
@@ -11,7 +11,7 @@ use crate::slice::MultiSliceArg;
 use num_complex::Complex;
 
 /// Methods for read-only array views.
-impl<'a, A, D> ArrayView<'a, A, D>
+impl<A, D> ArrayView<'_, A, D>
 where D: Dimension
 {
     /// Split the array view along `axis` and return one view strictly before the

--- a/src/iterators/mod.rs
+++ b/src/iterators/mod.rs
@@ -260,7 +260,7 @@ impl<'a, A> DoubleEndedIterator for ElementsBase<'a, A, Ix1>
     }
 }
 
-impl<'a, A, D> ExactSizeIterator for ElementsBase<'a, A, D>
+impl<A, D> ExactSizeIterator for ElementsBase<'_, A, D>
 where D: Dimension
 {
     fn len(&self) -> usize
@@ -503,7 +503,7 @@ impl<'a, A> DoubleEndedIterator for Iter<'a, A, Ix1>
     }
 }
 
-impl<'a, A, D> ExactSizeIterator for Iter<'a, A, D>
+impl<A, D> ExactSizeIterator for Iter<'_, A, D>
 where D: Dimension
 {
     fn len(&self) -> usize
@@ -534,7 +534,7 @@ impl<'a, A, D: Dimension> Iterator for IndexedIter<'a, A, D>
     }
 }
 
-impl<'a, A, D> ExactSizeIterator for IndexedIter<'a, A, D>
+impl<A, D> ExactSizeIterator for IndexedIter<'_, A, D>
 where D: Dimension
 {
     fn len(&self) -> usize
@@ -635,7 +635,7 @@ impl<'a, A> DoubleEndedIterator for IterMut<'a, A, Ix1>
     }
 }
 
-impl<'a, A, D> ExactSizeIterator for IterMut<'a, A, D>
+impl<A, D> ExactSizeIterator for IterMut<'_, A, D>
 where D: Dimension
 {
     fn len(&self) -> usize
@@ -686,7 +686,7 @@ impl<'a, A> DoubleEndedIterator for ElementsBaseMut<'a, A, Ix1>
     }
 }
 
-impl<'a, A, D> ExactSizeIterator for ElementsBaseMut<'a, A, D>
+impl<A, D> ExactSizeIterator for ElementsBaseMut<'_, A, D>
 where D: Dimension
 {
     fn len(&self) -> usize
@@ -717,7 +717,7 @@ impl<'a, A, D: Dimension> Iterator for IndexedIterMut<'a, A, D>
     }
 }
 
-impl<'a, A, D> ExactSizeIterator for IndexedIterMut<'a, A, D>
+impl<A, D> ExactSizeIterator for IndexedIterMut<'_, A, D>
 where D: Dimension
 {
     fn len(&self) -> usize
@@ -767,7 +767,7 @@ where D: Dimension
     }
 }
 
-impl<'a, A, D> ExactSizeIterator for LanesIter<'a, A, D>
+impl<A, D> ExactSizeIterator for LanesIter<'_, A, D>
 where D: Dimension
 {
     fn len(&self) -> usize
@@ -776,7 +776,7 @@ where D: Dimension
     }
 }
 
-impl<'a, A> DoubleEndedIterator for LanesIter<'a, A, Ix1>
+impl<A> DoubleEndedIterator for LanesIter<'_, A, Ix1>
 {
     fn next_back(&mut self) -> Option<Self::Item>
     {
@@ -819,7 +819,7 @@ where D: Dimension
     }
 }
 
-impl<'a, A, D> ExactSizeIterator for LanesIterMut<'a, A, D>
+impl<A, D> ExactSizeIterator for LanesIterMut<'_, A, D>
 where D: Dimension
 {
     fn len(&self) -> usize
@@ -828,7 +828,7 @@ where D: Dimension
     }
 }
 
-impl<'a, A> DoubleEndedIterator for LanesIterMut<'a, A, Ix1>
+impl<A> DoubleEndedIterator for LanesIterMut<'_, A, Ix1>
 {
     fn next_back(&mut self) -> Option<Self::Item>
     {
@@ -1079,7 +1079,7 @@ where D: Dimension
     }
 }
 
-impl<'a, A, D> DoubleEndedIterator for AxisIter<'a, A, D>
+impl<A, D> DoubleEndedIterator for AxisIter<'_, A, D>
 where D: Dimension
 {
     fn next_back(&mut self) -> Option<Self::Item>
@@ -1088,7 +1088,7 @@ where D: Dimension
     }
 }
 
-impl<'a, A, D> ExactSizeIterator for AxisIter<'a, A, D>
+impl<A, D> ExactSizeIterator for AxisIter<'_, A, D>
 where D: Dimension
 {
     fn len(&self) -> usize
@@ -1169,7 +1169,7 @@ where D: Dimension
     }
 }
 
-impl<'a, A, D> DoubleEndedIterator for AxisIterMut<'a, A, D>
+impl<A, D> DoubleEndedIterator for AxisIterMut<'_, A, D>
 where D: Dimension
 {
     fn next_back(&mut self) -> Option<Self::Item>
@@ -1178,7 +1178,7 @@ where D: Dimension
     }
 }
 
-impl<'a, A, D> ExactSizeIterator for AxisIterMut<'a, A, D>
+impl<A, D> ExactSizeIterator for AxisIterMut<'_, A, D>
 where D: Dimension
 {
     fn len(&self) -> usize
@@ -1187,7 +1187,7 @@ where D: Dimension
     }
 }
 
-impl<'a, A, D: Dimension> NdProducer for AxisIter<'a, A, D>
+impl<A, D: Dimension> NdProducer for AxisIter<'_, A, D>
 {
     type Item = <Self as Iterator>::Item;
     type Dim = Ix1;
@@ -1246,7 +1246,7 @@ impl<'a, A, D: Dimension> NdProducer for AxisIter<'a, A, D>
     private_impl! {}
 }
 
-impl<'a, A, D: Dimension> NdProducer for AxisIterMut<'a, A, D>
+impl<A, D: Dimension> NdProducer for AxisIterMut<'_, A, D>
 {
     type Item = <Self as Iterator>::Item;
     type Dim = Ix1;
@@ -1555,12 +1555,12 @@ unsafe impl<F> TrustedIterator for Linspace<F> {}
 unsafe impl<F> TrustedIterator for Geomspace<F> {}
 #[cfg(feature = "std")]
 unsafe impl<F> TrustedIterator for Logspace<F> {}
-unsafe impl<'a, A, D> TrustedIterator for Iter<'a, A, D> {}
-unsafe impl<'a, A, D> TrustedIterator for IterMut<'a, A, D> {}
+unsafe impl<A, D> TrustedIterator for Iter<'_, A, D> {}
+unsafe impl<A, D> TrustedIterator for IterMut<'_, A, D> {}
 unsafe impl<I> TrustedIterator for std::iter::Cloned<I> where I: TrustedIterator {}
 unsafe impl<I, F> TrustedIterator for std::iter::Map<I, F> where I: TrustedIterator {}
-unsafe impl<'a, A> TrustedIterator for slice::Iter<'a, A> {}
-unsafe impl<'a, A> TrustedIterator for slice::IterMut<'a, A> {}
+unsafe impl<A> TrustedIterator for slice::Iter<'_, A> {}
+unsafe impl<A> TrustedIterator for slice::IterMut<'_, A> {}
 unsafe impl TrustedIterator for ::std::ops::Range<usize> {}
 // FIXME: These indices iter are dubious -- size needs to be checked up front.
 unsafe impl<D> TrustedIterator for IndicesIter<D> where D: Dimension {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1498,7 +1498,7 @@ pub enum CowRepr<'a, A>
     Owned(OwnedRepr<A>),
 }
 
-impl<'a, A> CowRepr<'a, A>
+impl<A> CowRepr<'_, A>
 {
     /// Returns `true` iff the data is the `View` variant.
     pub fn is_view(&self) -> bool

--- a/src/split_at.rs
+++ b/src/split_at.rs
@@ -35,7 +35,7 @@ where D: Dimension
     }
 }
 
-impl<'a, A, D> SplitAt for ArrayViewMut<'a, A, D>
+impl<A, D> SplitAt for ArrayViewMut<'_, A, D>
 where D: Dimension
 {
     fn split_at(self, axis: Axis, index: usize) -> (Self, Self)

--- a/tests/azip.rs
+++ b/tests/azip.rs
@@ -118,7 +118,7 @@ fn test_zip_collect_drop()
 
     struct Recorddrop<'a>((usize, usize), &'a RefCell<Vec<(usize, usize)>>);
 
-    impl<'a> Drop for Recorddrop<'a>
+    impl Drop for Recorddrop<'_>
     {
         fn drop(&mut self)
         {
@@ -470,9 +470,9 @@ fn test_zip_all()
     let b = Array::<f32, _>::ones(62);
     let mut c = Array::<f32, _>::ones(62);
     c[5] = 0.0;
-    assert_eq!(true, Zip::from(&a).and(&b).all(|&x, &y| x + y == 1.0));
-    assert_eq!(false, Zip::from(&a).and(&b).all(|&x, &y| x == y));
-    assert_eq!(false, Zip::from(&a).and(&c).all(|&x, &y| x + y == 1.0));
+    assert!(Zip::from(&a).and(&b).all(|&x, &y| x + y == 1.0));
+    assert!(!Zip::from(&a).and(&b).all(|&x, &y| x == y));
+    assert!(!Zip::from(&a).and(&c).all(|&x, &y| x + y == 1.0));
 }
 
 #[test]
@@ -480,6 +480,6 @@ fn test_zip_all_empty_array()
 {
     let a = Array::<f32, _>::zeros(0);
     let b = Array::<f32, _>::ones(0);
-    assert_eq!(true, Zip::from(&a).and(&b).all(|&_x, &_y| true));
-    assert_eq!(true, Zip::from(&a).and(&b).all(|&_x, &_y| false));
+    assert!(Zip::from(&a).and(&b).all(|&_x, &_y| true));
+    assert!(Zip::from(&a).and(&b).all(|&_x, &_y| false));
 }


### PR DESCRIPTION
All of these were generated using `cargo clippy --features docs --fix`. I frankly don't understand why these are just showing up now.