### PR TITLE
Axis permutation to correctly handle cycles using bitmask approach

### DIFF
--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -2596,11 +2596,11 @@ where
         for count in usage_counts.slice() {
             assert_eq!(*count, 1, "each axis must be listed exactly once");
         }
-        
+
         // Create temporary arrays for the new dimensions and strides
         let mut new_dim = D::zeros(self.ndim());
         let mut new_strides = D::zeros(self.ndim());
-        
+
         {
             let dim = self.layout.dim.slice();
             let strides = self.layout.strides.slice();
@@ -2609,10 +2609,13 @@ where
                 new_strides[new_axis] = strides[axis];
             }
         }
-        
+
         // Update the dimensions and strides in place
         self.layout.dim.slice_mut().copy_from_slice(new_dim.slice());
-        self.layout.strides.slice_mut().copy_from_slice(new_strides.slice());
+        self.layout
+            .strides
+            .slice_mut()
+            .copy_from_slice(new_strides.slice());
     }
 }
 

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -2553,11 +2553,11 @@ where
     ///
     /// The cycle detection is done using a bitmask to track visited positions.
     ///
-    /// For example, axes from [0,1,2] to [2, 0, 1]
-    /// For axis values [1, 0, 2]:
-    /// 1 << 1;  // 0b0001 << 1 = 0b0010 (decimal 2)
-    /// 1 << 0; // 0b0001 << 0 = 0b0001 (decimal 1)
-    /// 1 << 2; // 0b0001 << 2 = 0b0100 (decimal 4)
+    /// For example, axes from \[0,1,2\] to \[2, 0, 1\]
+    /// For axis values \[1, 0, 2\]:
+    /// 1 << 1  // 0b0001 << 1 = 0b0010 (decimal 2)
+    /// 1 << 0  // 0b0001 << 0 = 0b0001 (decimal 1)
+    /// 1 << 2  // 0b0001 << 2 = 0b0100 (decimal 4)
     ///
     /// Each axis gets its own unique bit position in the bitmask:
     /// - Axis 0: bit 0 (rightmost)
@@ -2567,13 +2567,15 @@ where
     /// The check `(visited & (1 << axis)) != 0` works as follows:
     /// ```no_run
     /// let mut visited = 0;  // 0b0000
+    /// let axis = 1;
+    /// let new_axis = 0;
     /// // Check axis 1
-    /// if (visited & (1 << 1)) != 0 {  // 0b0000 & 0b0010 = 0b0000
+    /// if (visited & (1 << axis)) != 0 {  // 0b0000 & 0b0010 = 0b0000
     ///     // Not visited yet
     /// }
     /// // Mark axis 1 as visited
-    /// visited |= (1 << axis) | (1 << new_axis);    /// // Check axis 1 again
-    /// if (visited & (1 << 1)) != 0 {  // 0b0010 & 0b0010 = 0b0010
+    /// visited |= (1 << axis) | (1 << new_axis);    // 0b0000 | 0b0010 | 0b0001 = 0b0011
+    /// if (visited & (1 << 1)) != 0 {  // 0b0011 & 0b0010 = 0b0010
     ///     // Already visited!
     /// }
     /// ```
@@ -2614,13 +2616,9 @@ where
                 continue;
             }
 
-            let temp = dim[axis];
-            dim[axis] = dim[new_axis];
-            dim[new_axis] = temp;
+            dim.swap(axis, new_axis);
+            strides.swap(axis, new_axis);
 
-            let temp = strides[axis];
-            strides[axis] = strides[new_axis];
-            strides[new_axis] = temp;
             visited |= (1 << axis) | (1 << new_axis);
         }
     }

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -2558,7 +2558,7 @@ where
     /// 1 << 1;  // 0b0001 << 1 = 0b0010 (decimal 2)
     /// 1 << 0; // 0b0001 << 0 = 0b0001 (decimal 1)
     /// 1 << 2; // 0b0001 << 2 = 0b0100 (decimal 4)
