### PR TITLE
Add partition(similar to numpy.partition)

### DIFF
--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -3228,33 +3228,34 @@ impl<A, D: Dimension> ArrayRef<A, D>
         }
 
         let mut result = self.to_owned();
-        
+
         // Check if the first lane is contiguous
-        let is_contiguous = result.lanes_mut(axis)
+        let is_contiguous = result
+            .lanes_mut(axis)
             .into_iter()
             .next()
             .map(|lane| lane.is_contiguous())
             .unwrap_or(false);
-        
+
         if is_contiguous {
             Zip::from(result.lanes_mut(axis)).for_each(|mut lane| {
                 lane.as_slice_mut().unwrap().select_nth_unstable(kth);
             });
         } else {
             let mut temp_vec = Vec::with_capacity(axis_len);
-            
+
             Zip::from(result.lanes_mut(axis)).for_each(|mut lane| {
                 temp_vec.clear();
                 temp_vec.extend(lane.iter().cloned());
-                
+
                 temp_vec.select_nth_unstable(kth);
-                
+
                 Zip::from(&mut lane).and(&temp_vec).for_each(|dest, src| {
                     *dest = src.clone();
                 });
             });
         }
-        
+
         result
     }
 }
@@ -3352,7 +3353,8 @@ mod tests
     }
 
     #[test]
-    fn test_partition_1d() {
+    fn test_partition_1d()
+    {
         // Test partitioning a 1D array
         let array = arr1(&[3, 1, 4, 1, 5, 9, 2, 6]);
         let result = array.partition(3, Axis(0));
@@ -3362,17 +3364,18 @@ mod tests
     }
 
     #[test]
-    fn test_partition_2d() {
+    fn test_partition_2d()
+    {
         // Test partitioning a 2D array along both axes
         let array = arr2(&[[3, 1, 4], [1, 5, 9], [2, 6, 5]]);
-        
+
         // Partition along axis 0 (rows)
         let result0 = array.partition(1, Axis(0));
         // After partitioning along axis 0, each column should have its middle element in the correct position
         assert!(result0[[0, 0]] <= result0[[1, 0]] && result0[[2, 0]] >= result0[[1, 0]]);
         assert!(result0[[0, 1]] <= result0[[1, 1]] && result0[[2, 1]] >= result0[[1, 1]]);
         assert!(result0[[0, 2]] <= result0[[1, 2]] && result0[[2, 2]] >= result0[[1, 2]]);
-        
+
         // Partition along axis 1 (columns)
         let result1 = array.partition(1, Axis(1));
         // After partitioning along axis 1, each row should have its middle element in the correct position
@@ -3382,10 +3385,11 @@ mod tests
     }
 
     #[test]
-    fn test_partition_3d() {
+    fn test_partition_3d()
+    {
         // Test partitioning a 3D array
         let array = arr3(&[[[3, 1], [4, 1]], [[5, 9], [2, 6]]]);
-        
+
         // Partition along axis 0
         let result = array.partition(0, Axis(0));
         // After partitioning, each 2x2 slice should have its first element in the correct position

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -3242,12 +3242,9 @@ impl<A, D: Dimension> ArrayRef<A, D>
                 lane.as_slice_mut().unwrap().select_nth_unstable(kth);
             });
         } else {
-            let mut temp_vec = Vec::with_capacity(axis_len);
+            let mut temp_vec = vec![A::zero(); axis_len];
 
             Zip::from(result.lanes_mut(axis)).for_each(|mut lane| {
-                temp_vec.clear();
-                temp_vec.resize(axis_len, A::zero());
-
                 Zip::from(&mut temp_vec).and(&lane).for_each(|dest, src| {
                     *dest = src.clone();
                 });


### PR DESCRIPTION
## 1. Overview

This is about the `partition` function to handle both contiguous and non-contiguous memory more efficiently. The function now uses a simpler approach for handling non-contiguous memory, reducing overhead in the fallback path.

## 2. Motivation

The `partition` function is an important operation that partially sorts an array around the k-th element along a specified axis. This is useful for:

- Efficiently finding the k-th smallest/largest element without fully sorting
- Dividing data into smaller-than-k and larger-than-k groups (e.g., for quick select algorithms)
- Implementing median-finding algorithms

## 3. Note
- The implementation relies on [select_nth_unstable](https://doc.rust-lang.org/std/primitive.slice.html#method.select_nth_unstable)
  - It might be possible to write our own functions to implement `quickselect` algorithm rather than to use existing one. 
  - let me know if that's the case😃 
- The current implementation of partition() creates a temporary array for each lane when memory is non-contiguous, which can be inefficient. 

## 4. We can go further
- in `numpy.partition`, it is possible to pass sequence of ints as a `kth` parameter. It would be nice to have one in our case, maybe seperated function like `partition_multiple()`
- there is also interesting and useful function `numpy.argpartition`. I think I could implement that also as a follow-up. 

## Related issue
- #1497 

