### PR TITLE
refactor: add a trait to describe shapes

### DIFF
--- a/src/layout/dyn_repr.rs
+++ b/src/layout/dyn_repr.rs
@@ -1,0 +1,214 @@
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+use core::ops::{Add, AddAssign, Mul, MulAssign, Sub, SubAssign};
+use core::ops::{Deref, DerefMut, Index, IndexMut};
+use core::slice::Iter;
+use num_traits::Zero;
+
+use crate::layout::rank::DynRank;
+use crate::layout::ranked::Ranked;
+use crate::layout::shape::{IntoShape, Shape};
+use crate::Axis;
+
+const CAP: usize = 4;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DynAxesRepr<T>
+{
+    Inline(usize, [T; CAP]),
+    Alloc(Box<[T]>),
+}
+
+pub type DShape = DynAxesRepr<usize>;
+
+impl<T> DynAxesRepr<T>
+{
+    fn ndim(&self) -> usize
+    {
+        match self {
+            DynAxesRepr::Inline(len, _) => *len,
+            DynAxesRepr::Alloc(items) => items.len(),
+        }
+    }
+}
+
+impl<T> Deref for DynAxesRepr<T>
+{
+    type Target = [T];
+
+    fn deref(&self) -> &Self::Target
+    {
+        match self {
+            DynAxesRepr::Inline(len, arr) => {
+                debug_assert!(*len <= arr.len());
+                unsafe { arr.get_unchecked(..*len) }
+            }
+            DynAxesRepr::Alloc(items) => items,
+        }
+    }
+}
+
+impl<T> DerefMut for DynAxesRepr<T>
+{
+    fn deref_mut(&mut self) -> &mut Self::Target
+    {
+        todo!()
+    }
+}
+
+impl<T> Index<usize> for DynAxesRepr<T>
+{
+    type Output = T;
+
+    fn index(&self, index: usize) -> &Self::Output
+    {
+        &(**self)[index]
+    }
+}
+
+impl<T> IndexMut<usize> for DynAxesRepr<T>
+{
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output
+    {
+        &mut (**self)[index]
+    }
+}
+
+impl<T> Index<Axis> for DynAxesRepr<T>
+{
+    type Output = T;
+
+    fn index(&self, index: Axis) -> &Self::Output
+    {
+        self.index(index.0)
+    }
+}
+
+impl<T> IndexMut<Axis> for DynAxesRepr<T>
+{
+    fn index_mut(&mut self, index: Axis) -> &mut Self::Output
+    {
+        self.index_mut(index.0)
+    }
+}
+
+impl<T> Default for DynAxesRepr<T>
+where T: Zero + Copy
+{
+    fn default() -> Self
+    {
+        Self::Inline(1, [T::zero(); 4])
+    }
+}
+
+impl Zero for DShape
+{
+    fn zero() -> Self
+    {
+        Self::Inline(1, [0usize; CAP])
+    }
+
+    fn is_zero(&self) -> bool
+    {
+        self.iter().all(|e| e.is_zero())
+    }
+
+    fn set_zero(&mut self)
+    {
+        self.iter_mut().for_each(|e| e.set_zero());
+    }
+}
+
+impl<Rhs, T> From<Rhs> for DynAxesRepr<T>
+where
+    Rhs: AsRef<[T]>,
+    T: Default + Copy,
+{
+    fn from(value: Rhs) -> Self
+    {
+        let value = value.as_ref();
+        let n = value.len();
+        if n <= CAP {
+            let mut inline = [T::default(); CAP];
+            inline.split_at_mut(n).0.copy_from_slice(value);
+            Self::Inline(n, inline)
+        } else {
+            Self::Alloc(value.into())
+        }
+    }
+}
+
+impl<T> Ranked for DynAxesRepr<T>
+{
+    type NDim = DynRank;
+
+    fn ndim(&self) -> usize
+    {
+        match self {
+            DynAxesRepr::Inline(d, _) => d.clone(),
+            DynAxesRepr::Alloc(items) => items.len(),
+        }
+    }
+}
+
+macro_rules! impl_op {
+    ($op_trait:ty, $op_fn:ident, $op_assign_trait:ty, $op_assign_fn:ident) => {
+        /// *Panics* if the two dimensionalities are different
+        impl<Rhs> $op_trait for DShape
+        where
+            Rhs: IntoShape<NDim = DynRank>,
+        {
+            type Output = DShape;
+
+            fn $op_fn(self, rhs: Rhs) -> <Self as $op_trait>::Output {
+                let mut output = self.clone();
+                output.$op_assign_fn(rhs);
+                output
+            }
+        }
+
+        /// *Panics* if the two dimensionalities are different
+        impl<Rhs> $op_assign_trait for DShape
+        where
+            Rhs: IntoShape<NDim = DynRank>,
+        {
+            fn $op_assign_fn(&mut self, rhs: Rhs) {
+                let other = rhs.into_shape();
+                for i in 0..self.ndim().max(other.ndim()) {
+                    self[i].$op_assign_fn(other[i]);
+                }
+            }
+        }
+    };
+}
+
+impl_op!(Add<Rhs>, add, AddAssign<Rhs>, add_assign);
+impl_op!(Sub<Rhs>, sub, SubAssign<Rhs>, sub_assign);
+impl_op!(Mul<Rhs>, mul, MulAssign<Rhs>, mul_assign);
+
+impl<T> IntoIterator for DynAxesRepr<T>
+where T: Clone
+{
+    type Item = T;
+    type IntoIter = alloc::vec::IntoIter<T>;
+
+    fn into_iter(self) -> Self::IntoIter
+    {
+        match self {
+            DynAxesRepr::Inline(len, arr) => Vec::from(arr[..len].to_vec()).into_iter(),
+            DynAxesRepr::Alloc(b) => b.into_vec().into_iter(),
+        }
+    }
+}
+
+impl Shape for DynAxesRepr<usize>
+{
+    type Iter<'a>
+        = Iter<'a, usize>
+    where Self: 'a;
+
+    fn iter(&self) -> Self::Iter<'_>
+    {
+        (**self).iter()
+    }
+}

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -13,6 +13,7 @@ pub mod rank;
 pub mod ranked;
 mod shape;
 mod n_repr;
