### PR TITLE
Avoid index clone in next

### DIFF
--- a/src/dimension/dimension_trait.rs
+++ b/src/dimension/dimension_trait.rs
@@ -196,20 +196,9 @@ pub trait Dimension:
     /// Iteration -- Use self as size, and return next index after `index`
     /// or None if there are no more.
     #[inline]
-    fn next_for(&self, index: Self) -> Option<Self>
+    fn next_for(&self, mut index: Self) -> Option<Self>
     {
-        let mut index = index;
-        let mut done = false;
-        for (&dim, ix) in zip(self.slice(), index.slice_mut()).rev() {
-            *ix += 1;
-            if *ix == dim {
-                *ix = 0;
-            } else {
-                done = true;
-                break;
-            }
-        }
-        if done {
+        if self.next_for_mut(&mut index) {
             Some(index)
         } else {
             None

--- a/src/dimension/dimension_trait.rs
+++ b/src/dimension/dimension_trait.rs
@@ -195,7 +195,6 @@ pub trait Dimension:
     #[doc(hidden)]
     /// Iteration -- Use self as size, and return next index after `index`
     /// or None if there are no more.
-    // FIXME: use &Self for index or even &mut?
     #[inline]
     fn next_for(&self, index: Self) -> Option<Self>
     {
@@ -215,6 +214,24 @@ pub trait Dimension:
         } else {
             None
         }
+    }
+
+    #[doc(hidden)]
+    /// Iteration -- Similar to `next_for`, but addresses the index as mutable reference.
+    #[inline]
+    fn next_for_mut(&self, index: &mut Self) -> bool
+    {
+        let mut end_iteration = true;
+        for (&dim, ix) in zip(self.slice(), index.slice_mut()).rev() {
+            *ix += 1;
+            if *ix == dim {
+                *ix = 0;
+            } else {
+                end_iteration = false;
+                break;
+            }
+        }
+        !end_iteration
     }
 
     #[doc(hidden)]

--- a/src/iterators/mod.rs
+++ b/src/iterators/mod.rs
@@ -74,10 +74,12 @@ impl<A, D: Dimension> Iterator for Baseiter<A, D>
     {
         let index = match self.index {
             None => return None,
-            Some(ref ix) => ix.clone(),
+            Some(ref mut ix) => ix,
         };
         let offset = D::stride_offset(&index, &self.strides);
-        self.index = self.dim.next_for(index);
+        if !self.dim.next_for_mut(index) {
+            self.index = None;
+        }
         unsafe { Some(self.ptr.offset(offset)) }
     }
 

--- a/src/iterators/mod.rs
+++ b/src/iterators/mod.rs
@@ -76,7 +76,7 @@ impl<A, D: Dimension> Iterator for Baseiter<A, D>
             None => return None,
             Some(ref mut ix) => ix,
         };
-        let offset = D::stride_offset(&index, &self.strides);
+        let offset = D::stride_offset(index, &self.strides);
         if !self.dim.next_for_mut(index) {
             self.index = None;
         }

--- a/src/partial.rs
+++ b/src/partial.rs
@@ -71,7 +71,7 @@ impl<T> Partial<T>
         // covers the whole output.
         if left.is_stub() {
             right
-        } else if left.ptr.wrapping_add(left.len) == right.ptr {
+        } else if ptr::eq(left.ptr.wrapping_add(left.len), right.ptr) {
             left.len += right.release_ownership();
             left
         } else {


### PR DESCRIPTION
Hello, everyone.

My colleague @chaehhyun found that there are some regressions due to the `clone` in `next` during a profiling. We suspect `ix.clone()` inside `Baseiter::next` is the culprit, but not 100% for sure as of now. We are still experimenting its impact internally.

I have a couple of questions:
- I am curious if the cloning of index in `next` is intentional.
- If it is not the case, is there any pre-existing perf test in CI?

Thank you.