### PR TITLE
perf(iteration): use move instead of clone for iteration

### DIFF
--- a/src/dimension/dimension_trait.rs
+++ b/src/dimension/dimension_trait.rs
@@ -197,9 +197,8 @@ pub trait Dimension:
     /// or None if there are no more.
     // FIXME: use &Self for index or even &mut?
     #[inline]
-    fn next_for(&self, index: Self) -> Option<Self>
+    fn next_for(&self, mut index: Self) -> Option<Self>
     {
-        let mut index = index;
         let mut done = false;
         for (&dim, ix) in zip(self.slice(), index.slice_mut()).rev() {
             *ix += 1;

--- a/src/iterators/mod.rs
+++ b/src/iterators/mod.rs
@@ -18,8 +18,8 @@ mod windows;
 use alloc::vec::Vec;
 use std::iter::FromIterator;
 use std::marker::PhantomData;
+use std::ptr;
 use std::ptr::NonNull;
-use std::{mem, ptr};
 
 #[allow(unused_imports)] // Needed for Rust 1.64
 use rawpointer::PointerExt;

--- a/src/iterators/mod.rs
+++ b/src/iterators/mod.rs
@@ -18,8 +18,8 @@ mod windows;
 use alloc::vec::Vec;
 use std::iter::FromIterator;
 use std::marker::PhantomData;
-use std::ptr;
 use std::ptr::NonNull;
+use std::{mem, ptr};
 
 #[allow(unused_imports)] // Needed for Rust 1.64
 use rawpointer::PointerExt;
@@ -72,10 +72,7 @@ impl<A, D: Dimension> Iterator for Baseiter<A, D>
     #[inline]
     fn next(&mut self) -> Option<Self::Item>
     {
-        let index = match self.index {
-            None => return None,
-            Some(ref ix) => ix.clone(),
-        };
+        let index = self.index.take()?;
         let offset = D::stride_offset(&index, &self.strides);
         self.index = self.dim.next_for(index);
         unsafe { Some(self.ptr.offset(offset)) }


### PR DESCRIPTION
@scho-furiosa pointed out in #1584 that there was an unnecessary `clone` in `Baseiter::next` that was degrading performance for dynamic-dimensional arrays. This change switches to a move, netting a 74% speedup in iteration for dynamic-dimensional arrays.

Tests (detailed in #1584) showed that there was a trade-off in performance between dynamic- and fixed-dimensional iteration. `ArrayD` performs best when mutating its index; `ArrayN` performs best when using a move. This is an indication that, in the future, `Baseiter::next` should dispatch to the "layout" / `Dimension` underlying type.