+mod dyn_repr;
 
 use core::any::type_name;
 use core::error::Error;
@@ -23,6 +24,7 @@ use crate::layout::ranked::Ranked;
 
 #[allow(deprecated)]
 pub use bitset::{Layout, LayoutBitset};
+pub use dyn_repr::DShape;
 pub use n_repr::NShape;
 pub use shape::Shape;
 

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -11,7 +11,8 @@
 mod bitset;
 pub mod rank;
 pub mod ranked;
-pub mod shape;
+mod shape;
+mod n_repr;
 
 use core::any::type_name;
 use core::error::Error;
@@ -22,6 +23,8 @@ use crate::layout::ranked::Ranked;
 
 #[allow(deprecated)]
 pub use bitset::{Layout, LayoutBitset};
+pub use n_repr::NShape;
+pub use shape::Shape;
 
 /// The error type for dealing with shapes and strides
 #[derive(Debug, Clone, Copy)]
@@ -31,20 +34,8 @@ pub enum ShapeStrideError<S>
     OutOfBounds(PhantomData<S>, usize),
     /// The error when trying to construct or mutate a shape or strides with the wrong dimensionality value.
     RankMismatch(PhantomData<S>, usize),
-    /// The desired shape would represent an array with more elements than `usize::MAX`
+    /// The desired shape would represent an array with more elements than `isize::MAX`
     ShapeOverflow,
-}
-
-impl<S> ShapeStrideError<S>
-{
-    pub fn replace_type_with<T>(&self) -> ShapeStrideError<T>
-    {
-        match self {
-            ShapeStrideError::OutOfBounds(_, u) => ShapeStrideError::OutOfBounds(PhantomData, *u),
-            ShapeStrideError::RankMismatch(_, u) => ShapeStrideError::RankMismatch(PhantomData, *u),
-            ShapeStrideError::ShapeOverflow => ShapeStrideError::ShapeOverflow,
-        }
-    }
 }
 
 impl<S: Ranked> Display for ShapeStrideError<S>

--- a/src/layout/n_repr.rs
+++ b/src/layout/n_repr.rs
@@ -171,6 +171,19 @@ where ConstRank<N>: Rank
     }
 }
 