-    /// 
+    ///
     /// Each axis gets its own unique bit position in the bitmask:
     /// - Axis 0: bit 0 (rightmost)
     /// - Axis 1: bit 1

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -2549,37 +2549,6 @@ where
     /// **Panics** if any of the axes are out of bounds, if an axis is missing,
     /// or if an axis is repeated more than once.    
     ///
-    /// # About the Cycle Detection
-    ///
-    /// The cycle detection is done using a bitmask to track visited positions.
-    ///
-    /// For example, axes from \[0,1,2\] to \[2, 0, 1\]
-    /// For axis values \[1, 0, 2\]:
-    /// 1 << 1  // 0b0001 << 1 = 0b0010 (decimal 2)
-    /// 1 << 0  // 0b0001 << 0 = 0b0001 (decimal 1)
-    /// 1 << 2  // 0b0001 << 2 = 0b0100 (decimal 4)
-    ///
-    /// Each axis gets its own unique bit position in the bitmask:
-    /// - Axis 0: bit 0 (rightmost)
-    /// - Axis 1: bit 1
-    /// - Axis 2: bit 2
-    ///
-    /// The check `(visited & (1 << axis)) != 0` works as follows:
-    /// ```no_run
-    /// let mut visited = 0;  // 0b0000
-    /// let axis = 1;
-    /// let new_axis = 0;
-    /// // Check axis 1
-    /// if (visited & (1 << axis)) != 0 {  // 0b0000 & 0b0010 = 0b0000
-    ///     // Not visited yet
-    /// }
-    /// // Mark axis 1 as visited
-    /// visited |= (1 << axis) | (1 << new_axis);    // 0b0000 | 0b0010 | 0b0001 = 0b0011
-    /// if (visited & (1 << 1)) != 0 {  // 0b0011 & 0b0010 = 0b0010
-    ///     // Already visited!
-    /// }
-    /// ```
-    ///
     /// # Example
     /// ```rust
     /// use ndarray::{arr2, Array3};
@@ -2610,6 +2579,18 @@ where
         let strides = self.layout.strides.slice_mut();
         let axes = axes.slice();
 
