### PR TITLE
Uses a simple fix to enable arraybase to be covariant.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1277,15 +1277,15 @@ pub type Ixs = isize;
 // may change in the future.
 //
 // [`.offset()`]: https://doc.rust-lang.org/stable/std/primitive.pointer.html#method.offset-1
-pub struct ArrayBase<S, D>
-where S: RawData
+pub struct ArrayBase<S, D, A = <S as RawData>::Elem>
+where S: RawData<Elem = A>
 {
     /// Data buffer / ownership information. (If owned, contains the data
     /// buffer; if borrowed, contains the lifetime and mutability.)
     data: S,
     /// A non-null pointer into the buffer held by `data`; may point anywhere
     /// in its range. If `S: Data`, this pointer must be aligned.
-    ptr: std::ptr::NonNull<S::Elem>,
+    ptr: std::ptr::NonNull<A>,
     /// The lengths of the axes.
     dim: D,
     /// The element count stride per axis. To be parsed as `isize`.

--- a/tests/variance.rs
+++ b/tests/variance.rs
@@ -1,0 +1,14 @@
+use ndarray::{Array1, ArrayView1};
+
+fn arrayview_covariant<'a: 'b, 'b>(x: ArrayView1<'a, f64>) -> ArrayView1<'b, f64>
+{
+    x
+}
+
+#[test]
+fn test_covariance()
+{
+    let x = Array1::zeros(2);
+    let shorter_view = arrayview_covariant(x.view());
+    assert_eq!(shorter_view[0], 0.0);
+}


### PR DESCRIPTION
See rust-lang/rust#115799 and rust-lang/rust#57440 for more details. Closes #1332