### PR TITLE
Add PartialEq implementations between ArrayRef and ArrayBase

### DIFF
--- a/src/arraytraits.rs
+++ b/src/arraytraits.rs
@@ -717,6 +717,7 @@ where
 mod tests
 {
     use crate::array;
+    use alloc::vec;
 
     #[test]
     fn test_eq_traits()


### PR DESCRIPTION
This will allow users to ergonomically compare the two types without over-verbose dereferences.

Closes #1549 