+        // The cycle detection is done using a bitmask to track visited positions.
+        // For example, axes from [0,1,2] to [2, 0, 1]
+        // For axis values [1, 0, 2]:
+        // 1 << 1  // 0b0001 << 1 = 0b0010 (decimal 2)
+        // 1 << 0  // 0b0001 << 0 = 0b0001 (decimal 1)
+        // 1 << 2  // 0b0001 << 2 = 0b0100 (decimal 4)
+        //
+        // Each axis gets its own unique bit position in the bitmask:
+        // - Axis 0: bit 0 (rightmost)
+        // - Axis 1: bit 1
+        // - Axis 2: bit 2
+        //
         let mut visited = 0usize;
         for (new_axis, &axis) in axes.iter().enumerate() {
             if (visited & (1 << axis)) != 0 {

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -2828,3 +2828,81 @@ fn test_slice_assign()
     *a.slice_mut(s![1..3]) += 1;
     assert_eq!(a, array![0, 2, 3, 3, 4]);
 }
+
+#[test]
+fn reverse_axes()
+{
+    let mut a = arr2(&[[1, 2], [3, 4]]);
+    a.reverse_axes();
+    assert_eq!(a, arr2(&[[1, 3], [2, 4]]));
+
+    let mut a = arr2(&[[1, 2, 3], [4, 5, 6]]);
+    a.reverse_axes();
+    assert_eq!(a, arr2(&[[1, 4], [2, 5], [3, 6]]));
+
+    let mut a = Array::from_iter(0..24)
+        .into_shape_with_order((2, 3, 4))
+        .unwrap();
+    let original = a.clone();
+    a.reverse_axes();
+    for ((i0, i1, i2), elem) in original.indexed_iter() {
+        assert_eq!(*elem, a[(i2, i1, i0)]);
+    }
+}
+
+#[test]
+fn permute_axes()
+{
+    let mut a = arr2(&[[1, 2], [3, 4]]);
+    a.permute_axes([1, 0]);
+    assert_eq!(a, arr2(&[[1, 3], [2, 4]]));
+
+    let mut a = Array::from_iter(0..24)
+        .into_shape_with_order((2, 3, 4))
+        .unwrap();
+    let original = a.clone();
+    a.permute_axes([2, 1, 0]);
+    for ((i0, i1, i2), elem) in original.indexed_iter() {
+        assert_eq!(*elem, a[(i2, i1, i0)]);
+    }
+
+    let mut a = Array::from_iter(0..120)
+        .into_shape_with_order((2, 3, 4, 5))
+        .unwrap();
+    let original = a.clone();
+    a.permute_axes([1, 0, 3, 2]);
+    for ((i0, i1, i2, i3), elem) in original.indexed_iter() {
+        assert_eq!(*elem, a[(i1, i0, i3, i2)]);
+    }
+}
+
+#[should_panic]
+#[test]
+fn permute_axes_repeated_axis()
+{
+    let mut a = Array::from_iter(0..24)
+        .into_shape_with_order((2, 3, 4))
+        .unwrap();
+    a.permute_axes([1, 0, 1]);
+}
+
+#[should_panic]
+#[test]
+fn permute_axes_missing_axis()
+{
+    let mut a = Array::from_iter(0..24)
+        .into_shape_with_order((2, 3, 4))
+        .unwrap()
+        .into_dyn();
+    a.permute_axes(&[2, 0][..]);
+}
+
+#[should_panic]
+#[test]
+fn permute_axes_oob()
+{
+    let mut a = Array::from_iter(0..24)
+        .into_shape_with_order((2, 3, 4))
+        .unwrap();
+    a.permute_axes([1, 0, 3]);
+}


### PR DESCRIPTION
## Overview
What's up! 😃 Currently, there're two functions to deal with permuting and reversing arrays(`permuted_axes` and `reversed_axes`).
As mentioned from related issue, they're not `in-place`, so I added `permute_axes` and `reverse_axes`. The new implementation for `permute_axes` uses a bitmask-based approach to efficiently track and process cycles in axis permutations!

## Related issue
- #1443 

## Changes
1. **permute_axes (in-place)**: 
   - A new function with a cycle detection algorithm based on bitmasking. 
   - try to maintain the zero-allocation, in-place modification approach
  
2. **reverse_axes (in-place)**:
    - simply use `&mut self`

## Details on permute_axes

### How it works
The new implementation uses a bitmask to track visited axes during permutation cycles:

1. **Cycle Detection**: When permuting axes, we identify cycles of positions that need to be updated.
2. **Bitmask Tracking**: A single `usize` is used as a bitmask to efficiently track which axes have been processed.
4. **In-place Updates**: Each cycle is processed in-place by following the permutation pattern.

### Example

Consider permuting a 2×2 array from `[[1, 2], [3, 4]]` with axes permutation `[1, 0]` (transpose):

```rust
// Original array
let mut arr = array![[1, 2], [3, 4]];
// Original: dims = [2, 2], strides = [2, 1]

// Permute axes [1, 0]
arr.permute_axes([1, 0]);
// Result: dims = [2, 2], strides = [1, 2]
// Array is now [[1, 3], [2, 4]]
```

Here's how the algorithm processes this:

1. Start with axis 1 (new_axis=0):
   - Store initial values: dim[1]=2, stride[1]=1
   - Follow cycle: 1 → 0 → 1
   - Update dim[1] = dim[0] = 2
   - Update stride[1] = stride[0] = 2
   - Mark axes 0 and 1 as visited

2. Process axis 0 (new_axis=1):
   - Already visited in the previous cycle, skip

The bitmask approach ensures each axis is processed exactly once, even in complex permutations with multiple cycles. The key operations are:
- `visited |= 1 << axis`: Mark axis as visited
- `(visited & (1 << axis)) != 0`: Check if axis is visited

@akern40 @nilgoyette added test cases similar to the original functions(`premuted_axes` and `reversed_axes`), but there might be missing cases. please take a look when you guys have some time! 🚀 


