### PR TITLE
Mention the used rand version 0.9 in ndarray-rand

### DIFF
--- a/ndarray-rand/src/lib.rs
+++ b/ndarray-rand/src/lib.rs
@@ -12,7 +12,7 @@
 //!
 //! ## Note
 //!
-//! `ndarray-rand` depends on [`rand` 0.8][rand].
+//! `ndarray-rand` depends on [`rand` 0.9][rand].
 //!
 //! [`rand`][rand] and [`rand_distr`][rand_distr]
 //! are re-exported as sub-modules, [`ndarray_rand::rand`](rand)
@@ -20,8 +20,8 @@
 //! You can use these submodules for guaranteed version compatibility or
 //! convenience.
 //!
-//! [rand]: https://docs.rs/rand/0.8
-//! [rand_distr]: https://docs.rs/rand_distr/0.4
+//! [rand]: https://docs.rs/rand/0.9
+//! [rand_distr]: https://docs.rs/rand_distr/0.5
 //!
 //! If you want to use a random number generator or distribution from another crate
 //! with `ndarray-rand`, you need to make sure that the other crate also depends on the


### PR DESCRIPTION
`ndarray-rand` crate on the main branch uses the workspace `rand` and `rand_distr` versions, which are 0.9 and 0.5 respectively. This PR documents those versions at `ndarray-rand`'s `lib.rs`' module level, replacing the old versions currently listed there.