### PR TITLE
Configure docs for feature gates globally

### DIFF
--- a/src/array_approx.rs
+++ b/src/array_approx.rs
@@ -1,5 +1,4 @@
 #[cfg(feature = "approx")]
-#[cfg_attr(docsrs, doc(cfg(feature = "approx")))]
 mod approx_methods
 {
     use crate::imp_prelude::*;
@@ -244,5 +243,4 @@ macro_rules! impl_approx_traits {
 }
 
 #[cfg(feature = "approx")]
-#[cfg_attr(docsrs, doc(cfg(feature = "approx")))]
 impl_approx_traits!(approx, "**Requires crate feature `\"approx\"`.**");

--- a/src/arraytraits.rs
+++ b/src/arraytraits.rs
@@ -507,7 +507,6 @@ unsafe impl<A, D> Sync for ArrayRef<A, D> where A: Sync {}
 unsafe impl<A, D> Send for ArrayRef<A, D> where A: Send {}
 
 #[cfg(feature = "serde")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 // Use version number so we can add a packed format later.
 pub const ARRAY_FORMAT_VERSION: u8 = 1u8;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -81,7 +81,6 @@ impl PartialEq for ShapeError
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl Error for ShapeError {}
 
 impl fmt::Display for ShapeError

--- a/src/impl_constructors.rs
+++ b/src/impl_constructors.rs
@@ -99,7 +99,6 @@ where S: DataOwned<Elem = A>
     /// assert!(array == arr1(&[0.0, 0.25, 0.5, 0.75, 1.0]))
     /// ```
     #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     pub fn linspace(start: A, end: A, n: usize) -> Self
     where A: Float
     {
@@ -118,7 +117,6 @@ where S: DataOwned<Elem = A>
     /// assert!(array == arr1(&[0., 1., 2., 3., 4.]))
     /// ```
     #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     pub fn range(start: A, end: A, step: A) -> Self
     where A: Float
     {
@@ -147,7 +145,6 @@ where S: DataOwned<Elem = A>
     /// # }
     /// ```
     #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     pub fn logspace(base: A, start: A, end: A, n: usize) -> Self
     where A: Float
     {
@@ -182,7 +179,6 @@ where S: DataOwned<Elem = A>
     /// # example().unwrap();
     /// ```
     #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     pub fn geomspace(start: A, end: A, n: usize) -> Option<Self>
     where A: Float
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 // Enable the doc_cfg nightly feature for including feature gate flags in the documentation
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, doc(auto_cfg))]
 #![warn(missing_docs)]
 
 //! The `ndarray` crate provides an *n*-dimensional container for general elements
@@ -158,7 +159,6 @@ use crate::iterators::{ElementsBase, ElementsBaseMut};
 pub use crate::arraytraits::AsArray;
 pub use crate::linalg_traits::LinalgScalar;
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub use crate::linalg_traits::NdFloat;
 
 pub use crate::stacking::{concatenate, stack};
@@ -201,11 +201,9 @@ mod layout;
 mod linalg_traits;
 mod linspace;
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub use crate::linspace::{linspace, range, Linspace};
 mod logspace;
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub use crate::logspace::{logspace, Logspace};
 mod math_cell;
 mod numeric_util;
@@ -1841,7 +1839,6 @@ where
 
 // parallel methods
 #[cfg(feature = "rayon")]
-#[cfg_attr(docsrs, doc(cfg(feature = "rayon")))]
 pub mod parallel;
 
 mod impl_1d;

--- a/src/linalg_traits.rs
+++ b/src/linalg_traits.rs
@@ -42,7 +42,6 @@ impl<T> LinalgScalar for T where T: 'static + Copy + Zero + One + Add<Output = T
 ///
 /// **Requires default crate feature `"std"`**
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub trait NdFloat:
     Float
     + AddAssign
@@ -62,8 +61,6 @@ pub trait NdFloat:
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl NdFloat for f32 {}
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl NdFloat for f64 {}

--- a/src/numeric/impl_float_maths.rs
+++ b/src/numeric/impl_float_maths.rs
@@ -54,7 +54,6 @@ macro_rules! binary_ops {
 ///
 /// Element-wise math functions for any array type that contains float number.
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl<A, D> ArrayRef<A, D>
 where
     A: 'static + Float,

--- a/src/numeric/impl_numeric.rs
+++ b/src/numeric/impl_numeric.rs
@@ -177,7 +177,6 @@ where D: Dimension
     /// ```
     #[track_caller]
     #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     pub fn var(&self, ddof: A) -> A
     where A: Float + FromPrimitive
     {
@@ -243,7 +242,6 @@ where D: Dimension
     /// ```
     #[track_caller]
     #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     pub fn std(&self, ddof: A) -> A
     where A: Float + FromPrimitive
     {
@@ -400,7 +398,6 @@ where D: Dimension
     /// ```
     #[track_caller]
     #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     pub fn var_axis(&self, axis: Axis, ddof: A) -> Array<A, D::Smaller>
     where
         A: Float + FromPrimitive,
@@ -471,7 +468,6 @@ where D: Dimension
     /// ```
     #[track_caller]
     #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     pub fn std_axis(&self, axis: Axis, ddof: A) -> Array<A, D::Smaller>
     where
         A: Float + FromPrimitive,

--- a/src/partial.rs
+++ b/src/partial.rs
@@ -37,7 +37,6 @@ impl<T> Partial<T>
     }
 
     #[cfg(feature = "rayon")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "rayon")))]
     pub(crate) fn stub() -> Self
     {
         Self {
@@ -47,7 +46,6 @@ impl<T> Partial<T>
     }
 
     #[cfg(feature = "rayon")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "rayon")))]
     pub(crate) fn is_stub(&self) -> bool
     {
         self.ptr.is_null()
@@ -62,7 +60,6 @@ impl<T> Partial<T>
     }
 
     #[cfg(feature = "rayon")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "rayon")))]
     /// Merge if they are in order (left to right) and contiguous.
     /// Skips merge if T does not need drop.
     pub(crate) fn try_merge(mut left: Self, right: Self) -> Self


### PR DESCRIPTION
In #1479 we used `cfg_attr(docsrs, doc(cfg(feature = "...")))` to add feature-gating information to the documentation. However, this required us to "remember" this at every call site. It turns out that there is a `doc(auto_cfg)` setting that we can use globally to do this for us automatically.