+impl<const N: usize> Zero for NShape<N>
+{
+    fn zero() -> Self
+    {
+        Self([usize::zero(); N])
+    }
+
+    fn is_zero(&self) -> bool
+    {
+        self.0.iter().all(|e| *e == 0usize)
+    }
+}
+
 macro_rules! impl_op {
     ($op_trait:ty, $op_fn:ident, $op_assign_trait:ty, $op_assign_fn:ident) => {
         impl<Rhs, const N: usize> $op_trait for NShape<N>
@@ -270,6 +283,6 @@ impl<const N: usize> Default for NShape<N>
 {
     fn default() -> Self
     {
-        Self([0; N])
+        Self::zero()
     }
 }

--- a/src/layout/n_repr.rs
+++ b/src/layout/n_repr.rs
@@ -1,9 +1,10 @@
 use core::{
     array::IntoIter,
+    iter::Cloned,
     marker::PhantomData,
     ops::{Add, AddAssign, Deref, DerefMut, Index, IndexMut, Mul, MulAssign, Sub, SubAssign},
+    slice::Iter,
 };
-use std::{iter::Cloned, slice::Iter};
 
 use num_traits::Zero;
 

--- a/src/layout/n_repr.rs
+++ b/src/layout/n_repr.rs
@@ -1,0 +1,298 @@
+use core::{
+    array::IntoIter,
+    marker::PhantomData,
+    ops::{Add, AddAssign, Deref, DerefMut, Index, IndexMut, Mul, MulAssign, Sub, SubAssign},
+};
+use std::slice::Iter;
+
+use num_traits::Zero;
+
+use crate::layout::{
+    rank::{ConstRank, Rank},
+    ranked::Ranked,
+    shape::{IntoShape, Shape},
+    ShapeStrideError,
+};
+
+/// A wrapper for fixed-length arrays that can be used for shape and strides.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ShapeStrideN<T, const N: usize>([T; N]);
+
+pub type NShape<const N: usize> = ShapeStrideN<usize, N>;
+
+impl<T, const N: usize> Deref for ShapeStrideN<T, N>
+{
+    type Target = [T; N];
+
+    fn deref(&self) -> &Self::Target
+    {
+        &self.0
+    }
+}
+
+impl<T, const N: usize> DerefMut for ShapeStrideN<T, N>
+{
+    fn deref_mut(&mut self) -> &mut Self::Target
+    {
+        &mut self.0
+    }
+}
+
+impl<T, const N: usize> Index<usize> for ShapeStrideN<T, N>
+{
+    type Output = T;
+
+    fn index(&self, index: usize) -> &Self::Output
+    {
+        &self.0[index]
+    }
+}
+
+impl<T, const N: usize> IndexMut<usize> for ShapeStrideN<T, N>
+{
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output
+    {
+        &mut self.0[index]
+    }
+}
+
+impl<T, const N: usize> From<[T; N]> for ShapeStrideN<T, N>
+{
+    fn from(value: [T; N]) -> Self
+    {
+        Self { 0: value }
+    }
+}
+
+impl<T, const N: usize> From<ShapeStrideN<T, N>> for [T; N]
+{
+    fn from(value: ShapeStrideN<T, N>) -> Self
+    {
+        value.0
+    }
+}
+
+impl<'a, T, const N: usize> TryFrom<&'a [T]> for ShapeStrideN<T, N>
+where T: Copy + Zero
+{
+    type Error = ShapeStrideError<Self>;
+
+    fn try_from(value: &'a [T]) -> Result<Self, Self::Error>
+    {
+        if value.len() != N {
+            Err(ShapeStrideError::BadDimality(PhantomData, value.len()))
+        } else {
+            let mut arr = [T::zero(); N];
+            arr.copy_from_slice(value);
+            Ok(Self { 0: arr })
+        }
+    }
+}
+
+impl<T, const N: usize> IntoIterator for ShapeStrideN<T, N>
+{
+    type Item = T;
+
+    type IntoIter = IntoIter<T, N>;
+
+    fn into_iter(self) -> Self::IntoIter
+    {
+        self.0.into_iter()
+    }
+}
+
+macro_rules! shapestride_and_tuples {
+    ($(($tuple:ty, $N:literal)),*) => {
+        $(
+            impl<T> From<$tuple> for ShapeStrideN<T, $N>
+            {
+                fn from(value: $tuple) -> Self
+                {
+                    Self { 0: value.into() }
+                }
+            }
+
+            impl<T> From<ShapeStrideN<T, $N>> for $tuple
+            {
+                fn from(value: ShapeStrideN<T, $N>) -> Self
+                {
+                    value.0.into()
+                }
+            }
+
+            impl<T> IntoShape for $tuple
+            where
+                NShape<$N>: From<$tuple>,
+                T: Copy,
+            {
+                type NDim = ConstRank<$N>;
+
+                type Shape = NShape<$N>;
+
+                fn into_shape(&self) -> Self::Shape
+                {
+                    (*self).into()
+                }
+            }
+        )*
+    };
+}
+
+shapestride_and_tuples!(
+    ((T,), 1),
+    ((T, T), 2),
+    ((T, T, T), 3),
+    ((T, T, T, T), 4),
+    ((T, T, T, T, T), 5),
+    ((T, T, T, T, T, T), 6),
+    ((T, T, T, T, T, T, T), 7),
+    ((T, T, T, T, T, T, T, T), 8),
+    ((T, T, T, T, T, T, T, T, T), 9),
+    ((T, T, T, T, T, T, T, T, T, T), 10),
+    ((T, T, T, T, T, T, T, T, T, T, T), 11),
+    ((T, T, T, T, T, T, T, T, T, T, T, T), 12)
+);
+
+impl<Rhs, T, const N: usize> PartialEq<Rhs> for ShapeStrideN<T, N>
+where
+    T: PartialEq,
+    Rhs: AsRef<[T]>,
+{
+    fn eq(&self, other: &Rhs) -> bool
+    {
+        let other = other.as_ref();
+        if other.len() != N {
+            return false;
+        }
+        for i in 0..N {
+            if self[i] != other[i] {
+                return false;
+            }
+        }
+        return true;
+    }
+}
+
+impl<T, const N: usize> Ranked for ShapeStrideN<T, N>
+where ConstRank<N>: Rank
+{
+    type NDim = ConstRank<N>;
+
+    fn ndim(&self) -> usize
+    {
+        N
+    }
+}
+
+impl<const N: usize> IntoShape for [usize; N]
+where ConstRank<N>: Rank
+{
+    type NDim = ConstRank<N>;
+
+    type Shape = NShape<N>;
+
+    fn into_shape(&self) -> Self::Shape
+    {
+        (*self).into()
+    }
+}
+
+macro_rules! impl_op {
+    ($op_trait:ty, $op_fn:ident, $op_assign_trait:ty, $op_assign_fn:ident) => {
+        impl<Rhs, const N: usize> $op_trait for NShape<N>
+        where
+            Rhs: IntoShape<NDim = ConstRank<N>>,
+        {
+            type Output = NShape<N>;
+
+            fn $op_fn(self, rhs: Rhs) -> Self::Output {
+                let mut output = self.clone();
+                output.$op_assign_fn(rhs);
+                output
+            }
+        }
+
+        impl<Rhs, const N: usize> $op_assign_trait for NShape<N>
+        where
+            Rhs: IntoShape<NDim = ConstRank<N>>,
+        {
+            fn $op_assign_fn(&mut self, rhs: Rhs) {
+                let other = rhs.into_shape();
+                for i in 0..N {
+                    self[i].$op_assign_fn(other[i]);
+                }
+            }
+        }
+    };
+}
+
+impl_op!(Add<Rhs>, add, AddAssign<Rhs>, add_assign);
+impl_op!(Sub<Rhs>, sub, SubAssign<Rhs>, sub_assign);
+impl_op!(Mul<Rhs>, mul, MulAssign<Rhs>, mul_assign);
+
+impl<const N: usize> Add<usize> for NShape<N>
+{
+    type Output = NShape<N>;
+
+    fn add(self, rhs: usize) -> Self::Output
+    {
+        let mut output = self.clone();
+        output += rhs;
+        output
+    }
+}
+
+impl<const N: usize> AddAssign<usize> for NShape<N>
+{
+    fn add_assign(&mut self, rhs: usize)
+    {
+        for o in self.iter_mut() {
+            *o += rhs;
+        }
+    }
+}
+
+impl<const N: usize> Mul<usize> for NShape<N>
+{
+    type Output = NShape<N>;
+
+    fn mul(self, rhs: usize) -> Self::Output
+    {
+        let mut output = self.clone();
+        for o in output.iter_mut() {
+            *o = *o * rhs;
+        }
+        output
+    }
+}
+
+impl<const N: usize> MulAssign<usize> for NShape<N>
+{
+    fn mul_assign(&mut self, rhs: usize)
+    {
+        for o in self.iter_mut() {
+            *o += rhs;
+        }
+    }
+}
+
+impl<const N: usize> Shape for NShape<N>
+where ConstRank<N>: Rank
+{
+    type Iter<'a>
+        = Iter<'a, usize>
+    where Self: 'a;
+
+    fn iter(&self) -> Self::Iter<'_>
+    {
+        self.0.iter()
+    }
+}
+
+impl<const N: usize> Default for NShape<N>
+{
+    fn default() -> Self
+    {
+        Self([0; N])
+    }
+}

--- a/src/layout/shape.rs
+++ b/src/layout/shape.rs
@@ -1,0 +1,83 @@
+use core::iter::Map;
+
+use crate::layout::rank::Rank;
+use crate::layout::ranked::Ranked;
+
+pub trait Shape: Ranked
+{
+    type Iter<'a>: Iterator<Item = &'a usize> + ExactSizeIterator + DoubleEndedIterator
+    where Self: 'a;
+
+    type Pattern: Ranked<NDim = Self::NDim>;
+
+    /// The length of the array along a given axis.
+    fn axis_len(&self, axis: usize) -> usize;
+
+    /// Iterate over the dimensions of the shape.
+    fn iter(&self) -> Self::Iter<'_>;
+
+    /// Get the number of elements that the array contains.
+    ///
+    /// If the number of elements is greater than `isize::MAX`, returns `None`.
+    ///
+    /// # Safety
+    /// This method checks for overflow past `isize`, not `usize`. If this method returns `Some(_)`,
+    /// then users know they can safely cast all dimensions of the shape to `isize`, which is often
+    /// necessary for calculations with strides and offsets.
+    fn size_checked(&self) -> Option<usize>
+    {
+        self.iter()
+            .try_fold(1_usize, |acc, &i| acc.checked_mul(i))
+            .and_then(as_usize_if_isize_compatible)
+    }
+
+    /// Get the number of bytes that this array would fill.
+    ///
+    /// # Safety
+    /// This method checks for bytes overflow past `isize`. If this method returns `Some(_)`,
+    /// then users know that an allocated array is indexable using `isize` offsets.
+    fn size_bytes_checked<T>(&self) -> Option<usize>
+    {
+        self.size_checked()
+            .and_then(|v| v.checked_mul(size_of::<T>()))
+            .and_then(as_usize_if_isize_compatible)
+    }
+
+    fn iter_isize<'a>(&'a self) -> Option<Map<Self::Iter<'a>, impl FnMut(&'a usize) -> isize>>
+    {
+        self.size_checked()
+            .map(|_| self.iter().map(|v| *v as isize))
+    }
+}
+
+fn as_usize_if_isize_compatible(v: usize) -> Option<usize>
+{
+    if v <= (isize::MAX as usize) {
+        Some(v)
+    } else {
+        None
+    }
+}
+
+/// A conversion trait for types that can turn into a shape.
+pub trait IntoShape
+{
+    type NDim: Rank;
+
+    type Shape: Shape<NDim = Self::NDim>;
+
+    fn into_shape(&self) -> Self::Shape;
+}
+
+impl<T> IntoShape for T
+where T: Shape
+{
+    type NDim = T::NDim;
+
+    type Shape = T;
+
+    fn into_shape(&self) -> Self::Shape
+    {
+        self.clone()
+    }
+}

--- a/src/layout/shape.rs
+++ b/src/layout/shape.rs
@@ -1,20 +1,26 @@
+use core::array;
 use core::iter::Map;
 
-use crate::layout::rank::Rank;
+use crate::layout::rank::{ConstRank, DynRank, Rank};
 use crate::layout::ranked::Ranked;
 
 pub trait Shape: Ranked
 {
-    type Iter<'a>: Iterator<Item = &'a usize> + ExactSizeIterator + DoubleEndedIterator
-    where Self: 'a;
+    type Iter: Iterator<Item = usize> + ExactSizeIterator + DoubleEndedIterator;
 
+    /// A representation of the shape as a type that can be destructured.
+    ///
+    /// For example, for 2D shapes, this should be something like [usize; 2].
+    /// For 3D shapes, [usize; 3], etc.
+    /// For shapes whose rank isn't known at compile time, this can be the marker
+    /// type [`DMarker`].
     type Pattern: Ranked<NDim = Self::NDim>;
 
     /// The length of the array along a given axis.
     fn axis_len(&self, axis: usize) -> usize;
 
     /// Iterate over the dimensions of the shape.
-    fn iter(&self) -> Self::Iter<'_>;
+    fn iter(&self) -> Self::Iter;
 
     /// Get the number of elements that the array contains.
     ///
@@ -27,7 +33,7 @@ pub trait Shape: Ranked
     fn size_checked(&self) -> Option<usize>
     {
         self.iter()
-            .try_fold(1_usize, |acc, &i| acc.checked_mul(i))
+            .try_fold(1_usize, |acc, i| acc.checked_mul(i))
             .and_then(as_usize_if_isize_compatible)
     }
 
@@ -43,10 +49,9 @@ pub trait Shape: Ranked
             .and_then(as_usize_if_isize_compatible)
     }
 
-    fn iter_isize<'a>(&'a self) -> Option<Map<Self::Iter<'a>, impl FnMut(&'a usize) -> isize>>
+    fn iter_isize<'a>(&'a self) -> Option<Map<Self::Iter, impl FnMut(usize) -> isize>>
     {
-        self.size_checked()
-            .map(|_| self.iter().map(|v| *v as isize))
+        self.size_checked().map(|_| self.iter().map(|v| v as isize))
     }
 }
 
