### PR TITLE
Remove as many `feature = "std"` gates in tests as possible

### DIFF
--- a/tests/array.rs
+++ b/tests/array.rs
@@ -68,17 +68,16 @@ fn arrayviewmut_shrink_lifetime<'a, 'b: 'a>(view: ArrayViewMut1<'b, f64>) -> Arr
 }
 
 #[test]
-#[cfg(feature = "std")]
 fn test_mat_mul()
 {
     // smoke test, a big matrix multiplication of uneven size
     let (n, m) = (45, 33);
-    let a = ArcArray::linspace(0., ((n * m) - 1) as f32, n as usize * m as usize)
+    let a = Array::from_iter(0..(n * m))
         .into_shape_with_order((n, m))
         .unwrap();
-    let b = ArcArray::eye(m);
+    let b = Array::eye(m);
     assert_eq!(a.dot(&b), a);
-    let c = ArcArray::eye(n);
+    let c = Array::eye(n);
     assert_eq!(c.dot(&a), a);
 }
 
@@ -692,21 +691,20 @@ fn test_cow_shrink()
 }
 
 #[test]
-#[cfg(feature = "std")]
 fn test_sub()
 {
-    let mat = ArcArray::linspace(0., 15., 16)
+    let mat = Array::from_iter(0..16)
         .into_shape_with_order((2, 4, 2))
         .unwrap();
     let s1 = mat.index_axis(Axis(0), 0);
     let s2 = mat.index_axis(Axis(0), 1);
     assert_eq!(s1.shape(), &[4, 2]);
     assert_eq!(s2.shape(), &[4, 2]);
-    let n = ArcArray::linspace(8., 15., 8)
+    let n = Array::from_iter(8..16)
         .into_shape_with_order((4, 2))
         .unwrap();
     assert_eq!(n, s2);
-    let m = ArcArray::from(vec![2., 3., 10., 11.])
+    let m = Array::from(vec![2, 3, 10, 11])
         .into_shape_with_order((2, 2))
         .unwrap();
     assert_eq!(m, mat.index_axis(Axis(1), 1));
@@ -714,10 +712,9 @@ fn test_sub()
 
 #[should_panic]
 #[test]
-#[cfg(feature = "std")]
 fn test_sub_oob_1()
 {
-    let mat = ArcArray::linspace(0., 15., 16)
+    let mat = Array::from_iter(0..16)
         .into_shape_with_order((2, 4, 2))
         .unwrap();
     mat.index_axis(Axis(0), 2);
@@ -1845,7 +1842,6 @@ fn scalar_ops()
 }
 
 #[test]
-#[cfg(feature = "std")]
 fn split_at()
 {
     let mut a = arr2(&[[1., 2.], [3., 4.]]);
@@ -1864,7 +1860,7 @@ fn split_at()
     }
     assert_eq!(a, arr2(&[[1., 5.], [8., 4.]]));
 
-    let b = ArcArray::linspace(0., 59., 60)
+    let b = ArcArray::from_iter(0..60)
         .into_shape_with_order((3, 4, 5))
         .unwrap();
 
@@ -1874,9 +1870,9 @@ fn split_at()
     assert_eq!(
         left,
         arr3(&[
-            [[0., 1.], [5., 6.], [10., 11.], [15., 16.]],
-            [[20., 21.], [25., 26.], [30., 31.], [35., 36.]],
-            [[40., 41.], [45., 46.], [50., 51.], [55., 56.]]
+            [[0, 1], [5, 6], [10, 11], [15, 16]],
+            [[20, 21], [25, 26], [30, 31], [35, 36]],
+            [[40, 41], [45, 46], [50, 51], [55, 56]]
         ])
     );
 

--- a/tests/broadcast.rs
+++ b/tests/broadcast.rs
@@ -1,21 +1,20 @@
 use ndarray::prelude::*;
 
 #[test]
-#[cfg(feature = "std")]
 fn broadcast_1()
 {
     let a_dim = Dim([2, 4, 2, 2]);
     let b_dim = Dim([2, 1, 2, 1]);
-    let a = ArcArray::linspace(0., 1., a_dim.size())
+    let a = Array::from_iter(0..a_dim.size())
         .into_shape_with_order(a_dim)
         .unwrap();
-    let b = ArcArray::linspace(0., 1., b_dim.size())
+    let b = Array::from_iter(0..b_dim.size())
         .into_shape_with_order(b_dim)
         .unwrap();
     assert!(b.broadcast(a.dim()).is_some());
 
     let c_dim = Dim([2, 1]);
-    let c = ArcArray::linspace(0., 1., c_dim.size())
+    let c = Array::from_iter(0..c_dim.size())
         .into_shape_with_order(c_dim)
         .unwrap();
     assert!(c.broadcast(1).is_none());
@@ -26,7 +25,7 @@ fn broadcast_1()
     assert!(c.broadcast((32, 1, 2)).is_none());
 
     /* () can be broadcast to anything */
-    let z = ArcArray::<f32, _>::zeros(());
+    let z = Array::<f32, _>::zeros(());
     assert!(z.broadcast(()).is_some());
     assert!(z.broadcast(1).is_some());
     assert!(z.broadcast(3).is_some());
@@ -34,32 +33,30 @@ fn broadcast_1()
 }
 
 #[test]
-#[cfg(feature = "std")]
 fn test_add()
 {
     let a_dim = Dim([2, 4, 2, 2]);
     let b_dim = Dim([2, 1, 2, 1]);
-    let mut a = ArcArray::linspace(0.0, 1., a_dim.size())
+    let mut a = Array::from_iter(0..a_dim.size())
         .into_shape_with_order(a_dim)
         .unwrap();
-    let b = ArcArray::linspace(0.0, 1., b_dim.size())
+    let b = Array::from_iter(0..b_dim.size())
         .into_shape_with_order(b_dim)
         .unwrap();
     a += &b;
-    let t = ArcArray::from_elem((), 1.0f32);
+    let t = Array::from_elem((), 1);
     a += &t;
 }
 
 #[test]
 #[should_panic]
-#[cfg(feature = "std")]
 fn test_add_incompat()
 {
     let a_dim = Dim([2, 4, 2, 2]);
-    let mut a = ArcArray::linspace(0.0, 1., a_dim.size())
+    let mut a = Array::from_iter(0..a_dim.size())
         .into_shape_with_order(a_dim)
         .unwrap();
-    let incompat = ArcArray::from_elem(3, 1.0f32);
+    let incompat = Array::from_elem(3, 1);
     a += &incompat;
 }
 

--- a/tests/dimension.rs
+++ b/tests/dimension.rs
@@ -324,7 +324,6 @@ fn test_array_view()
 
 #[test]
 #[cfg_attr(miri, ignore)] // Very slow on CI/CD machines
-#[cfg(feature = "std")]
 #[allow(clippy::cognitive_complexity)]
 fn test_all_ndindex()
 {
@@ -334,7 +333,7 @@ fn test_all_ndindex()
         for &rev in &[false, true] {
             // rev is for C / F order
             let size = $($i *)* 1;
-            let mut a = Array::linspace(0., (size - 1) as f64, size);
+            let mut a = Array::from_iter(0..size);
             if rev {
                 a = a.reversed_axes();
             }

--- a/tests/iterator_chunks.rs
+++ b/tests/iterator_chunks.rs
@@ -6,11 +6,10 @@
 use ndarray::prelude::*;
 
 #[test]
-#[cfg(feature = "std")]
 fn chunks()
 {
     use ndarray::NdProducer;
-    let a = <Array1<f32>>::linspace(1., 100., 10 * 10)
+    let a = Array1::from_iter(0..100)
         .into_shape_with_order((10, 10))
         .unwrap();
 

--- a/tests/iterators.rs
+++ b/tests/iterators.rs
@@ -22,15 +22,14 @@ macro_rules! assert_panics {
 }
 
 #[test]
-#[cfg(feature = "std")]
 fn double_ended()
 {
-    let a = ArcArray::linspace(0., 7., 8);
+    let a = Array::from_iter(0..8);
     let mut it = a.iter().cloned();
-    assert_eq!(it.next(), Some(0.));
-    assert_eq!(it.next_back(), Some(7.));
-    assert_eq!(it.next(), Some(1.));
-    assert_eq!(it.rev().last(), Some(2.));
+    assert_eq!(it.next(), Some(0));
+    assert_eq!(it.next_back(), Some(7));
+    assert_eq!(it.next(), Some(1));
+    assert_eq!(it.rev().last(), Some(2));
     assert_equal(aview1(&[1, 2, 3]), &[1, 2, 3]);
     assert_equal(aview1(&[1, 2, 3]).into_iter().rev(), [1, 2, 3].iter().rev());
 }
@@ -82,7 +81,7 @@ fn iter_size_hint()
 #[cfg(feature = "std")]
 fn indexed()
 {
-    let a = ArcArray::linspace(0., 7., 8);
+    let a = Array::from_iter(0..8);
     for (i, elt) in a.indexed_iter() {
         assert_eq!(i, *elt as usize);
     }
@@ -100,7 +99,6 @@ fn indexed()
 }
 
 #[test]
-#[cfg(feature = "std")]
 fn as_slice()
 {
     use ndarray::Data;
@@ -118,7 +116,7 @@ fn as_slice()
         assert_equal(v.iter(), slc);
     }
 
-    let a = ArcArray::linspace(0., 7., 8);
+    let a = Array::from_iter(0..8);
     let a = a.into_shape_with_order((2, 4, 1)).unwrap();
 
     assert_slice_correct(&a);
@@ -546,7 +544,6 @@ fn axis_iter_mut_zip_partially_consumed_discontiguous()
 }
 
 #[test]
-#[cfg(feature = "std")]
 fn axis_chunks_iter_corner_cases()
 {
     // examples provided by @bluss in PR #65
@@ -554,7 +551,7 @@ fn axis_chunks_iter_corner_cases()
     // and enable checking if no pointer offsetting is out of bounds. However
     // checking the absence of of out of bounds offsetting cannot (?) be
     // done automatically, so one has to launch this test in a debugger.
-    let a = ArcArray::<f32, _>::linspace(0., 7., 8)
+    let a = Array::from_iter(0..8)
         .into_shape_with_order((8, 1))
         .unwrap();
     let it = a.axis_chunks_iter(Axis(0), 4);
@@ -564,9 +561,9 @@ fn axis_chunks_iter_corner_cases()
     assert_equal(it, vec![a.view()]);
     let it = a.axis_chunks_iter(Axis(0), 3);
     assert_equal(it, vec![
-            array![[7.], [6.], [5.]],
-            array![[4.], [3.], [2.]],
-            array![[1.], [0.]],
+            array![[7], [6], [5]],
+            array![[4], [3], [2]],
+            array![[1], [0]],
         ]);
 
     let b = ArcArray::<f32, _>::zeros((8, 2));

--- a/tests/ixdyn.rs
+++ b/tests/ixdyn.rs
@@ -163,12 +163,11 @@ fn test_0_add_broad()
 }
 
 #[test]
-#[cfg(feature = "std")]
 fn test_into_dimension()
 {
     use ndarray::{Ix0, Ix1, Ix2, IxDyn};
 
-    let a = Array::linspace(0., 41., 6 * 7)
+    let a = Array::from_iter(0..42)
         .into_shape_with_order((6, 7))
         .unwrap();
     let a2 = a.clone().into_shape_with_order(IxDyn(&[6, 7])).unwrap();

--- a/tests/oper.rs
+++ b/tests/oper.rs
@@ -1,7 +1,6 @@
 #![allow(
     clippy::many_single_char_names, clippy::deref_addrof, clippy::unreadable_literal, clippy::many_single_char_names
 )]
-#![cfg(feature = "std")]
 use ndarray::linalg::general_mat_mul;
 use ndarray::linalg::kron;
 use ndarray::prelude::*;
@@ -133,7 +132,7 @@ where
 #[test]
 fn dot_product()
 {
-    let a = Array::range(0., 69., 1.);
+    let a = Array::from_iter((0..69).map(|x| x as f32));
     let b = &a * 2. - 7.;
     let dot = 197846.;
     assert_abs_diff_eq!(a.dot(&b), reference_dot(&a, &b), epsilon = 1e-5);
@@ -172,7 +171,7 @@ fn dot_product()
 #[test]
 fn dot_product_0()
 {
-    let a = Array::range(0., 69., 1.);
+    let a = Array::from_iter((0..69).map(|x| x as f32));
     let x = 1.5;
     let b = aview0(&x);
     let b = b.broadcast(a.dim()).unwrap();
@@ -194,7 +193,7 @@ fn dot_product_0()
 fn dot_product_neg_stride()
 {
     // test that we can dot with negative stride
-    let a = Array::range(0., 69., 1.);
+    let a = Array::from_iter((0..69).map(|x| x as f32));
     let b = &a * 2. - 7.;
     for stride in -10..0 {
         // both negative
@@ -213,7 +212,7 @@ fn dot_product_neg_stride()
 #[test]
 fn fold_and_sum()
 {
-    let a = Array::linspace(0., 127., 128)
+    let a = Array::from_iter((0..128).map(|x| x as f32))
         .into_shape_with_order((8, 16))
         .unwrap();
     assert_abs_diff_eq!(a.fold(0., |acc, &x| acc + x), a.sum(), epsilon = 1e-5);
@@ -255,7 +254,8 @@ fn fold_and_sum()
 #[test]
 fn product()
 {
-    let a = Array::linspace(0.5, 2., 128)
+    let step = (2. - 0.5) / 127.;
+    let a = Array::from_iter((0..128).map(|i| 0.5 + step * (i as f64)))
         .into_shape_with_order((8, 16))
         .unwrap();
     assert_abs_diff_eq!(a.fold(1., |acc, &x| acc * x), a.product(), epsilon = 1e-5);


### PR DESCRIPTION
We have several tests that are unnecessarily behind a `std` feature gate; i.e., the actual code that they're testing does not require `std`. This tries to hunt them all down and make them `no_std` friendly, mostly by removing `ArcArray` and `linspace`.