### PR TITLE
Exclude development scripts from published package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,16 @@ description = "An n-dimensional array for general elements and for numerics. Lig
 
 keywords = ["array", "data-structure", "multidimensional", "matrix", "blas"]
 categories = ["data-structures", "science"]
-
+include = [
+    "README-crates.io.md", 
+    "README-quick-start.md", 
+    "README.rst", 
+    "RELEASES.md", 
+    "LICENSE-MIT", 
+    "LICENSE-APACHE", 
+    "Cargo.toml", 
+    "src/**/*.rs",
+]
 exclude = ["docgen/images/*"]
 resolver = "2"
 


### PR DESCRIPTION
During a dependency review we noticed that the ndarray crate includes various development scripts. These development scripts shouldn't be there as they might, at some point become problematic. As of now they prevent any downstream user from enabling the `[bans.build.interpreted]` option of cargo deny.

I opted for using an explicit include list instead of an exclude list to prevent these files from being included in the published packages to make sure that everything that's included is an conscious choice.