### PR TITLE
Only include files that are necessary for crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,14 @@ description = "An n-dimensional array for general elements and for numerics. Lig
 keywords = ["array", "data-structure", "multidimensional", "matrix", "blas"]
 categories = ["data-structures", "science"]
 
-exclude = ["docgen/images/*"]
+include = [
+    "/src/**/*.rs",
+    "LICENSE-MIT",
+    "LICENSE-APACHE",
+    "RELEASES.md",
+    "README.rst",
+    "README-quick-start.md"
+]
 resolver = "2"
 
 [lib]

--- a/ndarray-rand/Cargo.toml
+++ b/ndarray-rand/Cargo.toml
@@ -13,6 +13,14 @@ description = "Constructors for randomized arrays. `rand` integration for `ndarr
 
 keywords = ["multidimensional", "matrix", "rand", "ndarray"]
 
+include = [
+    "/src/**/*.rs",
+    "LICENSE-MIT",
+    "LICENSE-APACHE",
+    "RELEASES.md",
+    "README.rst"
+]
+
 [dependencies]
 ndarray = { workspace = true }
 


### PR DESCRIPTION
Hi everyone 👋

While reviewing dependency updates in our project (trying to assure supply chain safety) I noticed that there are a couple of scripts, tests, benchmarks etc. that are not necessarily required to be published to crates.io. They make it harder to review `ndarray` when checking the supply chain and I was wondering if it would be possible to remove these items from the published package. That would remove potential vectors for a security vulnerability in the future and it would also shrink the size of `ndarray` from 309.5KiB to 237.6KiB compressed. :)

The downside of course would be that e.g. the tests couldn't be run from the crate package anymore, but I'm not sure how popular that is.

I've tried to include all the files that are required (licenses) and that make reviewing things a bit easier (readme and release files can give a good context what has changed between versions).

Best regards!