@@ -57,6 +62,13 @@ fn as_usize_if_isize_compatible(v: usize) -> Option<usize>
     } else {
         None
     }
+}
+
+pub trait Patterned
+{
+    type Pattern;
+
+    fn into_pattern(&self) -> Self::Pattern;
 }
 
 /// A conversion trait for types that can turn into a shape.
@@ -70,7 +82,7 @@ pub trait IntoShape
 }
 
 impl<T> IntoShape for T
-where T: Shape
+where T: Shape + Clone
 {
     type NDim = T::NDim;
 

--- a/src/layout/shape.rs
+++ b/src/layout/shape.rs
@@ -1,35 +1,23 @@
-use core::array;
 use core::iter::Map;
 
-use crate::layout::rank::{ConstRank, DynRank, Rank};
 use crate::layout::ranked::Ranked;
 
+/// A trait for array shapes.
 pub trait Shape: Ranked
 {
-    type Iter: Iterator<Item = usize> + ExactSizeIterator + DoubleEndedIterator;
-
-    /// A representation of the shape as a type that can be destructured.
-    ///
-    /// For example, for 2D shapes, this should be something like [usize; 2].
-    /// For 3D shapes, [usize; 3], etc.
-    /// For shapes whose rank isn't known at compile time, this can be the marker
-    /// type [`DMarker`].
-    type Pattern: Ranked<NDim = Self::NDim>;
+    /// The iterator type over the dimensions of the shape.
+    type Iter<'a>: Iterator<Item = usize> + ExactSizeIterator + DoubleEndedIterator
+    where Self: 'a;
 
     /// The length of the array along a given axis.
     fn axis_len(&self, axis: usize) -> usize;
 
     /// Iterate over the dimensions of the shape.
-    fn iter(&self) -> Self::Iter;
+    fn iter(&self) -> Self::Iter<'_>;
 
     /// Get the number of elements that the array contains.
     ///
     /// If the number of elements is greater than `isize::MAX`, returns `None`.
-    ///
-    /// # Safety
-    /// This method checks for overflow past `isize`, not `usize`. If this method returns `Some(_)`,
-    /// then users know they can safely cast all dimensions of the shape to `isize`, which is often
-    /// necessary for calculations with strides and offsets.
     fn size_checked(&self) -> Option<usize>
     {
         self.iter()
@@ -49,7 +37,10 @@ pub trait Shape: Ranked
             .and_then(as_usize_if_isize_compatible)
     }
 
-    fn iter_isize<'a>(&'a self) -> Option<Map<Self::Iter, impl FnMut(usize) -> isize>>
+    /// Iterate over the shape as `isize`.
+    ///
+    /// If the number of elements is greater than `isize::MAX`, returns `None`.
+    fn iter_isize<'a>(&'a self) -> Option<Map<Self::Iter<'a>, impl FnMut(usize) -> isize>>
     {
         self.size_checked().map(|_| self.iter().map(|v| v as isize))
     }
@@ -61,35 +52,5 @@ fn as_usize_if_isize_compatible(v: usize) -> Option<usize>
         Some(v)
     } else {
         None
-    }
-}
-
-pub trait Patterned
-{
-    type Pattern;
-
-    fn into_pattern(&self) -> Self::Pattern;
-}
-
-/// A conversion trait for types that can turn into a shape.
-pub trait IntoShape
-{
-    type NDim: Rank;
-
-    type Shape: Shape<NDim = Self::NDim>;
-
-    fn into_shape(&self) -> Self::Shape;
-}
-
-impl<T> IntoShape for T
-where T: Shape + Clone
-{
-    type NDim = T::NDim;
-
-    type Shape = T;
-
-    fn into_shape(&self) -> Self::Shape
-    {
-        self.clone()
     }
 }

--- a/src/layout/shape.rs
+++ b/src/layout/shape.rs
@@ -2,7 +2,25 @@ use core::iter::Map;
 
 use crate::layout::ranked::Ranked;
 
-/// A trait for array shapes.
+/// A trait for array shapes: lists of `usize` describing the length of each dimension of an array.
+///
+/// ## Size Limits
+/// Arrays cannot have more than [`usize::MAX`] elements; otherwise, it would not be possible
+/// to address all of the elements in-memory. In addition, since an array may have negative strides
+/// (i.e., elements _behind_ the current pointer in memory), arrays must be addressable using
+/// [`isize`]. So no array can have more than [`isize::MAX`] elements. Finally, for multi-byte
+/// element types, the total byte size of the array also cannot exceed `isize::MAX`.
+///
+/// Implementing `Shape` for a type does not guarantee that the type will always represent an
+/// array that adheres to these size limits. It does, however, provide access to two methods that
+/// can cheaply check these invariants: [`Shape::size_checked`] and [`Shape::size_bytes_checked`].
+/// In order for an instance of a `Shape` to be valid, both of these methods must return `Some(_)`.
+///
+/// ## Mutability
+/// The `Shape` trait does not provide any sort of mutability for the lengths of each axis.
+/// This allows users to define constant-sized shapes, which can significantly increase performance.
+///
+/// Since `Shape` is still experimental, the mechanisms for mutability are still being designed.
 pub trait Shape: Ranked
 {
     /// The iterator type over the dimensions of the shape.
@@ -27,7 +45,6 @@ pub trait Shape: Ranked
 
     /// Get the number of bytes that this array would fill.
     ///
-    /// # Safety
     /// This method checks for bytes overflow past `isize`. If this method returns `Some(_)`,
     /// then users know that an allocated array is indexable using `isize` offsets.
     fn size_bytes_checked<T>(&self) -> Option<usize>


### PR DESCRIPTION
This is the next PR to address #1506. The aim of this PR is to introduce a minimal trait for representing shapes - an ordered collection of axis lengths for an array. Although this is a starting point for the trait, I suspect I will have to add / modify it as I move through the refactor and see just exactly how/when a `Shape` is used.

A few design quirks of this trait. First of all, there is no `Index` bound on `Shape`, or a default `Index` implementation. Unfortunately, `Index` requires returning `&T`: it requires that the return be borrowed from the indexed type. One of the explicit goals of this rework is to allow constant-sized shapes, including shapes which are entirely defined at compile time and zero-sized. These shapes wouldn't have any value to lend out for the borrow. The same goes for shapes which are computed.

Instead, this design makes two requirements of the shape. First, a function, `axis_len`, that returns the length of an axis. Second, that the shape can be iterated over.

We use these required methods to define several checks and derived methods on `Shape`, which are mostly concerned with the existing safety limit that `ndarray` imposes under the hood: that the number of elements and number of bytes in an array both be less than or equal to `isize::MAX`.

I also provide structs that implement `Shape` for both `const`-dimensionality and dynamic dimensionality.