### PR TITLE
implement dot for higher-dimensional arrays with Ix2

### DIFF
--- a/benches/bench1.rs
+++ b/benches/bench1.rs
@@ -6,6 +6,7 @@ extern crate test;
 
 use std::mem::MaybeUninit;
 
+use ndarray::linalg::Dot;
 use ndarray::{arr0, arr1, arr2, azip, s};
 use ndarray::{Array, Array1, Array2, Axis, Ix, Zip};
 use ndarray::{Array3, Array4, ShapeBuilder};
@@ -906,6 +907,23 @@ fn equality_f32_mixorder(bench: &mut test::Bencher)
     let a = Array::<f32, _>::zeros((64, 64));
     let b = Array::<f32, _>::zeros((64, 64).f());
     bench.iter(|| a == b);
+}
+
+#[bench]
+fn dot_3d_f64_contiguous(bench: &mut test::Bencher)
+{
+    let a: Array3<f64> = Array::zeros((32, 32, 32));
+    let b: Array2<f64> = Array::zeros((32, 32));
+    bench.iter(|| a.dot(&b));
+}
+
+#[bench]
+fn dot_3d_f64_non_contiguous(bench: &mut test::Bencher)
+{
+    let a_base: Array3<f64> = Array::zeros((64, 32, 32));
+    let a = a_base.slice(s![..;2, .., ..]).to_owned();
+    let b: Array2<f64> = Array::zeros((32, 32));
+    bench.iter(|| a.dot(&b));
 }
 
 #[bench]

--- a/src/indexes.rs
+++ b/src/indexes.rs
@@ -57,10 +57,7 @@ where D: Dimension
     #[inline]
     fn next(&mut self) -> Option<Self::Item>
     {
-        let index = match self.index {
-            None => return None,
-            Some(ref ix) => ix.clone(),
-        };
+        let index = self.index.as_ref()?.clone();
         self.index = self.dim.next_for(index.clone());
         Some(index.into_pattern())
     }

--- a/src/iterators/mod.rs
+++ b/src/iterators/mod.rs
@@ -512,10 +512,7 @@ impl<'a, A, D: Dimension> Iterator for IndexedIter<'a, A, D>
     #[inline]
     fn next(&mut self) -> Option<Self::Item>
     {
-        let index = match self.0.inner.index {
-            None => return None,
-            Some(ref ix) => ix.clone(),
-        };
+        let index = self.0.inner.index.as_ref()?.clone();
         match self.0.next() {
             None => None,
             Some(elem) => Some((index.into_pattern(), elem)),
@@ -695,10 +692,7 @@ impl<'a, A, D: Dimension> Iterator for IndexedIterMut<'a, A, D>
     #[inline]
     fn next(&mut self) -> Option<Self::Item>
     {
-        let index = match self.0.inner.index {
-            None => return None,
-            Some(ref ix) => ix.clone(),
-        };
+        let index = self.0.inner.index.as_ref()?.clone();
         match self.0.next() {
             None => None,
             Some(elem) => Some((index.into_pattern(), elem)),

--- a/src/linalg/impl_linalg.rs
+++ b/src/linalg/impl_linalg.rs
@@ -157,6 +157,22 @@ unsafe fn blas_1d_params<A>(ptr: *const A, len: usize, stride: isize) -> (*const
 ///
 /// For two-dimensional arrays, the dot method computes the matrix
 /// multiplication.
+///
+/// For higher-dimensional arrays (3-D through 6-D, and dynamic-dimensional),
+/// `Dot<Ix2>` contracts the last axis of the left-hand side with the first
+/// axis of the right-hand side, following NumPy semantics.  For example, if
+/// `self` has shape *I* × *J* × *K* and `rhs` has shape *K* × *N*, the
+/// result has shape *I* × *J* × *N*.
+///
+/// ```
+/// use ndarray::{Array3, Array2};
+/// use ndarray::linalg::Dot;
+///
+/// let a = Array3::<f64>::zeros((3, 4, 5));
+/// let b = Array2::<f64>::zeros((5, 6));
+/// let c = a.dot(&b);
+/// assert_eq!(c.shape(), &[3, 4, 6]);
+/// ```
 pub trait Dot<Rhs: ?Sized>
 {
     /// The result of the operation.
@@ -222,13 +238,58 @@ impl_dots!(Ix1, Ix2);
 impl_dots!(Ix2, Ix1);
 impl_dots!(Ix2, Ix2);
 
-fn nd_dot_non_contiguous<A, S1, S2, S3>(
-    lhs: &ArrayBase<S1, IxDyn>, rhs: &ArrayBase<S2, Ix2>, out: &mut ArrayBase<S3, IxDyn>,
+/// Compute the dot product of an N-dimensional LHS array with a 2-D RHS matrix.
+///
+/// Contracts the last axis of `lhs` with the first axis of `rhs`.
+/// If `lhs` has shape *d₀ × d₁ × … × dₙ₋₁ × K* and `rhs` has shape
+/// *K × N*, the result has shape *d₀ × d₁ × … × dₙ₋₁ × N*.
+///
+/// Two paths are used internally:
+/// - **C-contiguous LHS**: the leading axes are flattened into a single
+///   2-D view (zero-copy) and delegated to the optimised 2-D `dot`.
+/// - **Non-contiguous LHS**: a result array is pre-allocated and filled
+///   in-place via recursive `general_mat_mul` calls (no intermediate copies).
+#[track_caller]
+fn nd_dot<A: LinalgScalar>(lhs: &ArrayRef<A, IxDyn>, rhs: &ArrayRef<A, Ix2>) -> Array<A, IxDyn>
+{
+    let ndim = lhs.ndim();
+    let k = lhs.shape()[ndim - 1];
+    let k2 = rhs.shape()[0];
+    let n = rhs.shape()[1];
+    if k != k2 {
+        panic!(
+            "shapes {:?} and {:?} are not compatible for nd dot \
+             (last axis of lhs must equal first axis of rhs)",
+            lhs.shape(),
+            rhs.shape()
+        );
+    }
+
+    let mut out_shape = lhs.shape().to_vec();
+    *out_shape.last_mut().unwrap() = n;
+
+    if lhs.is_standard_layout() {
+        // C-contiguous: to_shape returns a *view* (no copy of LHS data).
+        let rows = lhs.len() / k;
+        // unwrap: rows * k == lhs.len() by construction, so reshape always succeeds.
+        let lhs_2d = lhs.to_shape((rows, k)).unwrap();
+        let result_2d = lhs_2d.dot(rhs);
+        // unwrap: result_2d is a fresh C-contiguous owned array of the correct size.
+        result_2d.into_shape_with_order(IxDyn(&out_shape)).unwrap()
+    } else {
+        // Non-contiguous: pre-allocate and fill in-place to avoid whole-array copying.
+        let mut out = Array::zeros(IxDyn(&out_shape));
+        nd_dot_non_contiguous(&lhs.view(), &rhs.view(), &mut out.view_mut());
+        out
+    }
+}
+
+/// Recursive helper: writes the N-D × 2-D product directly into `out`
+/// using `general_mat_mul` at the 2-D base case.
+fn nd_dot_non_contiguous<A>(
+    lhs: &ArrayRef<A, IxDyn>, rhs: &ArrayRef<A, Ix2>, out: &mut ArrayRef<A, IxDyn>,
 ) where
     A: LinalgScalar,
-    S1: Data<Elem = A>,
-    S2: Data<Elem = A>,
-    S3: DataMut<Elem = A>,
 {
     let ndim = lhs.ndim();
     if ndim == 2 {
@@ -237,8 +298,8 @@ fn nd_dot_non_contiguous<A, S1, S2, S3>(
         let mut out_2d = out.view_mut().into_dimensionality::<Ix2>().unwrap();
         general_mat_mul(A::one(), &lhs_2d, rhs, A::zero(), &mut out_2d);
     } else {
-        Zip::from(lhs.axis_iter(Axis(0)))
-            .and(out.axis_iter_mut(Axis(0)))
+        Zip::from(lhs.view().axis_iter(Axis(0)))
+            .and(out.view_mut().axis_iter_mut(Axis(0)))
             .for_each(|lhs_slice, mut out_slice| {
                 nd_dot_non_contiguous(&lhs_slice, rhs, &mut out_slice);
             });
@@ -255,46 +316,9 @@ macro_rules! impl_dot_nd_ix2 {
             #[track_caller]
             fn dot(&self, rhs: &ArrayRef<A, Ix2>) -> Array<A, $dim>
             {
-                let ndim = self.ndim();
-                let k = self.shape()[ndim - 1];
-                let k2 = rhs.shape()[0];
-                let n = rhs.shape()[1];
-                if k != k2 {
-                    panic!(
-                        "shapes {:?} and {:?} are not compatible for nd dot \
-                         (last axis of lhs must equal first axis of rhs)",
-                        self.shape(),
-                        rhs.shape()
-                    );
-                }
-
-                if self.is_standard_layout() {
-                    // C-contiguous: to_shape returns a *view* (no copy of LHS data).
-                    let rows = self.len() / k;
-                    // unwrap: rows * k == self.len() by construction, so reshape always succeeds.
-                    let lhs_2d = self.to_shape((rows, k)).unwrap();
-                    let result_2d = lhs_2d.dot(rhs);
-
-                    let mut out_dim = <$dim>::zeros(ndim);
-                    for i in 0..ndim - 1 {
-                        out_dim[i] = self.shape()[i];
-                    }
-                    out_dim[ndim - 1] = n;
-
-                    // unwrap: result_2d is a fresh C-contiguous owned array of the correct size.
-                    result_2d.into_shape_with_order(out_dim).unwrap()
-                } else {
-                    // Non-contiguous: iterate over the first axis and write results directly
-                    // into the pre-allocated output array to avoid whole-array copying.
-                    let mut out_dim = <$dim>::zeros(ndim);
-                    for i in 0..ndim - 1 {
-                        out_dim[i] = self.shape()[i];
-                    }
-                    out_dim[ndim - 1] = n;
-                    let mut out = Array::zeros(out_dim);
-                    nd_dot_non_contiguous(&self.view().into_dyn(), &rhs.view(), &mut out.view_mut().into_dyn());
-                    out
-                }
+                let result_dyn = nd_dot(&self.view().into_dyn(), rhs);
+                // unwrap: nd_dot preserves the number of dimensions.
+                result_dyn.into_dimensionality::<$dim>().unwrap()
             }
         }
 
@@ -315,40 +339,7 @@ where A: LinalgScalar
     #[track_caller]
     fn dot(&self, rhs: &ArrayRef<A, Ix2>) -> Array<A, IxDyn>
     {
-        let ndim = self.ndim();
-        let k = self.shape()[ndim - 1];
-        let k2 = rhs.shape()[0];
-        let n = rhs.shape()[1];
-        if k != k2 {
-            panic!(
-                "shapes {:?} and {:?} are not compatible for nd dot \
-                 (last axis of lhs must equal first axis of rhs)",
-                self.shape(),
-                rhs.shape()
-            );
-        }
-
-        if self.is_standard_layout() {
-            // C-contiguous: to_shape returns a *view* (no copy of LHS data).
-            let rows = self.len() / k;
-            // unwrap: rows * k == self.len() by construction, so reshape always succeeds.
-            let lhs_2d = self.to_shape((rows, k)).unwrap();
-            let result_2d = lhs_2d.dot(rhs);
-
-            let mut out_shape = self.shape().to_vec();
-            *out_shape.last_mut().unwrap() = n;
-
-            // unwrap: result_2d is a fresh C-contiguous owned array of the correct size.
-            result_2d.into_shape_with_order(IxDyn(&out_shape)).unwrap()
-        } else {
-            // Non-contiguous: iterate recursively over the first axis and write results
-            // directly into the pre-allocated output array to avoid whole-array copying.
-            let mut out_shape = self.shape().to_vec();
-            *out_shape.last_mut().unwrap() = n;
-            let mut out = Array::zeros(IxDyn(&out_shape));
-            nd_dot_non_contiguous(&self.view(), &rhs.view(), &mut out.view_mut());
-            out
-        }
+        nd_dot(&self.view().into_dyn(), rhs)
     }
 }
 

--- a/src/linalg/impl_linalg.rs
+++ b/src/linalg/impl_linalg.rs
@@ -286,10 +286,8 @@ fn nd_dot<A: LinalgScalar>(lhs: &ArrayRef<A, IxDyn>, rhs: &ArrayRef<A, Ix2>) -> 
 
 /// Recursive helper: writes the N-D × 2-D product directly into `out`
 /// using `general_mat_mul` at the 2-D base case.
-fn nd_dot_non_contiguous<A>(
-    lhs: &ArrayRef<A, IxDyn>, rhs: &ArrayRef<A, Ix2>, out: &mut ArrayRef<A, IxDyn>,
-) where
-    A: LinalgScalar,
+fn nd_dot_non_contiguous<A>(lhs: &ArrayRef<A, IxDyn>, rhs: &ArrayRef<A, Ix2>, out: &mut ArrayRef<A, IxDyn>)
+where A: LinalgScalar
 {
     let ndim = lhs.ndim();
     if ndim == 2 {

--- a/src/linalg/impl_linalg.rs
+++ b/src/linalg/impl_linalg.rs
@@ -237,24 +237,39 @@ macro_rules! impl_dot_nd_ix2 {
                 let k2 = rhs.shape()[0];
                 let n = rhs.shape()[1];
                 if k != k2 {
-                    dot_shape_error(self.len() / k, k, k2, n);
+                    panic!(
+                        "shapes {:?} and {:?} are not compatible for nd dot \
+                         (last axis of lhs must equal first axis of rhs)",
+                        self.shape(),
+                        rhs.shape()
+                    );
                 }
-                let rows = self.len() / k;
-                let lhs_2d = self
-                    .to_shape((rows, k))
-                    .expect("ndarray: to_shape failed in nd dot");
-                let result_2d = lhs_2d.dot(rhs);
 
-                let mut out_dim = <$dim>::zeros(ndim);
-                for i in 0..ndim - 1 {
-                    out_dim[i] = self.shape()[i];
+                if self.is_standard_layout() {
+                    // C-contiguous: to_shape returns a *view* (no copy of LHS data).
+                    // Safety: rows * k == self.len() by construction.
+                    let rows = self.len() / k;
+                    let lhs_2d = self.to_shape((rows, k)).unwrap();
+                    let result_2d = lhs_2d.dot(rhs);
+
+                    let mut out_dim = <$dim>::zeros(ndim);
+                    for i in 0..ndim - 1 {
+                        out_dim[i] = self.shape()[i];
+                    }
+                    out_dim[ndim - 1] = n;
+
+                    // result_2d is a fresh C-contiguous owned array;
+                    // into_shape_with_order is free.
+                    result_2d.into_shape_with_order(out_dim).unwrap()
+                } else {
+                    // Non-contiguous: iterate over the first axis so no whole-array
+                    // copy is needed. Each sub-array is (ndim-1)-D; the impl for that
+                    // dimension is already compiled (macro invocations are in order).
+                    let sub_results: Vec<_> =
+                        self.axis_iter(Axis(0)).map(|lane| lane.dot(rhs)).collect();
+                    let views: Vec<_> = sub_results.iter().map(|a| a.view()).collect();
+                    crate::stack(Axis(0), &views).unwrap()
                 }
-                out_dim[ndim - 1] = n;
-
-                result_2d
-                    .to_shape(out_dim)
-                    .expect("ndarray: to_shape failed reshaping nd dot result")
-                    .into_owned()
             }
         }
 
@@ -280,21 +295,35 @@ where A: LinalgScalar
         let k2 = rhs.shape()[0];
         let n = rhs.shape()[1];
         if k != k2 {
-            dot_shape_error(self.len() / k, k, k2, n);
+            panic!(
+                "shapes {:?} and {:?} are not compatible for nd dot \
+                 (last axis of lhs must equal first axis of rhs)",
+                self.shape(),
+                rhs.shape()
+            );
         }
-        let rows = self.len() / k;
-        let lhs_2d = self
-            .to_shape((rows, k))
-            .expect("ndarray: to_shape failed in nd dot (IxDyn)");
-        let result_2d = lhs_2d.dot(rhs);
 
-        let mut out_shape = self.shape().to_vec();
-        *out_shape.last_mut().unwrap() = n;
+        if self.is_standard_layout() {
+            // C-contiguous: to_shape returns a *view* (no copy of LHS data).
+            // Safety: rows * k == self.len() by construction.
+            let rows = self.len() / k;
+            let lhs_2d = self.to_shape((rows, k)).unwrap();
+            let result_2d = lhs_2d.dot(rhs);
 
-        result_2d
-            .to_shape(IxDyn(&out_shape))
-            .expect("ndarray: to_shape failed reshaping nd dot result (IxDyn)")
-            .into_owned()
+            let mut out_shape = self.shape().to_vec();
+            *out_shape.last_mut().unwrap() = n;
+
+            // result_2d is a fresh C-contiguous owned array;
+            // into_shape_with_order is free.
+            result_2d.into_shape_with_order(IxDyn(&out_shape)).unwrap()
+        } else {
+            // Non-contiguous: iterate over the first axis so no whole-array
+            // copy is needed. Each sub-array is (ndim-1)-D IxDyn; recursion
+            // eventually reaches contiguous 2-D which terminates the recursion.
+            let sub_results: Vec<_> = self.axis_iter(Axis(0)).map(|lane| lane.dot(rhs)).collect();
+            let views: Vec<_> = sub_results.iter().map(|a| a.view()).collect();
+            crate::stack(Axis(0), &views).unwrap()
+        }
     }
 }
 

--- a/src/linalg/impl_linalg.rs
+++ b/src/linalg/impl_linalg.rs
@@ -45,7 +45,8 @@ const GEMM_BLAS_CUTOFF: usize = 7;
 #[allow(non_camel_case_types)]
 type blas_index = c_int; // blas index type
 
-impl<A> ArrayRef<A, Ix1> {
+impl<A> ArrayRef<A, Ix1>
+{
     /// Perform dot product or matrix multiplication of arrays `self` and `rhs`.
     ///
     /// `Rhs` may be either a one-dimensional or a two-dimensional array.
@@ -65,15 +66,13 @@ impl<A> ArrayRef<A, Ix1> {
     /// layout allows.
     #[track_caller]
     pub fn dot<Rhs: ?Sized>(&self, rhs: &Rhs) -> <Self as Dot<Rhs>>::Output
-    where
-        Self: Dot<Rhs>,
+    where Self: Dot<Rhs>
     {
         Dot::dot(self, rhs)
     }
 
     fn dot_generic(&self, rhs: &ArrayRef<A, Ix1>) -> A
-    where
-        A: LinalgScalar,
+    where A: LinalgScalar
     {
         debug_assert_eq!(self.len(), rhs.len());
         assert!(self.len() == rhs.len());
@@ -93,16 +92,14 @@ impl<A> ArrayRef<A, Ix1> {
 
     #[cfg(not(feature = "blas"))]
     fn dot_impl(&self, rhs: &ArrayRef<A, Ix1>) -> A
-    where
-        A: LinalgScalar,
+    where A: LinalgScalar
     {
         self.dot_generic(rhs)
     }
 
     #[cfg(feature = "blas")]
     fn dot_impl(&self, rhs: &ArrayRef<A, Ix1>) -> A
-    where
-        A: LinalgScalar,
+    where A: LinalgScalar
     {
         // Use only if the vector is large enough to be worth it
         if self.len() >= DOT_BLAS_CUTOFF {
@@ -114,8 +111,15 @@ impl<A> ArrayRef<A, Ix1> {
                         unsafe {
                             let (lhs_ptr, n, incx) =
                                 blas_1d_params(self._ptr().as_ptr(), self.len(), self.strides()[0]);
-                            let (rhs_ptr, _, incy) = blas_1d_params(rhs._ptr().as_ptr(), rhs.len(), rhs.strides()[0]);
-                            let ret = blas_sys::$func(n, lhs_ptr as *const $ty, incx, rhs_ptr as *const $ty, incy);
+                            let (rhs_ptr, _, incy) =
+                                blas_1d_params(rhs._ptr().as_ptr(), rhs.len(), rhs.strides()[0]);
+                            let ret = blas_sys::$func(
+                                n,
+                                lhs_ptr as *const $ty,
+                                incx,
+                                rhs_ptr as *const $ty,
+                                incy,
+                            );
                             return cast_as::<$ty, A>(&ret);
                         }
                     }
@@ -135,7 +139,8 @@ impl<A> ArrayRef<A, Ix1> {
 /// which agrees with our pointer for non-negative strides, but
 /// is at the opposite end for negative strides.
 #[cfg(feature = "blas")]
-unsafe fn blas_1d_params<A>(ptr: *const A, len: usize, stride: isize) -> (*const A, blas_index, blas_index) {
+unsafe fn blas_1d_params<A>(ptr: *const A, len: usize, stride: isize) -> (*const A, blas_index, blas_index)
+{
     // [x x x x]
     //        ^--ptr
     //        stride = -1
@@ -152,7 +157,8 @@ unsafe fn blas_1d_params<A>(ptr: *const A, len: usize, stride: isize) -> (*const
 ///
 /// For two-dimensional arrays, the dot method computes the matrix
 /// multiplication.
-pub trait Dot<Rhs: ?Sized> {
+pub trait Dot<Rhs: ?Sized>
+{
     /// The result of the operation.
     ///
     /// For two-dimensional arrays: a rectangular array.
@@ -177,7 +183,8 @@ macro_rules! impl_dots {
         {
             type Output = <ArrayRef<A, $shape1> as Dot<ArrayRef<A, $shape2>>>::Output;
 
-            fn dot(&self, rhs: &ArrayBase<S2, $shape2>) -> Self::Output {
+            fn dot(&self, rhs: &ArrayBase<S2, $shape2>) -> Self::Output
+            {
                 Dot::dot(&**self, &**rhs)
             }
         }
@@ -189,7 +196,8 @@ macro_rules! impl_dots {
         {
             type Output = <ArrayRef<A, $shape1> as Dot<ArrayRef<A, $shape2>>>::Output;
 
-            fn dot(&self, rhs: &ArrayRef<A, $shape2>) -> Self::Output {
+            fn dot(&self, rhs: &ArrayRef<A, $shape2>) -> Self::Output
+            {
                 (**self).dot(rhs)
             }
         }
@@ -201,7 +209,8 @@ macro_rules! impl_dots {
         {
             type Output = <ArrayRef<A, $shape1> as Dot<ArrayRef<A, $shape2>>>::Output;
 
-            fn dot(&self, rhs: &ArrayBase<S, $shape2>) -> Self::Output {
+            fn dot(&self, rhs: &ArrayBase<S, $shape2>) -> Self::Output
+            {
                 self.dot(&**rhs)
             }
         }
@@ -213,9 +222,87 @@ impl_dots!(Ix1, Ix2);
 impl_dots!(Ix2, Ix1);
 impl_dots!(Ix2, Ix2);
 
+macro_rules! impl_dot_nd_ix2 {
+    ($dim:ty) => {
+        impl<A> Dot<ArrayRef<A, Ix2>> for ArrayRef<A, $dim>
+        where A: LinalgScalar
+        {
+            type Output = Array<A, $dim>;
+
+            #[track_caller]
+            fn dot(&self, rhs: &ArrayRef<A, Ix2>) -> Array<A, $dim>
+            {
+                let ndim = self.ndim();
+                let k = self.shape()[ndim - 1];
+                let k2 = rhs.shape()[0];
+                let n = rhs.shape()[1];
+                if k != k2 {
+                    dot_shape_error(self.len() / k, k, k2, n);
+                }
+                let rows = self.len() / k;
+                let lhs_2d = self
+                    .to_shape((rows, k))
+                    .expect("ndarray: to_shape failed in nd dot");
+                let result_2d = lhs_2d.dot(rhs);
+
+                let mut out_dim = <$dim>::zeros(ndim);
+                for i in 0..ndim - 1 {
+                    out_dim[i] = self.shape()[i];
+                }
+                out_dim[ndim - 1] = n;
+
+                result_2d
+                    .to_shape(out_dim)
+                    .expect("ndarray: to_shape failed reshaping nd dot result")
+                    .into_owned()
+            }
+        }
+
+        impl_dots!($dim, Ix2);
+    };
+}
+
+impl_dot_nd_ix2!(Ix3);
+impl_dot_nd_ix2!(Ix4);
+impl_dot_nd_ix2!(Ix5);
+impl_dot_nd_ix2!(Ix6);
+
+impl<A> Dot<ArrayRef<A, Ix2>> for ArrayRef<A, IxDyn>
+where A: LinalgScalar
+{
+    type Output = Array<A, IxDyn>;
+
+    #[track_caller]
+    fn dot(&self, rhs: &ArrayRef<A, Ix2>) -> Array<A, IxDyn>
+    {
+        let ndim = self.ndim();
+        let k = self.shape()[ndim - 1];
+        let k2 = rhs.shape()[0];
+        let n = rhs.shape()[1];
+        if k != k2 {
+            dot_shape_error(self.len() / k, k, k2, n);
+        }
+        let rows = self.len() / k;
+        let lhs_2d = self
+            .to_shape((rows, k))
+            .expect("ndarray: to_shape failed in nd dot (IxDyn)");
+        let result_2d = lhs_2d.dot(rhs);
+
+        let mut out_shape = self.shape().to_vec();
+        *out_shape.last_mut().unwrap() = n;
+
+        result_2d
+            .to_shape(IxDyn(&out_shape))
+            .expect("ndarray: to_shape failed reshaping nd dot result (IxDyn)")
+            .into_owned()
+    }
+}
+
+impl_dots!(IxDyn, Ix2);
+impl_dots!(IxDyn, IxDyn);
+
 impl<A> Dot<ArrayRef<A, Ix1>> for ArrayRef<A, Ix1>
-where
-    A: LinalgScalar,
+where A: LinalgScalar
 {
     type Output = A;
 
@@ -228,14 +315,14 @@ where
     /// *Note:* If enabled, uses blas `dot` for elements of `f32, f64` when memory
     /// layout allows.
     #[track_caller]
-    fn dot(&self, rhs: &ArrayRef<A, Ix1>) -> A {
+    fn dot(&self, rhs: &ArrayRef<A, Ix1>) -> A
+    {
         self.dot_impl(rhs)
     }
 }
 
 impl<A> Dot<ArrayRef<A, Ix2>> for ArrayRef<A, Ix1>
-where
-    A: LinalgScalar,
+where A: LinalgScalar
 {
     type Output = Array<A, Ix1>;
 
@@ -249,12 +336,14 @@ where
     ///
     /// **Panics** if shapes are incompatible.
     #[track_caller]
-    fn dot(&self, rhs: &ArrayRef<A, Ix2>) -> Array<A, Ix1> {
+    fn dot(&self, rhs: &ArrayRef<A, Ix2>) -> Array<A, Ix1>
+    {
         (*rhs.t()).dot(self)
     }
 }
 
-impl<A> ArrayRef<A, Ix2> {
+impl<A> ArrayRef<A, Ix2>
+{
     /// Perform matrix multiplication of rectangular arrays `self` and `rhs`.
     ///
     /// `Rhs` may be either a one-dimensional or a two-dimensional array.
@@ -286,20 +375,19 @@ impl<A> ArrayRef<A, Ix2> {
     /// ```
     #[track_caller]
     pub fn dot<Rhs: ?Sized>(&self, rhs: &Rhs) -> <Self as Dot<Rhs>>::Output
-    where
-        Self: Dot<Rhs>,
+    where Self: Dot<Rhs>
     {
         Dot::dot(self, rhs)
     }
 }
 
 impl<A> Dot<ArrayRef<A, Ix2>> for ArrayRef<A, Ix2>
-where
-    A: LinalgScalar,
+where A: LinalgScalar
 {
     type Output = Array2<A>;
 
-    fn dot(&self, b: &ArrayRef<A, Ix2>) -> Array2<A> {
+    fn dot(&self, b: &ArrayRef<A, Ix2>) -> Array2<A>
+    {
         let a = self.view();
         let b = b.view();
         let ((m, k), (k2, n)) = (a.dim(), b.dim());
@@ -322,127 +410,27 @@ where
     }
 }
 
-/// Implement `Dot<ArrayRef<A, Ix2>>` for a fixed higher-dimensional `ArrayRef<A, D>`.
-///
-/// The last axis of `self` must equal the first axis of `rhs`.  All other axes
-/// of `self` are preserved in the output, with the last axis replaced by the
-/// column count of `rhs`.
-///
-/// This mirrors NumPy's behaviour for `x @ y` when `x.ndim > 2`.
-macro_rules! impl_dot_nd_ix2 {
-    ($dim:ty, $larger:ty) => {
-        impl<A> Dot<ArrayRef<A, Ix2>> for ArrayRef<A, $dim>
-        where
-            A: LinalgScalar,
-        {
-            type Output = Array<A, $larger>;
-
-            /// Perform matrix multiplication of `self` and matrix `rhs`.
-            ///
-            /// The last axis of `self` must have the same length as the
-            /// number of rows in `rhs`. The output keeps all leading axes of
-            /// `self` and replaces the last axis with the number of columns
-            /// in `rhs`.
-            ///
-            /// **Panics** if shapes are incompatible.
-            #[track_caller]
-            fn dot(&self, rhs: &ArrayRef<A, Ix2>) -> Array<A, $larger> {
-                let ndim = self.ndim();
-                let k = self.shape()[ndim - 1];
-                let (k2, n) = rhs.dim();
-                if k != k2 {
-                    dot_shape_error(self.len() / k, k, k2, n);
-                }
-                let rows = self.len() / k;
-
-                // Flatten all but the last axis, then do a regular 2-D dot.
-                let lhs_2d = self
-                    .to_shape((rows, k))
-                    .expect("ndarray: to_shape failed in nd dot");
-                let result_2d: Array2<A> = lhs_2d.dot(rhs);
-
-                let mut out_shape = <$larger>::zeros(ndim);
-                for i in 0..ndim - 1 {
-                    out_shape[i] = self.shape()[i];
-                }
-                out_shape[ndim - 1] = n;
-
-                result_2d
-                    .to_shape(out_shape)
-                    .expect("ndarray: to_shape failed reshaping nd dot result")
-                    .into_owned()
-            }
-        }
-
-        impl_dots!($dim, Ix2);
-    };
-}
-
-impl_dot_nd_ix2!(Ix3, Ix3);
-impl_dot_nd_ix2!(Ix4, Ix4);
-impl_dot_nd_ix2!(Ix5, Ix5);
-impl_dot_nd_ix2!(Ix6, Ix6);
-
-impl<A> Dot<ArrayRef<A, Ix2>> for ArrayRef<A, IxDyn>
-where
-    A: LinalgScalar,
-{
-    type Output = Array<A, IxDyn>;
-
-    /// Perform matrix multiplication of `self` and matrix `rhs`.
-    ///
-    /// `self` must have at least 2 dimensions. The last axis of `self` must
-    /// have the same length as the number of rows in `rhs`. The output keeps
-    /// all leading axes of `self` and replaces the last with the column count
-    /// of `rhs`.
-    ///
-    /// **Panics** if `self.ndim() < 2` or if shapes are incompatible.
-    #[track_caller]
-    fn dot(&self, rhs: &ArrayRef<A, Ix2>) -> Array<A, IxDyn> {
-        let ndim = self.ndim();
-        assert!(ndim >= 2, "ndarray: dot requires at least a 2-D array on the left, got {}D", ndim);
-        let k = self.shape()[ndim - 1];
-        let (k2, n) = rhs.dim();
-        if k != k2 {
-            dot_shape_error(self.len() / k, k, k2, n);
-        }
-        let rows = self.len() / k;
-
-        let lhs_2d = self
-            .to_shape((rows, k))
-            .expect("ndarray: to_shape failed in nd dot (IxDyn)");
-        let result_2d: Array2<A> = lhs_2d.dot(rhs);
-
-        let mut out_shape = self.shape().to_vec();
-        *out_shape.last_mut().unwrap() = n;
-
-        result_2d
-            .to_shape(IxDyn(&out_shape))
-            .expect("ndarray: to_shape failed reshaping nd dot result (IxDyn)")
-            .into_owned()
-    }
-}
-
-impl_dots!(IxDyn, Ix2);
-
 /// Assumes that `m` and `n` are ≤ `isize::MAX`.
 #[cold]
 #[inline(never)]
-fn dot_shape_error(m: usize, k: usize, k2: usize, n: usize) -> ! {
+fn dot_shape_error(m: usize, k: usize, k2: usize, n: usize) -> !
+{
     match m.checked_mul(n) {
         Some(len) if len <= isize::MAX as usize => {}
         _ => panic!("ndarray: shape {} × {} overflows isize", m, n),
     }
-    panic!("ndarray: inputs {} × {} and {} × {} are not compatible for matrix multiplication", m, k, k2, n);
+    panic!(
+        "ndarray: inputs {} × {} and {} × {} are not compatible for matrix multiplication",
+        m, k, k2, n
+    );
 }
 
 #[cold]
 #[inline(never)]
-fn general_dot_shape_error(m: usize, k: usize, k2: usize, n: usize, c1: usize, c2: usize) -> ! {
-    panic!(
-        "ndarray: inputs {} × {}, {} × {}, and output {} × {} are not compatible for matrix multiplication",
-        m, k, k2, n, c1, c2
-    );
+fn general_dot_shape_error(m: usize, k: usize, k2: usize, n: usize, c1: usize, c2: usize) -> !
+{
+    panic!("ndarray: inputs {} × {}, {} × {}, and output {} × {} are not compatible for matrix multiplication",
+           m, k, k2, n, c1, c2);
 }
 
 /// Perform the matrix multiplication of the rectangular array `self` and
@@ -455,13 +443,13 @@ fn general_dot_shape_error(m: usize, k: usize, k2: usize, n: usize, c1: usize, c
 ///
 /// **Panics** if shapes are incompatible.
 impl<A> Dot<ArrayRef<A, Ix1>> for ArrayRef<A, Ix2>
-where
-    A: LinalgScalar,
+where A: LinalgScalar
 {
     type Output = Array<A, Ix1>;
 
     #[track_caller]
-    fn dot(&self, rhs: &ArrayRef<A, Ix1>) -> Array<A, Ix1> {
+    fn dot(&self, rhs: &ArrayRef<A, Ix1>) -> Array<A, Ix1>
+    {
         let ((m, a), n) = (self.dim(), rhs.dim());
         if a != n {
             dot_shape_error(m, a, n, 1);
@@ -477,8 +465,7 @@ where
 }
 
 impl<A, D> ArrayRef<A, D>
-where
-    D: Dimension,
+where D: Dimension
 {
     /// Perform the operation `self += alpha * rhs` efficiently, where
     /// `alpha` is a scalar and `rhs` is another array. This operation is
@@ -504,8 +491,7 @@ use self::mat_mul_general as mat_mul_impl;
 
 #[cfg(feature = "blas")]
 fn mat_mul_impl<A>(alpha: A, a: &ArrayRef2<A>, b: &ArrayRef2<A>, beta: A, c: &mut ArrayRef2<A>)
-where
-    A: LinalgScalar,
+where A: LinalgScalar
 {
     let ((m, k), (k2, n)) = (a.dim(), b.dim());
     debug_assert_eq!(k, k2);
@@ -560,17 +546,17 @@ where
                                 cblas_layout,
                                 a_trans,
                                 b_trans,
-                                m as blas_index,               // m, rows of Op(a)
-                                n as blas_index,               // n, cols of Op(b)
-                                k as blas_index,               // k, cols of Op(a)
-                                gemm_scalar_cast!($ty, alpha), // alpha
-                                a._ptr().as_ptr() as *const _, // a
-                                lda,                           // lda
-                                b._ptr().as_ptr() as *const _, // b
-                                ldb,                           // ldb
-                                gemm_scalar_cast!($ty, beta),  // beta
-                                c._ptr().as_ptr() as *mut _,   // c
-                                ldc,                           // ldc
+                                m as blas_index,                 // m, rows of Op(a)
+                                n as blas_index,                 // n, cols of Op(b)
+                                k as blas_index,                 // k, cols of Op(a)
+                                gemm_scalar_cast!($ty, alpha),   // alpha
+                                a._ptr().as_ptr() as *const _,      // a
+                                lda,                             // lda
+                                b._ptr().as_ptr() as *const _,      // b
+                                ldb,                             // ldb
+                                gemm_scalar_cast!($ty, beta),    // beta
+                                c._ptr().as_ptr() as *mut _,        // c
+                                ldc,                             // ldc
                             );
                         }
                         return;
@@ -591,8 +577,7 @@ where
 
 /// C ← α A B + β C
 fn mat_mul_general<A>(alpha: A, lhs: &ArrayRef2<A>, rhs: &ArrayRef2<A>, beta: A, c: &mut ArrayRef2<A>)
-where
-    A: LinalgScalar,
+where A: LinalgScalar
 {
     let ((m, k), (_, n)) = (lhs.dim(), rhs.dim());
 
@@ -725,8 +710,7 @@ where
 /// `f32, f64` for all memory layouts.
 #[track_caller]
 pub fn general_mat_mul<A>(alpha: A, a: &ArrayRef2<A>, b: &ArrayRef2<A>, beta: A, c: &mut ArrayRef2<A>)
-where
-    A: LinalgScalar,
+where A: LinalgScalar
 {
     let ((m, k), (k2, n)) = (a.dim(), b.dim());
     let (m2, n2) = c.dim();
@@ -750,8 +734,7 @@ where
 #[track_caller]
 #[allow(clippy::collapsible_if)]
 pub fn general_mat_vec_mul<A>(alpha: A, a: &ArrayRef2<A>, x: &ArrayRef1<A>, beta: A, y: &mut ArrayRef1<A>)
-where
-    A: LinalgScalar,
+where A: LinalgScalar
 {
     unsafe { general_mat_vec_mul_impl(alpha, a, x, beta, y.raw_view_mut()) }
 }
@@ -765,9 +748,9 @@ where
 /// The caller must ensure that the raw view is valid for writing.
 /// the destination may be uninitialized iff beta is zero.
 #[allow(clippy::collapsible_else_if)]
-unsafe fn general_mat_vec_mul_impl<A>(alpha: A, a: &ArrayRef2<A>, x: &ArrayRef1<A>, beta: A, y: RawArrayViewMut<A, Ix1>)
-where
-    A: LinalgScalar,
+unsafe fn general_mat_vec_mul_impl<A>(
+    alpha: A, a: &ArrayRef2<A>, x: &ArrayRef1<A>, beta: A, y: RawArrayViewMut<A, Ix1>,
+) where A: LinalgScalar
 {
     let ((m, k), k2) = (a.dim(), x.dim());
     let m2 = y.dim();
@@ -801,15 +784,15 @@ where
                             blas_sys::$gemv(
                                 cblas_layout,
                                 a_trans,
-                                m as blas_index,               // m, rows of Op(a)
-                                k as blas_index,               // n, cols of Op(a)
-                                cast_as(&alpha),               // alpha
+                                m as blas_index,            // m, rows of Op(a)
+                                k as blas_index,            // n, cols of Op(a)
+                                cast_as(&alpha),            // alpha
                                 a._ptr().as_ptr() as *const _, // a
-                                a_stride,                      // lda
-                                x_ptr as *const _,             // x
+                                a_stride,                   // lda
+                                x_ptr as *const _,          // x
                                 x_stride,
-                                cast_as(&beta),  // beta
-                                y_ptr as *mut _, // y
+                                cast_as(&beta),             // beta
+                                y_ptr as *mut _,            // y
                                 y_stride,
                             );
                             return;
@@ -843,8 +826,7 @@ where
 /// The kronecker product of a LxN matrix A and a MxR matrix B is a (L*M)x(N*R)
 /// matrix K formed by the block multiplication A_ij * B.
 pub fn kron<A>(a: &ArrayRef2<A>, b: &ArrayRef2<A>) -> Array<A, Ix2>
-where
-    A: LinalgScalar,
+where A: LinalgScalar
 {
     let dimar = a.shape()[0];
     let dimac = a.shape()[1];
@@ -870,26 +852,25 @@ where
 
 #[inline(always)]
 /// Return `true` if `A` and `B` are the same type
-fn same_type<A: 'static, B: 'static>() -> bool {
+fn same_type<A: 'static, B: 'static>() -> bool
+{
     TypeId::of::<A>() == TypeId::of::<B>()
 }
 
 // Read pointer to type `A` as type `B`.
 //
 // **Panics** if `A` and `B` are not the same type
-fn cast_as<A: 'static + Copy, B: 'static + Copy>(a: &A) -> B {
-    assert!(
-        same_type::<A, B>(),
-        "expect type {} and {} to match",
-        std::any::type_name::<A>(),
-        std::any::type_name::<B>()
-    );
+fn cast_as<A: 'static + Copy, B: 'static + Copy>(a: &A) -> B
+{
+    assert!(same_type::<A, B>(), "expect type {} and {} to match",
+            std::any::type_name::<A>(), std::any::type_name::<B>());
     unsafe { ::std::ptr::read(a as *const _ as *const B) }
 }
 
 /// Return the complex in the form of an array [re, im]
 #[inline]
-fn complex_array<A: 'static + Copy>(z: Complex<A>) -> [A; 2] {
+fn complex_array<A: 'static + Copy>(z: Complex<A>) -> [A; 2]
+{
     [z.re, z.im]
 }
 
@@ -915,14 +896,17 @@ where
 #[cfg(feature = "blas")]
 #[derive(Copy, Clone)]
 #[cfg_attr(test, derive(PartialEq, Eq, Debug))]
-enum BlasOrder {
+enum BlasOrder
+{
     C,
     F,
 }
 
 #[cfg(feature = "blas")]
-impl BlasOrder {
-    fn transpose(self) -> Self {
+impl BlasOrder
+{
+    fn transpose(self) -> Self
+    {
         match self {
             Self::C => Self::F,
             Self::F => Self::C,
@@ -931,14 +915,16 @@ impl BlasOrder {
 
     #[inline]
     /// Axis of leading stride (opposite of contiguous axis)
-    fn get_blas_lead_axis(self) -> usize {
+    fn get_blas_lead_axis(self) -> usize
+    {
         match self {
             Self::C => 0,
             Self::F => 1,
         }
     }
 
-    fn to_cblas_layout(self) -> CBLAS_LAYOUT {
+    fn to_cblas_layout(self) -> CBLAS_LAYOUT
+    {
         match self {
             Self::C => CBLAS_LAYOUT::CblasRowMajor,
             Self::F => CBLAS_LAYOUT::CblasColMajor,
@@ -947,7 +933,8 @@ impl BlasOrder {
 
     /// When using cblas_sgemm (etc) with C matrix using `for_layout`,
     /// how should this `self` matrix be transposed
-    fn to_cblas_transpose_for(self, for_layout: CBLAS_LAYOUT) -> CBLAS_TRANSPOSE {
+    fn to_cblas_transpose_for(self, for_layout: CBLAS_LAYOUT) -> CBLAS_TRANSPOSE
+    {
         let effective_order = match for_layout {
             CBLAS_LAYOUT::CblasRowMajor => self,
             CBLAS_LAYOUT::CblasColMajor => self.transpose(),
@@ -961,7 +948,8 @@ impl BlasOrder {
 }
 
 #[cfg(feature = "blas")]
-fn is_blas_2d(dim: &Ix2, stride: &Ix2, order: BlasOrder) -> bool {
+fn is_blas_2d(dim: &Ix2, stride: &Ix2, order: BlasOrder) -> bool
+{
     let (m, n) = dim.into_pattern();
     let s0 = stride[0] as isize;
     let s1 = stride[1] as isize;
@@ -998,7 +986,8 @@ fn is_blas_2d(dim: &Ix2, stride: &Ix2, order: BlasOrder) -> bool {
 
 /// Get BLAS compatible layout if any (C or F, preferring the former)
 #[cfg(feature = "blas")]
-fn get_blas_compatible_layout<A>(a: &ArrayRef<A, Ix2>) -> Option<BlasOrder> {
+fn get_blas_compatible_layout<A>(a: &ArrayRef<A, Ix2>) -> Option<BlasOrder>
+{
     if is_blas_2d(a._dim(), a._strides(), BlasOrder::C) {
         Some(BlasOrder::C)
     } else if is_blas_2d(a._dim(), a._strides(), BlasOrder::F) {
@@ -1013,7 +1002,8 @@ fn get_blas_compatible_layout<A>(a: &ArrayRef<A, Ix2>) -> Option<BlasOrder> {
 ///
 /// Return leading stride (lda, ldb, ldc) of array
 #[cfg(feature = "blas")]
-fn blas_stride<A>(a: &ArrayRef<A, Ix2>, order: BlasOrder) -> blas_index {
+fn blas_stride<A>(a: &ArrayRef<A, Ix2>, order: BlasOrder) -> blas_index
+{
     let axis = order.get_blas_lead_axis();
     let other_axis = 1 - axis;
     let len_this = a.shape()[axis];
@@ -1075,12 +1065,12 @@ where
 /// - The array shapes are incompatible for the operation
 /// - For vector dot product: the vectors have different lengths
 impl<A> Dot<ArrayRef<A, IxDyn>> for ArrayRef<A, IxDyn>
-where
-    A: LinalgScalar,
+where A: LinalgScalar
 {
     type Output = Array<A, IxDyn>;
 
-    fn dot(&self, rhs: &ArrayRef<A, IxDyn>) -> Self::Output {
+    fn dot(&self, rhs: &ArrayRef<A, IxDyn>) -> Self::Output
+    {
         match (self.ndim(), rhs.ndim()) {
             (1, 1) => {
                 let a = self.view().into_dimensionality::<Ix1>().unwrap();
@@ -1116,32 +1106,37 @@ where
 
 #[cfg(test)]
 #[cfg(feature = "blas")]
-mod blas_tests {
+mod blas_tests
+{
     use super::*;
 
     #[test]
-    fn blas_row_major_2d_normal_matrix() {
+    fn blas_row_major_2d_normal_matrix()
+    {
         let m: Array2<f32> = Array2::zeros((3, 5));
         assert!(blas_row_major_2d::<f32, _>(&m));
         assert!(!blas_column_major_2d::<f32, _>(&m));
     }
 
     #[test]
-    fn blas_row_major_2d_row_matrix() {
+    fn blas_row_major_2d_row_matrix()
+    {
         let m: Array2<f32> = Array2::zeros((1, 5));
         assert!(blas_row_major_2d::<f32, _>(&m));
         assert!(blas_column_major_2d::<f32, _>(&m));
     }
 
     #[test]
-    fn blas_row_major_2d_column_matrix() {
+    fn blas_row_major_2d_column_matrix()
+    {
         let m: Array2<f32> = Array2::zeros((5, 1));
         assert!(blas_row_major_2d::<f32, _>(&m));
         assert!(blas_column_major_2d::<f32, _>(&m));
     }
 
     #[test]
-    fn blas_row_major_2d_transposed_row_matrix() {
+    fn blas_row_major_2d_transposed_row_matrix()
+    {
         let m: Array2<f32> = Array2::zeros((1, 5));
         let m_t = m.t();
         assert!(blas_row_major_2d::<f32, _>(&m_t));
@@ -1149,7 +1144,8 @@ mod blas_tests {
     }
 
     #[test]
-    fn blas_row_major_2d_transposed_column_matrix() {
+    fn blas_row_major_2d_transposed_column_matrix()
+    {
         let m: Array2<f32> = Array2::zeros((5, 1));
         let m_t = m.t();
         assert!(blas_row_major_2d::<f32, _>(&m_t));
@@ -1157,14 +1153,16 @@ mod blas_tests {
     }
 
     #[test]
-    fn blas_column_major_2d_normal_matrix() {
+    fn blas_column_major_2d_normal_matrix()
+    {
         let m: Array2<f32> = Array2::zeros((3, 5).f());
         assert!(!blas_row_major_2d::<f32, _>(&m));
         assert!(blas_column_major_2d::<f32, _>(&m));
     }
 
     #[test]
-    fn blas_row_major_2d_skip_rows_ok() {
+    fn blas_row_major_2d_skip_rows_ok()
+    {
         let m: Array2<f32> = Array2::zeros((5, 5));
         let mv = m.slice(s![..;2, ..]);
         assert!(blas_row_major_2d::<f32, _>(&mv));
@@ -1172,7 +1170,8 @@ mod blas_tests {
     }
 
     #[test]
-    fn blas_row_major_2d_skip_columns_fail() {
+    fn blas_row_major_2d_skip_columns_fail()
+    {
         let m: Array2<f32> = Array2::zeros((5, 5));
         let mv = m.slice(s![.., ..;2]);
         assert!(!blas_row_major_2d::<f32, _>(&mv));
@@ -1180,7 +1179,8 @@ mod blas_tests {
     }
 
     #[test]
-    fn blas_col_major_2d_skip_columns_ok() {
+    fn blas_col_major_2d_skip_columns_ok()
+    {
         let m: Array2<f32> = Array2::zeros((5, 5).f());
         let mv = m.slice(s![.., ..;2]);
         assert!(blas_column_major_2d::<f32, _>(&mv));
@@ -1188,7 +1188,8 @@ mod blas_tests {
     }
 
     #[test]
-    fn blas_col_major_2d_skip_rows_fail() {
+    fn blas_col_major_2d_skip_rows_fail()
+    {
         let m: Array2<f32> = Array2::zeros((5, 5).f());
         let mv = m.slice(s![..;2, ..]);
         assert!(!blas_column_major_2d::<f32, _>(&mv));
@@ -1196,7 +1197,8 @@ mod blas_tests {
     }
 
     #[test]
-    fn blas_too_short_stride() {
+    fn blas_too_short_stride()
+    {
         // leading stride must be longer than the other dimension
         // Example, in a 5 x 5 matrix, the leading stride must be >= 5 for BLAS.
 

--- a/src/linalg/impl_linalg.rs
+++ b/src/linalg/impl_linalg.rs
@@ -45,8 +45,7 @@ const GEMM_BLAS_CUTOFF: usize = 7;
 #[allow(non_camel_case_types)]
 type blas_index = c_int; // blas index type
 
-impl<A> ArrayRef<A, Ix1>
-{
+impl<A> ArrayRef<A, Ix1> {
     /// Perform dot product or matrix multiplication of arrays `self` and `rhs`.
     ///
     /// `Rhs` may be either a one-dimensional or a two-dimensional array.
@@ -66,13 +65,15 @@ impl<A> ArrayRef<A, Ix1>
     /// layout allows.
     #[track_caller]
     pub fn dot<Rhs: ?Sized>(&self, rhs: &Rhs) -> <Self as Dot<Rhs>>::Output
-    where Self: Dot<Rhs>
+    where
+        Self: Dot<Rhs>,
     {
         Dot::dot(self, rhs)
     }
 
     fn dot_generic(&self, rhs: &ArrayRef<A, Ix1>) -> A
-    where A: LinalgScalar
+    where
+        A: LinalgScalar,
     {
         debug_assert_eq!(self.len(), rhs.len());
         assert!(self.len() == rhs.len());
@@ -92,14 +93,16 @@ impl<A> ArrayRef<A, Ix1>
 
     #[cfg(not(feature = "blas"))]
     fn dot_impl(&self, rhs: &ArrayRef<A, Ix1>) -> A
-    where A: LinalgScalar
+    where
+        A: LinalgScalar,
     {
         self.dot_generic(rhs)
     }
 
     #[cfg(feature = "blas")]
     fn dot_impl(&self, rhs: &ArrayRef<A, Ix1>) -> A
-    where A: LinalgScalar
+    where
+        A: LinalgScalar,
     {
         // Use only if the vector is large enough to be worth it
         if self.len() >= DOT_BLAS_CUTOFF {
@@ -111,15 +114,8 @@ impl<A> ArrayRef<A, Ix1>
                         unsafe {
                             let (lhs_ptr, n, incx) =
                                 blas_1d_params(self._ptr().as_ptr(), self.len(), self.strides()[0]);
-                            let (rhs_ptr, _, incy) =
-                                blas_1d_params(rhs._ptr().as_ptr(), rhs.len(), rhs.strides()[0]);
-                            let ret = blas_sys::$func(
-                                n,
-                                lhs_ptr as *const $ty,
-                                incx,
-                                rhs_ptr as *const $ty,
-                                incy,
-                            );
+                            let (rhs_ptr, _, incy) = blas_1d_params(rhs._ptr().as_ptr(), rhs.len(), rhs.strides()[0]);
+                            let ret = blas_sys::$func(n, lhs_ptr as *const $ty, incx, rhs_ptr as *const $ty, incy);
                             return cast_as::<$ty, A>(&ret);
                         }
                     }
@@ -139,8 +135,7 @@ impl<A> ArrayRef<A, Ix1>
 /// which agrees with our pointer for non-negative strides, but
 /// is at the opposite end for negative strides.
 #[cfg(feature = "blas")]
-unsafe fn blas_1d_params<A>(ptr: *const A, len: usize, stride: isize) -> (*const A, blas_index, blas_index)
-{
+unsafe fn blas_1d_params<A>(ptr: *const A, len: usize, stride: isize) -> (*const A, blas_index, blas_index) {
     // [x x x x]
     //        ^--ptr
     //        stride = -1
@@ -157,8 +152,7 @@ unsafe fn blas_1d_params<A>(ptr: *const A, len: usize, stride: isize) -> (*const
 ///
 /// For two-dimensional arrays, the dot method computes the matrix
 /// multiplication.
-pub trait Dot<Rhs: ?Sized>
-{
+pub trait Dot<Rhs: ?Sized> {
     /// The result of the operation.
     ///
     /// For two-dimensional arrays: a rectangular array.
@@ -183,8 +177,7 @@ macro_rules! impl_dots {
         {
             type Output = <ArrayRef<A, $shape1> as Dot<ArrayRef<A, $shape2>>>::Output;
 
-            fn dot(&self, rhs: &ArrayBase<S2, $shape2>) -> Self::Output
-            {
+            fn dot(&self, rhs: &ArrayBase<S2, $shape2>) -> Self::Output {
                 Dot::dot(&**self, &**rhs)
             }
         }
@@ -196,8 +189,7 @@ macro_rules! impl_dots {
         {
             type Output = <ArrayRef<A, $shape1> as Dot<ArrayRef<A, $shape2>>>::Output;
 
-            fn dot(&self, rhs: &ArrayRef<A, $shape2>) -> Self::Output
-            {
+            fn dot(&self, rhs: &ArrayRef<A, $shape2>) -> Self::Output {
                 (**self).dot(rhs)
             }
         }
@@ -209,8 +201,7 @@ macro_rules! impl_dots {
         {
             type Output = <ArrayRef<A, $shape1> as Dot<ArrayRef<A, $shape2>>>::Output;
 
-            fn dot(&self, rhs: &ArrayBase<S, $shape2>) -> Self::Output
-            {
+            fn dot(&self, rhs: &ArrayBase<S, $shape2>) -> Self::Output {
                 self.dot(&**rhs)
             }
         }
@@ -223,7 +214,8 @@ impl_dots!(Ix2, Ix1);
 impl_dots!(Ix2, Ix2);
 
 impl<A> Dot<ArrayRef<A, Ix1>> for ArrayRef<A, Ix1>
-where A: LinalgScalar
+where
+    A: LinalgScalar,
 {
     type Output = A;
 
@@ -236,14 +228,14 @@ where A: LinalgScalar
     /// *Note:* If enabled, uses blas `dot` for elements of `f32, f64` when memory
     /// layout allows.
     #[track_caller]
-    fn dot(&self, rhs: &ArrayRef<A, Ix1>) -> A
-    {
+    fn dot(&self, rhs: &ArrayRef<A, Ix1>) -> A {
         self.dot_impl(rhs)
     }
 }
 
 impl<A> Dot<ArrayRef<A, Ix2>> for ArrayRef<A, Ix1>
-where A: LinalgScalar
+where
+    A: LinalgScalar,
 {
     type Output = Array<A, Ix1>;
 
@@ -257,14 +249,12 @@ where A: LinalgScalar
     ///
     /// **Panics** if shapes are incompatible.
     #[track_caller]
-    fn dot(&self, rhs: &ArrayRef<A, Ix2>) -> Array<A, Ix1>
-    {
+    fn dot(&self, rhs: &ArrayRef<A, Ix2>) -> Array<A, Ix1> {
         (*rhs.t()).dot(self)
     }
 }
 
-impl<A> ArrayRef<A, Ix2>
-{
+impl<A> ArrayRef<A, Ix2> {
     /// Perform matrix multiplication of rectangular arrays `self` and `rhs`.
     ///
     /// `Rhs` may be either a one-dimensional or a two-dimensional array.
@@ -296,19 +286,20 @@ impl<A> ArrayRef<A, Ix2>
     /// ```
     #[track_caller]
     pub fn dot<Rhs: ?Sized>(&self, rhs: &Rhs) -> <Self as Dot<Rhs>>::Output
-    where Self: Dot<Rhs>
+    where
+        Self: Dot<Rhs>,
     {
         Dot::dot(self, rhs)
     }
 }
 
 impl<A> Dot<ArrayRef<A, Ix2>> for ArrayRef<A, Ix2>
-where A: LinalgScalar
+where
+    A: LinalgScalar,
 {
     type Output = Array2<A>;
 
-    fn dot(&self, b: &ArrayRef<A, Ix2>) -> Array2<A>
-    {
+    fn dot(&self, b: &ArrayRef<A, Ix2>) -> Array2<A> {
         let a = self.view();
         let b = b.view();
         let ((m, k), (k2, n)) = (a.dim(), b.dim());
@@ -331,27 +322,127 @@ where A: LinalgScalar
     }
 }
 
+/// Implement `Dot<ArrayRef<A, Ix2>>` for a fixed higher-dimensional `ArrayRef<A, D>`.
+///
+/// The last axis of `self` must equal the first axis of `rhs`.  All other axes
+/// of `self` are preserved in the output, with the last axis replaced by the
+/// column count of `rhs`.
+///
+/// This mirrors NumPy's behaviour for `x @ y` when `x.ndim > 2`.
+macro_rules! impl_dot_nd_ix2 {
+    ($dim:ty, $larger:ty) => {
+        impl<A> Dot<ArrayRef<A, Ix2>> for ArrayRef<A, $dim>
+        where
+            A: LinalgScalar,
+        {
+            type Output = Array<A, $larger>;
+
+            /// Perform matrix multiplication of `self` and matrix `rhs`.
+            ///
+            /// The last axis of `self` must have the same length as the
+            /// number of rows in `rhs`. The output keeps all leading axes of
+            /// `self` and replaces the last axis with the number of columns
+            /// in `rhs`.
+            ///
+            /// **Panics** if shapes are incompatible.
+            #[track_caller]
+            fn dot(&self, rhs: &ArrayRef<A, Ix2>) -> Array<A, $larger> {
+                let ndim = self.ndim();
+                let k = self.shape()[ndim - 1];
+                let (k2, n) = rhs.dim();
+                if k != k2 {
+                    dot_shape_error(self.len() / k, k, k2, n);
+                }
+                let rows = self.len() / k;
+
+                // Flatten all but the last axis, then do a regular 2-D dot.
+                let lhs_2d = self
+                    .to_shape((rows, k))
+                    .expect("ndarray: to_shape failed in nd dot");
+                let result_2d: Array2<A> = lhs_2d.dot(rhs);
+
+                let mut out_shape = <$larger>::zeros(ndim);
+                for i in 0..ndim - 1 {
+                    out_shape[i] = self.shape()[i];
+                }
+                out_shape[ndim - 1] = n;
+
+                result_2d
+                    .to_shape(out_shape)
+                    .expect("ndarray: to_shape failed reshaping nd dot result")
+                    .into_owned()
+            }
+        }
+
+        impl_dots!($dim, Ix2);
+    };
+}
+
+impl_dot_nd_ix2!(Ix3, Ix3);
+impl_dot_nd_ix2!(Ix4, Ix4);
+impl_dot_nd_ix2!(Ix5, Ix5);
+impl_dot_nd_ix2!(Ix6, Ix6);
+
+impl<A> Dot<ArrayRef<A, Ix2>> for ArrayRef<A, IxDyn>
+where
+    A: LinalgScalar,
+{
+    type Output = Array<A, IxDyn>;
+
+    /// Perform matrix multiplication of `self` and matrix `rhs`.
+    ///
+    /// `self` must have at least 2 dimensions. The last axis of `self` must
+    /// have the same length as the number of rows in `rhs`. The output keeps
+    /// all leading axes of `self` and replaces the last with the column count
+    /// of `rhs`.
+    ///
+    /// **Panics** if `self.ndim() < 2` or if shapes are incompatible.
+    #[track_caller]
+    fn dot(&self, rhs: &ArrayRef<A, Ix2>) -> Array<A, IxDyn> {
+        let ndim = self.ndim();
+        assert!(ndim >= 2, "ndarray: dot requires at least a 2-D array on the left, got {}D", ndim);
+        let k = self.shape()[ndim - 1];
+        let (k2, n) = rhs.dim();
+        if k != k2 {
+            dot_shape_error(self.len() / k, k, k2, n);
+        }
+        let rows = self.len() / k;
+
+        let lhs_2d = self
+            .to_shape((rows, k))
+            .expect("ndarray: to_shape failed in nd dot (IxDyn)");
+        let result_2d: Array2<A> = lhs_2d.dot(rhs);
+
+        let mut out_shape = self.shape().to_vec();
+        *out_shape.last_mut().unwrap() = n;
+
+        result_2d
+            .to_shape(IxDyn(&out_shape))
+            .expect("ndarray: to_shape failed reshaping nd dot result (IxDyn)")
+            .into_owned()
+    }
+}
+
+impl_dots!(IxDyn, Ix2);
+
 /// Assumes that `m` and `n` are ≤ `isize::MAX`.
 #[cold]
 #[inline(never)]
-fn dot_shape_error(m: usize, k: usize, k2: usize, n: usize) -> !
-{
+fn dot_shape_error(m: usize, k: usize, k2: usize, n: usize) -> ! {
     match m.checked_mul(n) {
         Some(len) if len <= isize::MAX as usize => {}
         _ => panic!("ndarray: shape {} × {} overflows isize", m, n),
     }
-    panic!(
-        "ndarray: inputs {} × {} and {} × {} are not compatible for matrix multiplication",
-        m, k, k2, n
-    );
+    panic!("ndarray: inputs {} × {} and {} × {} are not compatible for matrix multiplication", m, k, k2, n);
 }
 
 #[cold]
 #[inline(never)]
-fn general_dot_shape_error(m: usize, k: usize, k2: usize, n: usize, c1: usize, c2: usize) -> !
-{
-    panic!("ndarray: inputs {} × {}, {} × {}, and output {} × {} are not compatible for matrix multiplication",
-           m, k, k2, n, c1, c2);
+fn general_dot_shape_error(m: usize, k: usize, k2: usize, n: usize, c1: usize, c2: usize) -> ! {
+    panic!(
+        "ndarray: inputs {} × {}, {} × {}, and output {} × {} are not compatible for matrix multiplication",
+        m, k, k2, n, c1, c2
+    );
 }
 
 /// Perform the matrix multiplication of the rectangular array `self` and
@@ -364,13 +455,13 @@ fn general_dot_shape_error(m: usize, k: usize, k2: usize, n: usize, c1: usize, c
 ///
 /// **Panics** if shapes are incompatible.
 impl<A> Dot<ArrayRef<A, Ix1>> for ArrayRef<A, Ix2>
-where A: LinalgScalar
+where
+    A: LinalgScalar,
 {
     type Output = Array<A, Ix1>;
 
     #[track_caller]
-    fn dot(&self, rhs: &ArrayRef<A, Ix1>) -> Array<A, Ix1>
-    {
+    fn dot(&self, rhs: &ArrayRef<A, Ix1>) -> Array<A, Ix1> {
         let ((m, a), n) = (self.dim(), rhs.dim());
         if a != n {
             dot_shape_error(m, a, n, 1);
@@ -386,7 +477,8 @@ where A: LinalgScalar
 }
 
 impl<A, D> ArrayRef<A, D>
-where D: Dimension
+where
+    D: Dimension,
 {
     /// Perform the operation `self += alpha * rhs` efficiently, where
     /// `alpha` is a scalar and `rhs` is another array. This operation is
@@ -412,7 +504,8 @@ use self::mat_mul_general as mat_mul_impl;
 
 #[cfg(feature = "blas")]
 fn mat_mul_impl<A>(alpha: A, a: &ArrayRef2<A>, b: &ArrayRef2<A>, beta: A, c: &mut ArrayRef2<A>)
-where A: LinalgScalar
+where
+    A: LinalgScalar,
 {
     let ((m, k), (k2, n)) = (a.dim(), b.dim());
     debug_assert_eq!(k, k2);
@@ -467,17 +560,17 @@ where A: LinalgScalar
                                 cblas_layout,
                                 a_trans,
                                 b_trans,
-                                m as blas_index,                 // m, rows of Op(a)
-                                n as blas_index,                 // n, cols of Op(b)
-                                k as blas_index,                 // k, cols of Op(a)
-                                gemm_scalar_cast!($ty, alpha),   // alpha
-                                a._ptr().as_ptr() as *const _,      // a
-                                lda,                             // lda
-                                b._ptr().as_ptr() as *const _,      // b
-                                ldb,                             // ldb
-                                gemm_scalar_cast!($ty, beta),    // beta
-                                c._ptr().as_ptr() as *mut _,        // c
-                                ldc,                             // ldc
+                                m as blas_index,               // m, rows of Op(a)
+                                n as blas_index,               // n, cols of Op(b)
+                                k as blas_index,               // k, cols of Op(a)
+                                gemm_scalar_cast!($ty, alpha), // alpha
+                                a._ptr().as_ptr() as *const _, // a
+                                lda,                           // lda
+                                b._ptr().as_ptr() as *const _, // b
+                                ldb,                           // ldb
+                                gemm_scalar_cast!($ty, beta),  // beta
+                                c._ptr().as_ptr() as *mut _,   // c
+                                ldc,                           // ldc
                             );
                         }
                         return;
@@ -498,7 +591,8 @@ where A: LinalgScalar
 
 /// C ← α A B + β C
 fn mat_mul_general<A>(alpha: A, lhs: &ArrayRef2<A>, rhs: &ArrayRef2<A>, beta: A, c: &mut ArrayRef2<A>)
-where A: LinalgScalar
+where
+    A: LinalgScalar,
 {
     let ((m, k), (_, n)) = (lhs.dim(), rhs.dim());
 
@@ -631,7 +725,8 @@ where A: LinalgScalar
 /// `f32, f64` for all memory layouts.
 #[track_caller]
 pub fn general_mat_mul<A>(alpha: A, a: &ArrayRef2<A>, b: &ArrayRef2<A>, beta: A, c: &mut ArrayRef2<A>)
-where A: LinalgScalar
+where
+    A: LinalgScalar,
 {
     let ((m, k), (k2, n)) = (a.dim(), b.dim());
     let (m2, n2) = c.dim();
@@ -655,7 +750,8 @@ where A: LinalgScalar
 #[track_caller]
 #[allow(clippy::collapsible_if)]
 pub fn general_mat_vec_mul<A>(alpha: A, a: &ArrayRef2<A>, x: &ArrayRef1<A>, beta: A, y: &mut ArrayRef1<A>)
-where A: LinalgScalar
+where
+    A: LinalgScalar,
 {
     unsafe { general_mat_vec_mul_impl(alpha, a, x, beta, y.raw_view_mut()) }
 }
@@ -669,9 +765,9 @@ where A: LinalgScalar
 /// The caller must ensure that the raw view is valid for writing.
 /// the destination may be uninitialized iff beta is zero.
 #[allow(clippy::collapsible_else_if)]
-unsafe fn general_mat_vec_mul_impl<A>(
-    alpha: A, a: &ArrayRef2<A>, x: &ArrayRef1<A>, beta: A, y: RawArrayViewMut<A, Ix1>,
-) where A: LinalgScalar
+unsafe fn general_mat_vec_mul_impl<A>(alpha: A, a: &ArrayRef2<A>, x: &ArrayRef1<A>, beta: A, y: RawArrayViewMut<A, Ix1>)
+where
+    A: LinalgScalar,
 {
     let ((m, k), k2) = (a.dim(), x.dim());
     let m2 = y.dim();
@@ -705,15 +801,15 @@ unsafe fn general_mat_vec_mul_impl<A>(
                             blas_sys::$gemv(
                                 cblas_layout,
                                 a_trans,
-                                m as blas_index,            // m, rows of Op(a)
-                                k as blas_index,            // n, cols of Op(a)
-                                cast_as(&alpha),            // alpha
+                                m as blas_index,               // m, rows of Op(a)
+                                k as blas_index,               // n, cols of Op(a)
+                                cast_as(&alpha),               // alpha
                                 a._ptr().as_ptr() as *const _, // a
-                                a_stride,                   // lda
-                                x_ptr as *const _,          // x
+                                a_stride,                      // lda
+                                x_ptr as *const _,             // x
                                 x_stride,
-                                cast_as(&beta),             // beta
-                                y_ptr as *mut _,            // y
+                                cast_as(&beta),  // beta
+                                y_ptr as *mut _, // y
                                 y_stride,
                             );
                             return;
@@ -747,7 +843,8 @@ unsafe fn general_mat_vec_mul_impl<A>(
 /// The kronecker product of a LxN matrix A and a MxR matrix B is a (L*M)x(N*R)
 /// matrix K formed by the block multiplication A_ij * B.
 pub fn kron<A>(a: &ArrayRef2<A>, b: &ArrayRef2<A>) -> Array<A, Ix2>
-where A: LinalgScalar
+where
+    A: LinalgScalar,
 {
     let dimar = a.shape()[0];
     let dimac = a.shape()[1];
@@ -773,25 +870,26 @@ where A: LinalgScalar
 
 #[inline(always)]
 /// Return `true` if `A` and `B` are the same type
-fn same_type<A: 'static, B: 'static>() -> bool
-{
+fn same_type<A: 'static, B: 'static>() -> bool {
     TypeId::of::<A>() == TypeId::of::<B>()
 }
 
 // Read pointer to type `A` as type `B`.
 //
 // **Panics** if `A` and `B` are not the same type
-fn cast_as<A: 'static + Copy, B: 'static + Copy>(a: &A) -> B
-{
-    assert!(same_type::<A, B>(), "expect type {} and {} to match",
-            std::any::type_name::<A>(), std::any::type_name::<B>());
+fn cast_as<A: 'static + Copy, B: 'static + Copy>(a: &A) -> B {
+    assert!(
+        same_type::<A, B>(),
+        "expect type {} and {} to match",
+        std::any::type_name::<A>(),
+        std::any::type_name::<B>()
+    );
     unsafe { ::std::ptr::read(a as *const _ as *const B) }
 }
 
 /// Return the complex in the form of an array [re, im]
 #[inline]
-fn complex_array<A: 'static + Copy>(z: Complex<A>) -> [A; 2]
-{
+fn complex_array<A: 'static + Copy>(z: Complex<A>) -> [A; 2] {
     [z.re, z.im]
 }
 
@@ -817,17 +915,14 @@ where
 #[cfg(feature = "blas")]
 #[derive(Copy, Clone)]
 #[cfg_attr(test, derive(PartialEq, Eq, Debug))]
-enum BlasOrder
-{
+enum BlasOrder {
     C,
     F,
 }
 
 #[cfg(feature = "blas")]
-impl BlasOrder
-{
-    fn transpose(self) -> Self
-    {
+impl BlasOrder {
+    fn transpose(self) -> Self {
         match self {
             Self::C => Self::F,
             Self::F => Self::C,
@@ -836,16 +931,14 @@ impl BlasOrder
 
     #[inline]
     /// Axis of leading stride (opposite of contiguous axis)
-    fn get_blas_lead_axis(self) -> usize
-    {
+    fn get_blas_lead_axis(self) -> usize {
         match self {
             Self::C => 0,
             Self::F => 1,
         }
     }
 
-    fn to_cblas_layout(self) -> CBLAS_LAYOUT
-    {
+    fn to_cblas_layout(self) -> CBLAS_LAYOUT {
         match self {
             Self::C => CBLAS_LAYOUT::CblasRowMajor,
             Self::F => CBLAS_LAYOUT::CblasColMajor,
@@ -854,8 +947,7 @@ impl BlasOrder
 
     /// When using cblas_sgemm (etc) with C matrix using `for_layout`,
     /// how should this `self` matrix be transposed
-    fn to_cblas_transpose_for(self, for_layout: CBLAS_LAYOUT) -> CBLAS_TRANSPOSE
-    {
+    fn to_cblas_transpose_for(self, for_layout: CBLAS_LAYOUT) -> CBLAS_TRANSPOSE {
         let effective_order = match for_layout {
             CBLAS_LAYOUT::CblasRowMajor => self,
             CBLAS_LAYOUT::CblasColMajor => self.transpose(),
@@ -869,8 +961,7 @@ impl BlasOrder
 }
 
 #[cfg(feature = "blas")]
-fn is_blas_2d(dim: &Ix2, stride: &Ix2, order: BlasOrder) -> bool
-{
+fn is_blas_2d(dim: &Ix2, stride: &Ix2, order: BlasOrder) -> bool {
     let (m, n) = dim.into_pattern();
     let s0 = stride[0] as isize;
     let s1 = stride[1] as isize;
@@ -907,8 +998,7 @@ fn is_blas_2d(dim: &Ix2, stride: &Ix2, order: BlasOrder) -> bool
 
 /// Get BLAS compatible layout if any (C or F, preferring the former)
 #[cfg(feature = "blas")]
-fn get_blas_compatible_layout<A>(a: &ArrayRef<A, Ix2>) -> Option<BlasOrder>
-{
+fn get_blas_compatible_layout<A>(a: &ArrayRef<A, Ix2>) -> Option<BlasOrder> {
     if is_blas_2d(a._dim(), a._strides(), BlasOrder::C) {
         Some(BlasOrder::C)
     } else if is_blas_2d(a._dim(), a._strides(), BlasOrder::F) {
@@ -923,8 +1013,7 @@ fn get_blas_compatible_layout<A>(a: &ArrayRef<A, Ix2>) -> Option<BlasOrder>
 ///
 /// Return leading stride (lda, ldb, ldc) of array
 #[cfg(feature = "blas")]
-fn blas_stride<A>(a: &ArrayRef<A, Ix2>, order: BlasOrder) -> blas_index
-{
+fn blas_stride<A>(a: &ArrayRef<A, Ix2>, order: BlasOrder) -> blas_index {
     let axis = order.get_blas_lead_axis();
     let other_axis = 1 - axis;
     let len_this = a.shape()[axis];
@@ -986,12 +1075,12 @@ where
 /// - The array shapes are incompatible for the operation
 /// - For vector dot product: the vectors have different lengths
 impl<A> Dot<ArrayRef<A, IxDyn>> for ArrayRef<A, IxDyn>
-where A: LinalgScalar
+where
+    A: LinalgScalar,
 {
     type Output = Array<A, IxDyn>;
 
-    fn dot(&self, rhs: &ArrayRef<A, IxDyn>) -> Self::Output
-    {
+    fn dot(&self, rhs: &ArrayRef<A, IxDyn>) -> Self::Output {
         match (self.ndim(), rhs.ndim()) {
             (1, 1) => {
                 let a = self.view().into_dimensionality::<Ix1>().unwrap();
@@ -1027,37 +1116,32 @@ where A: LinalgScalar
 
 #[cfg(test)]
 #[cfg(feature = "blas")]
-mod blas_tests
-{
+mod blas_tests {
     use super::*;
 
     #[test]
-    fn blas_row_major_2d_normal_matrix()
-    {
+    fn blas_row_major_2d_normal_matrix() {
         let m: Array2<f32> = Array2::zeros((3, 5));
         assert!(blas_row_major_2d::<f32, _>(&m));
         assert!(!blas_column_major_2d::<f32, _>(&m));
     }
 
     #[test]
-    fn blas_row_major_2d_row_matrix()
-    {
+    fn blas_row_major_2d_row_matrix() {
         let m: Array2<f32> = Array2::zeros((1, 5));
         assert!(blas_row_major_2d::<f32, _>(&m));
         assert!(blas_column_major_2d::<f32, _>(&m));
     }
 
     #[test]
-    fn blas_row_major_2d_column_matrix()
-    {
+    fn blas_row_major_2d_column_matrix() {
         let m: Array2<f32> = Array2::zeros((5, 1));
         assert!(blas_row_major_2d::<f32, _>(&m));
         assert!(blas_column_major_2d::<f32, _>(&m));
     }
 
     #[test]
-    fn blas_row_major_2d_transposed_row_matrix()
-    {
+    fn blas_row_major_2d_transposed_row_matrix() {
         let m: Array2<f32> = Array2::zeros((1, 5));
         let m_t = m.t();
         assert!(blas_row_major_2d::<f32, _>(&m_t));
@@ -1065,8 +1149,7 @@ mod blas_tests
     }
 
     #[test]
-    fn blas_row_major_2d_transposed_column_matrix()
-    {
+    fn blas_row_major_2d_transposed_column_matrix() {
         let m: Array2<f32> = Array2::zeros((5, 1));
         let m_t = m.t();
         assert!(blas_row_major_2d::<f32, _>(&m_t));
@@ -1074,16 +1157,14 @@ mod blas_tests
     }
 
     #[test]
-    fn blas_column_major_2d_normal_matrix()
-    {
+    fn blas_column_major_2d_normal_matrix() {
         let m: Array2<f32> = Array2::zeros((3, 5).f());
         assert!(!blas_row_major_2d::<f32, _>(&m));
         assert!(blas_column_major_2d::<f32, _>(&m));
     }
 
     #[test]
-    fn blas_row_major_2d_skip_rows_ok()
-    {
+    fn blas_row_major_2d_skip_rows_ok() {
         let m: Array2<f32> = Array2::zeros((5, 5));
         let mv = m.slice(s![..;2, ..]);
         assert!(blas_row_major_2d::<f32, _>(&mv));
@@ -1091,8 +1172,7 @@ mod blas_tests
     }
 
     #[test]
-    fn blas_row_major_2d_skip_columns_fail()
-    {
+    fn blas_row_major_2d_skip_columns_fail() {
         let m: Array2<f32> = Array2::zeros((5, 5));
         let mv = m.slice(s![.., ..;2]);
         assert!(!blas_row_major_2d::<f32, _>(&mv));
@@ -1100,8 +1180,7 @@ mod blas_tests
     }
 
     #[test]
-    fn blas_col_major_2d_skip_columns_ok()
-    {
+    fn blas_col_major_2d_skip_columns_ok() {
         let m: Array2<f32> = Array2::zeros((5, 5).f());
         let mv = m.slice(s![.., ..;2]);
         assert!(blas_column_major_2d::<f32, _>(&mv));
@@ -1109,8 +1188,7 @@ mod blas_tests
     }
 
     #[test]
-    fn blas_col_major_2d_skip_rows_fail()
-    {
+    fn blas_col_major_2d_skip_rows_fail() {
         let m: Array2<f32> = Array2::zeros((5, 5).f());
         let mv = m.slice(s![..;2, ..]);
         assert!(!blas_column_major_2d::<f32, _>(&mv));
@@ -1118,8 +1196,7 @@ mod blas_tests
     }
 
     #[test]
-    fn blas_too_short_stride()
-    {
+    fn blas_too_short_stride() {
         // leading stride must be longer than the other dimension
         // Example, in a 5 x 5 matrix, the leading stride must be >= 5 for BLAS.
 

--- a/src/linalg/impl_linalg.rs
+++ b/src/linalg/impl_linalg.rs
@@ -222,6 +222,29 @@ impl_dots!(Ix1, Ix2);
 impl_dots!(Ix2, Ix1);
 impl_dots!(Ix2, Ix2);
 
+fn nd_dot_non_contiguous<A, S1, S2, S3>(
+    lhs: &ArrayBase<S1, IxDyn>, rhs: &ArrayBase<S2, Ix2>, out: &mut ArrayBase<S3, IxDyn>,
+) where
+    A: LinalgScalar,
+    S1: Data<Elem = A>,
+    S2: Data<Elem = A>,
+    S3: DataMut<Elem = A>,
+{
+    let ndim = lhs.ndim();
+    if ndim == 2 {
+        // unwrap: converting a 2-D ArrayView/ArrayViewMut to Ix2 always succeeds.
+        let lhs_2d = lhs.view().into_dimensionality::<Ix2>().unwrap();
+        let mut out_2d = out.view_mut().into_dimensionality::<Ix2>().unwrap();
+        general_mat_mul(A::one(), &*lhs_2d, &*rhs, A::zero(), &mut *out_2d);
+    } else {
+        Zip::from(lhs.axis_iter(Axis(0)))
+            .and(out.axis_iter_mut(Axis(0)))
+            .for_each(|lhs_slice, mut out_slice| {
+                nd_dot_non_contiguous(&lhs_slice, rhs, &mut out_slice);
+            });
+    }
+}
+
 macro_rules! impl_dot_nd_ix2 {
     ($dim:ty) => {
         impl<A> Dot<ArrayRef<A, Ix2>> for ArrayRef<A, $dim>
@@ -247,8 +270,8 @@ macro_rules! impl_dot_nd_ix2 {
 
                 if self.is_standard_layout() {
                     // C-contiguous: to_shape returns a *view* (no copy of LHS data).
-                    // Safety: rows * k == self.len() by construction.
                     let rows = self.len() / k;
+                    // unwrap: rows * k == self.len() by construction, so reshape always succeeds.
                     let lhs_2d = self.to_shape((rows, k)).unwrap();
                     let result_2d = lhs_2d.dot(rhs);
 
@@ -258,17 +281,19 @@ macro_rules! impl_dot_nd_ix2 {
                     }
                     out_dim[ndim - 1] = n;
 
-                    // result_2d is a fresh C-contiguous owned array;
-                    // into_shape_with_order is free.
+                    // unwrap: result_2d is a fresh C-contiguous owned array of the correct size.
                     result_2d.into_shape_with_order(out_dim).unwrap()
                 } else {
-                    // Non-contiguous: iterate over the first axis so no whole-array
-                    // copy is needed. Each sub-array is (ndim-1)-D; the impl for that
-                    // dimension is already compiled (macro invocations are in order).
-                    let sub_results: Vec<_> =
-                        self.axis_iter(Axis(0)).map(|lane| lane.dot(rhs)).collect();
-                    let views: Vec<_> = sub_results.iter().map(|a| a.view()).collect();
-                    crate::stack(Axis(0), &views).unwrap()
+                    // Non-contiguous: iterate over the first axis and write results directly
+                    // into the pre-allocated output array to avoid whole-array copying.
+                    let mut out_dim = <$dim>::zeros(ndim);
+                    for i in 0..ndim - 1 {
+                        out_dim[i] = self.shape()[i];
+                    }
+                    out_dim[ndim - 1] = n;
+                    let mut out = Array::zeros(out_dim);
+                    nd_dot_non_contiguous(&self.view().into_dyn(), &rhs.view(), &mut out.view_mut().into_dyn());
+                    out
                 }
             }
         }
@@ -305,24 +330,24 @@ where A: LinalgScalar
 
         if self.is_standard_layout() {
             // C-contiguous: to_shape returns a *view* (no copy of LHS data).
-            // Safety: rows * k == self.len() by construction.
             let rows = self.len() / k;
+            // unwrap: rows * k == self.len() by construction, so reshape always succeeds.
             let lhs_2d = self.to_shape((rows, k)).unwrap();
             let result_2d = lhs_2d.dot(rhs);
 
             let mut out_shape = self.shape().to_vec();
             *out_shape.last_mut().unwrap() = n;
 
-            // result_2d is a fresh C-contiguous owned array;
-            // into_shape_with_order is free.
+            // unwrap: result_2d is a fresh C-contiguous owned array of the correct size.
             result_2d.into_shape_with_order(IxDyn(&out_shape)).unwrap()
         } else {
-            // Non-contiguous: iterate over the first axis so no whole-array
-            // copy is needed. Each sub-array is (ndim-1)-D IxDyn; recursion
-            // eventually reaches contiguous 2-D which terminates the recursion.
-            let sub_results: Vec<_> = self.axis_iter(Axis(0)).map(|lane| lane.dot(rhs)).collect();
-            let views: Vec<_> = sub_results.iter().map(|a| a.view()).collect();
-            crate::stack(Axis(0), &views).unwrap()
+            // Non-contiguous: iterate recursively over the first axis and write results
+            // directly into the pre-allocated output array to avoid whole-array copying.
+            let mut out_shape = self.shape().to_vec();
+            *out_shape.last_mut().unwrap() = n;
+            let mut out = Array::zeros(IxDyn(&out_shape));
+            nd_dot_non_contiguous(&self.view(), &rhs.view(), &mut out.view_mut());
+            out
         }
     }
 }

--- a/src/linalg/impl_linalg.rs
+++ b/src/linalg/impl_linalg.rs
@@ -235,7 +235,7 @@ fn nd_dot_non_contiguous<A, S1, S2, S3>(
         // unwrap: converting a 2-D ArrayView/ArrayViewMut to Ix2 always succeeds.
         let lhs_2d = lhs.view().into_dimensionality::<Ix2>().unwrap();
         let mut out_2d = out.view_mut().into_dimensionality::<Ix2>().unwrap();
-        general_mat_mul(A::one(), &*lhs_2d, &*rhs, A::zero(), &mut *out_2d);
+        general_mat_mul(A::one(), &lhs_2d, rhs, A::zero(), &mut out_2d);
     } else {
         Zip::from(lhs.axis_iter(Axis(0)))
             .and(out.axis_iter_mut(Axis(0)))

--- a/tests/oper.rs
+++ b/tests/oper.rs
@@ -1,6 +1,8 @@
 #![allow(clippy::many_single_char_names, clippy::deref_addrof, clippy::unreadable_literal)]
+#![recursion_limit = "256"]
 use ndarray::linalg::general_mat_mul;
 use ndarray::linalg::kron;
+use ndarray::linalg::Dot;
 use ndarray::prelude::*;
 #[cfg(feature = "approx")]
 use ndarray::Order;
@@ -14,8 +16,7 @@ use defmac::defmac;
 use num_traits::Num;
 use num_traits::Zero;
 
-fn test_oper(op: &str, a: &[f32], b: &[f32], c: &[f32])
-{
+fn test_oper(op: &str, a: &[f32], b: &[f32], c: &[f32]) {
     let aa = CowArray::from(arr1(a));
     let bb = CowArray::from(arr1(b));
     let cc = CowArray::from(arr1(c));
@@ -33,7 +34,8 @@ fn test_oper(op: &str, a: &[f32], b: &[f32], c: &[f32])
 }
 
 fn test_oper_arr<D>(op: &str, mut aa: CowArray<f32, D>, bb: CowArray<f32, D>, cc: CowArray<f32, D>)
-where D: Dimension
+where
+    D: Dimension,
 {
     match op {
         "+" => {
@@ -70,8 +72,7 @@ where D: Dimension
 }
 
 #[test]
-fn operations()
-{
+fn operations() {
     test_oper("+", &[1.0, 2.0, 3.0, 4.0], &[0.0, 1.0, 2.0, 3.0], &[1.0, 3.0, 5.0, 7.0]);
     test_oper("-", &[1.0, 2.0, 3.0, 4.0], &[0.0, 1.0, 2.0, 3.0], &[1.0, 1.0, 1.0, 1.0]);
     test_oper("*", &[1.0, 2.0, 3.0, 4.0], &[0.0, 1.0, 2.0, 3.0], &[0.0, 2.0, 6.0, 12.0]);
@@ -81,8 +82,7 @@ fn operations()
 }
 
 #[test]
-fn scalar_operations()
-{
+fn scalar_operations() {
     let a = arr0::<f32>(1.);
     let b = rcarr1::<f32>(&[1., 1.]);
     let c = rcarr2(&[[1., 1.], [1., 1.]]);
@@ -128,8 +128,7 @@ where
 }
 
 #[test]
-fn dot_product()
-{
+fn dot_product() {
     let a = Array::from_iter((0..69).map(|x| x as f32));
     let b = &a * 2. - 7.;
     let dot = 197846.;
@@ -165,8 +164,7 @@ fn dot_product()
 
 // test that we can dot product with a broadcast array
 #[test]
-fn dot_product_0()
-{
+fn dot_product_0() {
     let a = Array::from_iter((0..69).map(|x| x as f32));
     let x = 1.5;
     let b = aview0(&x);
@@ -186,8 +184,7 @@ fn dot_product_0()
 }
 
 #[test]
-fn dot_product_neg_stride()
-{
+fn dot_product_neg_stride() {
     // test that we can dot with negative stride
     let a = Array::from_iter((0..69).map(|x| x as f32));
     let b = &a * 2. - 7.;
@@ -206,8 +203,7 @@ fn dot_product_neg_stride()
 }
 
 #[test]
-fn fold_and_sum()
-{
+fn fold_and_sum() {
     let a = Array::from_iter((0..128).map(|x| x as f32))
         .into_shape_with_order((8, 16))
         .unwrap();
@@ -248,8 +244,7 @@ fn fold_and_sum()
 }
 
 #[test]
-fn product()
-{
+fn product() {
     let step = (2. - 0.5) / 127.;
     let a = Array::from_iter((0..128).map(|i| 0.5 + step * (i as f64)))
         .into_shape_with_order((8, 16))
@@ -271,19 +266,16 @@ fn product()
     }
 }
 
-fn range_mat<A: Num + Copy>(m: Ix, n: Ix) -> Array2<A>
-{
+fn range_mat<A: Num + Copy>(m: Ix, n: Ix) -> Array2<A> {
     ArrayBuilder::new((m, n)).build()
 }
 
 #[cfg(feature = "approx")]
-fn range1_mat64(m: Ix) -> Array1<f64>
-{
+fn range1_mat64(m: Ix) -> Array1<f64> {
     ArrayBuilder::new(m).build()
 }
 
-fn range_i32(m: Ix, n: Ix) -> Array2<i32>
-{
+fn range_i32(m: Ix, n: Ix) -> Array2<i32> {
     ArrayBuilder::new((m, n)).build()
 }
 
@@ -318,8 +310,7 @@ where
 }
 
 #[test]
-fn mat_mul()
-{
+fn mat_mul() {
     let (m, n, k) = (8, 8, 8);
     let a = range_mat::<f32>(m, n);
     let b = range_mat::<f32>(n, k);
@@ -381,8 +372,7 @@ fn mat_mul()
 // Check that matrix multiplication of contiguous matrices returns a
 // matrix with the same order
 #[test]
-fn mat_mul_order()
-{
+fn mat_mul_order() {
     let (m, n, k) = (8, 8, 8);
     let a = range_mat::<f32>(m, n);
     let b = range_mat::<f32>(n, k);
@@ -401,8 +391,7 @@ fn mat_mul_order()
 // test matrix multiplication shape mismatch
 #[test]
 #[should_panic]
-fn mat_mul_shape_mismatch()
-{
+fn mat_mul_shape_mismatch() {
     let (m, k, k2, n) = (8, 8, 9, 8);
     let a = range_mat::<f32>(m, k);
     let b = range_mat::<f32>(k2, n);
@@ -412,8 +401,7 @@ fn mat_mul_shape_mismatch()
 // test matrix multiplication shape mismatch
 #[test]
 #[should_panic]
-fn mat_mul_shape_mismatch_2()
-{
+fn mat_mul_shape_mismatch_2() {
     let (m, k, k2, n) = (8, 8, 8, 8);
     let a = range_mat::<f32>(m, k);
     let b = range_mat::<f32>(k2, n);
@@ -424,8 +412,7 @@ fn mat_mul_shape_mismatch_2()
 // Check that matrix multiplication
 // supports broadcast arrays.
 #[test]
-fn mat_mul_broadcast()
-{
+fn mat_mul_broadcast() {
     let (m, n, k) = (16, 16, 16);
     let a = range_mat::<f32>(m, n);
     let x1 = 1.;
@@ -444,8 +431,7 @@ fn mat_mul_broadcast()
 
 // Check that matrix multiplication supports reversed axes
 #[test]
-fn mat_mul_rev()
-{
+fn mat_mul_rev() {
     let (m, n, k) = (16, 16, 16);
     let a = range_mat::<f32>(m, n);
     let b = range_mat::<f32>(n, k);
@@ -461,8 +447,7 @@ fn mat_mul_rev()
 
 // Check that matrix multiplication supports arrays with zero rows or columns
 #[test]
-fn mat_mut_zero_len()
-{
+fn mat_mut_zero_len() {
     defmac!(mat_mul_zero_len range_mat_fn => {
         for n in 0..4 {
             for m in 0..4 {
@@ -483,8 +468,7 @@ fn mat_mut_zero_len()
 }
 
 #[test]
-fn scaled_add()
-{
+fn scaled_add() {
     let a = range_mat(16, 15);
     let mut b = range_mat(16, 15);
     b.mapv_inplace(f32::exp);
@@ -500,8 +484,7 @@ fn scaled_add()
 #[cfg(feature = "approx")]
 #[cfg_attr(miri, ignore)] // Very slow on CI/CD machines
 #[test]
-fn scaled_add_2()
-{
+fn scaled_add_2() {
     let beta = -2.3;
     let sizes = vec![
         (4, 4, 1, 4),
@@ -539,8 +522,7 @@ fn scaled_add_2()
 #[cfg(feature = "approx")]
 #[cfg_attr(miri, ignore)] // Very slow on CI/CD machines
 #[test]
-fn scaled_add_3()
-{
+fn scaled_add_3() {
     use approx::assert_relative_eq;
     use ndarray::{Slice, SliceInfo, SliceInfoElem};
     use std::convert::TryFrom;
@@ -567,10 +549,7 @@ fn scaled_add_3()
                 let cslice: Vec<SliceInfoElem> = if n == 1 {
                     vec![Slice::from(..).step_by(s2).into()]
                 } else {
-                    vec![
-                        Slice::from(..).step_by(s1).into(),
-                        Slice::from(..).step_by(s2).into(),
-                    ]
+                    vec![Slice::from(..).step_by(s1).into(), Slice::from(..).step_by(s2).into()]
                 };
 
                 let c = range_mat::<f64>(n, q).into_shape_with_order(cdim).unwrap();
@@ -592,8 +571,7 @@ fn scaled_add_3()
 #[cfg(feature = "approx")]
 #[cfg_attr(miri, ignore)]
 #[test]
-fn gen_mat_mul()
-{
+fn gen_mat_mul() {
     use core::f64;
 
     let alpha = -2.3;
@@ -637,8 +615,7 @@ fn gen_mat_mul()
 // Test y = A x where A is f-order
 #[cfg(feature = "approx")]
 #[test]
-fn gemm_64_1_f()
-{
+fn gemm_64_1_f() {
     let a = range_mat::<f64>(64, 64).reversed_axes();
     let (m, n) = a.dim();
     // m x n  times n x 1  == m x 1
@@ -650,8 +627,7 @@ fn gemm_64_1_f()
 }
 
 #[test]
-fn gen_mat_mul_i32()
-{
+fn gen_mat_mul_i32() {
     let alpha = -1;
     let beta = 2;
     let sizes = if cfg!(miri) {
@@ -683,8 +659,7 @@ fn gen_mat_mul_i32()
 #[cfg(feature = "approx")]
 #[test]
 #[cfg_attr(miri, ignore)] // Takes too long
-fn gen_mat_vec_mul()
-{
+fn gen_mat_vec_mul() {
     use core::f64;
 
     use approx::assert_relative_eq;
@@ -710,17 +685,7 @@ fn gen_mat_vec_mul()
 
     let alpha = -2.3;
     let beta = f64::consts::PI;
-    let sizes = vec![
-        (4, 4),
-        (8, 8),
-        (17, 15),
-        (4, 17),
-        (17, 3),
-        (19, 18),
-        (16, 17),
-        (15, 16),
-        (67, 63),
-    ];
+    let sizes = vec![(4, 4), (8, 8), (17, 15), (4, 17), (17, 3), (19, 18), (16, 17), (15, 16), (67, 63)];
     // test different strides
     for &s1 in &[1, 2, -1, -2] {
         for &s2 in &[1, 2, -1, -2] {
@@ -752,8 +717,7 @@ fn gen_mat_vec_mul()
 #[cfg(feature = "approx")]
 #[cfg_attr(miri, ignore)] // Very slow on CI/CD machines
 #[test]
-fn vec_mat_mul()
-{
+fn vec_mat_mul() {
     use approx::assert_relative_eq;
 
     // simple, slow, correct (hopefully) mat mul
@@ -774,17 +738,7 @@ fn vec_mat_mul()
         .unwrap()
     }
 
-    let sizes = vec![
-        (4, 4),
-        (8, 8),
-        (17, 15),
-        (4, 17),
-        (17, 3),
-        (19, 18),
-        (16, 17),
-        (15, 16),
-        (67, 63),
-    ];
+    let sizes = vec![(4, 4), (8, 8), (17, 15), (4, 17), (17, 3), (19, 18), (16, 17), (15, 16), (67, 63)];
     // test different strides
     for &s1 in &[1, 2, -1, -2] {
         for &s2 in &[1, 2, -1, -2] {
@@ -813,52 +767,33 @@ fn vec_mat_mul()
 }
 
 #[test]
-fn kron_square_f64()
-{
+fn kron_square_f64() {
     let a = arr2(&[[1.0, 0.0], [0.0, 1.0]]);
     let b = arr2(&[[0.0, 1.0], [1.0, 0.0]]);
 
     assert_eq!(
         kron(&a, &b),
-        arr2(&[
-            [0.0, 1.0, 0.0, 0.0],
-            [1.0, 0.0, 0.0, 0.0],
-            [0.0, 0.0, 0.0, 1.0],
-            [0.0, 0.0, 1.0, 0.0]
-        ]),
+        arr2(&[[0.0, 1.0, 0.0, 0.0], [1.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 1.0], [0.0, 0.0, 1.0, 0.0]]),
     );
 
     assert_eq!(
         kron(&b, &a),
-        arr2(&[
-            [0.0, 0.0, 1.0, 0.0],
-            [0.0, 0.0, 0.0, 1.0],
-            [1.0, 0.0, 0.0, 0.0],
-            [0.0, 1.0, 0.0, 0.0]
-        ]),
+        arr2(&[[0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0], [1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]]),
     )
 }
 
 #[test]
-fn kron_square_i64()
-{
+fn kron_square_i64() {
     let a = arr2(&[[1, 0], [0, 1]]);
     let b = arr2(&[[0, 1], [1, 0]]);
 
-    assert_eq!(
-        kron(&a, &b),
-        arr2(&[[0, 1, 0, 0], [1, 0, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0]]),
-    );
+    assert_eq!(kron(&a, &b), arr2(&[[0, 1, 0, 0], [1, 0, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0]]),);
 
-    assert_eq!(
-        kron(&b, &a),
-        arr2(&[[0, 0, 1, 0], [0, 0, 0, 1], [1, 0, 0, 0], [0, 1, 0, 0]]),
-    )
+    assert_eq!(kron(&b, &a), arr2(&[[0, 0, 1, 0], [0, 0, 0, 1], [1, 0, 0, 0], [0, 1, 0, 0]]),)
 }
 
 #[test]
-fn kron_i64()
-{
+fn kron_i64() {
     let a = arr2(&[[1, 0]]);
     let b = arr2(&[[0, 1], [1, 0]]);
     let r = arr2(&[[0, 1, 0, 0], [1, 0, 0, 0]]);
@@ -868,4 +803,149 @@ fn kron_i64()
     let b = arr2(&[[0, 1], [1, 0]]);
     let r = arr2(&[[0, 1, 0, 0], [1, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0]]);
     assert_eq!(kron(&a, &b), r);
+}
+
+// Helper for the higher-dimensional dot tests below: performs the same
+// operation as ndarray's nd dot but using only the 2-D path, so we can
+// cross-check the results independently.
+fn reference_nd_dot<A, D>(lhs: &Array<A, D>, rhs: &Array2<A>) -> Array<A, D>
+where
+    A: LinalgScalar + std::fmt::Debug,
+    D: Dimension,
+{
+    let ndim = lhs.ndim();
+    let k = lhs.shape()[ndim - 1];
+    let rows = lhs.len() / k;
+    let n = rhs.shape()[1];
+
+    let lhs_2d = lhs.to_shape((rows, k)).unwrap().into_owned();
+    let res_2d = reference_mat_mul(&lhs_2d, rhs);
+
+    let mut out_dim = D::zeros(ndim);
+    for i in 0..ndim - 1 {
+        out_dim[i] = lhs.shape()[i];
+    }
+    out_dim[ndim - 1] = n;
+
+    res_2d.to_shape(out_dim).unwrap().into_owned()
+}
+
+#[test]
+fn dot_3d_by_2d() {
+    let lhs: Array3<f64> = ArrayBuilder::new((3, 4, 5)).build();
+    let rhs: Array2<f64> = ArrayBuilder::new((5, 6)).build();
+
+    let result = lhs.dot(&rhs);
+    let expected = reference_nd_dot(&lhs, &rhs);
+
+    assert_eq!(result.shape(), &[3, 4, 6]);
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn dot_3d_by_2d_non_contiguous() {
+    // Slice with stride 2 to get a non-contiguous layout.
+    let base: Array3<f64> = ArrayBuilder::new((6, 4, 5)).build();
+    let lhs = base.slice(s![..;2, .., ..]).to_owned();
+    let rhs: Array2<f64> = ArrayBuilder::new((5, 7)).build();
+
+    let result = lhs.dot(&rhs);
+    let expected = reference_nd_dot(&lhs, &rhs);
+
+    assert_eq!(result.shape(), &[3, 4, 7]);
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn dot_3d_by_2d_integer() {
+    let lhs: Array3<i32> = ArrayBuilder::new((2, 3, 4)).build();
+    let rhs: Array2<i32> = ArrayBuilder::new((4, 5)).build();
+
+    let result = lhs.dot(&rhs);
+    let expected = reference_nd_dot(&lhs, &rhs);
+
+    assert_eq!(result.shape(), &[2, 3, 5]);
+    assert_eq!(result, expected);
+}
+
+#[test]
+#[should_panic(expected = "not compatible for matrix multiplication")]
+fn dot_3d_by_2d_shape_mismatch() {
+    let lhs: Array3<f64> = Array3::zeros((3, 4, 5));
+    let rhs: Array2<f64> = Array2::zeros((6, 7));
+    let _ = lhs.dot(&rhs);
+}
+
+#[test]
+fn dot_4d_by_2d() {
+    let lhs: Array4<f64> = ArrayBuilder::new((2, 3, 4, 5)).build();
+    let rhs: Array2<f64> = ArrayBuilder::new((5, 6)).build();
+
+    let result = lhs.dot(&rhs);
+    let expected = reference_nd_dot(&lhs, &rhs);
+
+    assert_eq!(result.shape(), &[2, 3, 4, 6]);
+    assert_eq!(result, expected);
+}
+
+// The shapes here match the NumPy example from issue #1587.
+#[test]
+fn dot_5d_by_2d() {
+    let lhs: Array5<f64> =
+        Array5::from_shape_vec((3, 2, 5, 9, 12), (0..3 * 2 * 5 * 9 * 12).map(|x| x as f64).collect()).unwrap();
+    let rhs: Array2<f64> = Array2::from_shape_vec((12, 13), (0..12 * 13).map(|x| x as f64).collect()).unwrap();
+
+    let result = lhs.dot(&rhs);
+    let expected = reference_nd_dot(&lhs, &rhs);
+
+    assert_eq!(result.shape(), &[3, 2, 5, 9, 13]);
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn dot_6d_by_2d() {
+    let lhs: Array6<f64> =
+        Array6::from_shape_vec((2, 2, 2, 2, 2, 3), (0..2usize.pow(5) * 3).map(|x| x as f64).collect()).unwrap();
+    let rhs: Array2<f64> = Array2::from_shape_vec((3, 4), (0..12).map(|x| x as f64).collect()).unwrap();
+
+    let result = lhs.dot(&rhs);
+    let expected = reference_nd_dot(&lhs, &rhs);
+
+    assert_eq!(result.shape(), &[2, 2, 2, 2, 2, 4]);
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn dot_dyn_3d_by_2d() {
+    let lhs: ArrayD<f64> = ArrayD::from_shape_vec(IxDyn(&[3, 4, 5]), (0..60).map(|x| x as f64).collect()).unwrap();
+    let rhs: Array2<f64> = ArrayBuilder::new((5, 6)).build();
+
+    let result = lhs.dot(&rhs);
+    assert_eq!(result.shape(), &[3, 4, 6]);
+
+    let lhs_fixed: Array3<f64> = lhs.into_dimensionality::<Ix3>().unwrap();
+    let expected = lhs_fixed.dot(&rhs);
+    assert_eq!(result.into_dimensionality::<Ix3>().unwrap(), expected);
+}
+
+#[test]
+fn dot_dyn_5d_by_2d() {
+    let lhs: ArrayD<f64> =
+        ArrayD::from_shape_vec(IxDyn(&[3, 2, 5, 9, 12]), (0..3 * 2 * 5 * 9 * 12).map(|x| x as f64).collect()).unwrap();
+    let rhs: Array2<f64> = Array2::from_shape_vec((12, 13), (0..12 * 13).map(|x| x as f64).collect()).unwrap();
+
+    let result = lhs.dot(&rhs);
+    assert_eq!(result.shape(), &[3, 2, 5, 9, 13]);
+
+    let lhs_fixed: Array5<f64> = lhs.into_dimensionality::<Ix5>().unwrap();
+    let expected: Array5<f64> = lhs_fixed.dot(&rhs);
+    assert_eq!(result.into_dimensionality::<Ix5>().unwrap(), expected);
+}
+
+#[test]
+#[should_panic(expected = "not compatible for matrix multiplication")]
+fn dot_dyn_shape_mismatch() {
+    let lhs: ArrayD<f64> = ArrayD::zeros(IxDyn(&[3, 4, 5]));
+    let rhs: Array2<f64> = Array2::zeros((6, 7));
+    let _ = lhs.dot(&rhs);
 }

--- a/tests/oper.rs
+++ b/tests/oper.rs
@@ -939,7 +939,7 @@ fn dot_3d_by_2d_integer()
 }
 
 #[test]
-#[should_panic(expected = "not compatible for matrix multiplication")]
+#[should_panic(expected = "are not compatible for nd dot")]
 fn dot_3d_by_2d_shape_mismatch()
 {
     let lhs: Array3<f64> = Array3::zeros((3, 4, 5));
@@ -1019,7 +1019,23 @@ fn dot_dyn_5d_by_2d()
 }
 
 #[test]
-#[should_panic(expected = "not compatible for matrix multiplication")]
+fn dot_dyn_3d_by_2d_non_contiguous()
+{
+    // Slice with stride 2 to get a non-contiguous layout.
+    let base: Array3<f64> = ArrayBuilder::new((6, 4, 5)).build();
+    let lhs = base.slice(s![..;2, .., ..]).into_dyn();
+    let rhs: Array2<f64> = ArrayBuilder::new((5, 7)).build();
+
+    let result = lhs.dot(&rhs);
+    assert_eq!(result.shape(), &[3, 4, 7]);
+
+    let lhs_fixed: ArrayView3<f64> = lhs.into_dimensionality::<Ix3>().unwrap();
+    let expected = lhs_fixed.dot(&rhs);
+    assert_eq!(result.into_dimensionality::<Ix3>().unwrap(), expected);
+}
+
+#[test]
+#[should_panic(expected = "are not compatible for nd dot")]
 fn dot_dyn_shape_mismatch()
 {
     let lhs: ArrayD<f64> = ArrayD::zeros(IxDyn(&[3, 4, 5]));

--- a/tests/oper.rs
+++ b/tests/oper.rs
@@ -16,7 +16,8 @@ use defmac::defmac;
 use num_traits::Num;
 use num_traits::Zero;
 
-fn test_oper(op: &str, a: &[f32], b: &[f32], c: &[f32]) {
+fn test_oper(op: &str, a: &[f32], b: &[f32], c: &[f32])
+{
     let aa = CowArray::from(arr1(a));
     let bb = CowArray::from(arr1(b));
     let cc = CowArray::from(arr1(c));
@@ -34,8 +35,7 @@ fn test_oper(op: &str, a: &[f32], b: &[f32], c: &[f32]) {
 }
 
 fn test_oper_arr<D>(op: &str, mut aa: CowArray<f32, D>, bb: CowArray<f32, D>, cc: CowArray<f32, D>)
-where
-    D: Dimension,
+where D: Dimension
 {
     match op {
         "+" => {
@@ -72,7 +72,8 @@ where
 }
 
 #[test]
-fn operations() {
+fn operations()
+{
     test_oper("+", &[1.0, 2.0, 3.0, 4.0], &[0.0, 1.0, 2.0, 3.0], &[1.0, 3.0, 5.0, 7.0]);
     test_oper("-", &[1.0, 2.0, 3.0, 4.0], &[0.0, 1.0, 2.0, 3.0], &[1.0, 1.0, 1.0, 1.0]);
     test_oper("*", &[1.0, 2.0, 3.0, 4.0], &[0.0, 1.0, 2.0, 3.0], &[0.0, 2.0, 6.0, 12.0]);
@@ -82,7 +83,8 @@ fn operations() {
 }
 
 #[test]
-fn scalar_operations() {
+fn scalar_operations()
+{
     let a = arr0::<f32>(1.);
     let b = rcarr1::<f32>(&[1., 1.]);
     let c = rcarr2(&[[1., 1.], [1., 1.]]);
@@ -128,7 +130,8 @@ where
 }
 
 #[test]
-fn dot_product() {
+fn dot_product()
+{
     let a = Array::from_iter((0..69).map(|x| x as f32));
     let b = &a * 2. - 7.;
     let dot = 197846.;
@@ -164,7 +167,8 @@ fn dot_product() {
 
 // test that we can dot product with a broadcast array
 #[test]
-fn dot_product_0() {
+fn dot_product_0()
+{
     let a = Array::from_iter((0..69).map(|x| x as f32));
     let x = 1.5;
     let b = aview0(&x);
@@ -184,7 +188,8 @@ fn dot_product_0() {
 }
 
 #[test]
-fn dot_product_neg_stride() {
+fn dot_product_neg_stride()
+{
     // test that we can dot with negative stride
     let a = Array::from_iter((0..69).map(|x| x as f32));
     let b = &a * 2. - 7.;
@@ -203,7 +208,8 @@ fn dot_product_neg_stride() {
 }
 
 #[test]
-fn fold_and_sum() {
+fn fold_and_sum()
+{
     let a = Array::from_iter((0..128).map(|x| x as f32))
         .into_shape_with_order((8, 16))
         .unwrap();
@@ -244,7 +250,8 @@ fn fold_and_sum() {
 }
 
 #[test]
-fn product() {
+fn product()
+{
     let step = (2. - 0.5) / 127.;
     let a = Array::from_iter((0..128).map(|i| 0.5 + step * (i as f64)))
         .into_shape_with_order((8, 16))
@@ -266,16 +273,19 @@ fn product() {
     }
 }
 
-fn range_mat<A: Num + Copy>(m: Ix, n: Ix) -> Array2<A> {
+fn range_mat<A: Num + Copy>(m: Ix, n: Ix) -> Array2<A>
+{
     ArrayBuilder::new((m, n)).build()
 }
 
 #[cfg(feature = "approx")]
-fn range1_mat64(m: Ix) -> Array1<f64> {
+fn range1_mat64(m: Ix) -> Array1<f64>
+{
     ArrayBuilder::new(m).build()
 }
 
-fn range_i32(m: Ix, n: Ix) -> Array2<i32> {
+fn range_i32(m: Ix, n: Ix) -> Array2<i32>
+{
     ArrayBuilder::new((m, n)).build()
 }
 
@@ -310,7 +320,8 @@ where
 }
 
 #[test]
-fn mat_mul() {
+fn mat_mul()
+{
     let (m, n, k) = (8, 8, 8);
     let a = range_mat::<f32>(m, n);
     let b = range_mat::<f32>(n, k);
@@ -372,7 +383,8 @@ fn mat_mul() {
 // Check that matrix multiplication of contiguous matrices returns a
 // matrix with the same order
 #[test]
-fn mat_mul_order() {
+fn mat_mul_order()
+{
     let (m, n, k) = (8, 8, 8);
     let a = range_mat::<f32>(m, n);
     let b = range_mat::<f32>(n, k);
@@ -391,7 +403,8 @@ fn mat_mul_order() {
 // test matrix multiplication shape mismatch
 #[test]
 #[should_panic]
-fn mat_mul_shape_mismatch() {
+fn mat_mul_shape_mismatch()
+{
     let (m, k, k2, n) = (8, 8, 9, 8);
     let a = range_mat::<f32>(m, k);
     let b = range_mat::<f32>(k2, n);
@@ -401,7 +414,8 @@ fn mat_mul_shape_mismatch() {
 // test matrix multiplication shape mismatch
 #[test]
 #[should_panic]
-fn mat_mul_shape_mismatch_2() {
+fn mat_mul_shape_mismatch_2()
+{
     let (m, k, k2, n) = (8, 8, 8, 8);
     let a = range_mat::<f32>(m, k);
     let b = range_mat::<f32>(k2, n);
@@ -412,7 +426,8 @@ fn mat_mul_shape_mismatch_2() {
 // Check that matrix multiplication
 // supports broadcast arrays.
 #[test]
-fn mat_mul_broadcast() {
+fn mat_mul_broadcast()
+{
     let (m, n, k) = (16, 16, 16);
     let a = range_mat::<f32>(m, n);
     let x1 = 1.;
@@ -431,7 +446,8 @@ fn mat_mul_broadcast() {
 
 // Check that matrix multiplication supports reversed axes
 #[test]
-fn mat_mul_rev() {
+fn mat_mul_rev()
+{
     let (m, n, k) = (16, 16, 16);
     let a = range_mat::<f32>(m, n);
     let b = range_mat::<f32>(n, k);
@@ -447,7 +463,8 @@ fn mat_mul_rev() {
 
 // Check that matrix multiplication supports arrays with zero rows or columns
 #[test]
-fn mat_mut_zero_len() {
+fn mat_mut_zero_len()
+{
     defmac!(mat_mul_zero_len range_mat_fn => {
         for n in 0..4 {
             for m in 0..4 {
@@ -468,7 +485,8 @@ fn mat_mut_zero_len() {
 }
 
 #[test]
-fn scaled_add() {
+fn scaled_add()
+{
     let a = range_mat(16, 15);
     let mut b = range_mat(16, 15);
     b.mapv_inplace(f32::exp);
@@ -484,7 +502,8 @@ fn scaled_add() {
 #[cfg(feature = "approx")]
 #[cfg_attr(miri, ignore)] // Very slow on CI/CD machines
 #[test]
-fn scaled_add_2() {
+fn scaled_add_2()
+{
     let beta = -2.3;
     let sizes = vec![
         (4, 4, 1, 4),
@@ -522,7 +541,8 @@ fn scaled_add_2() {
 #[cfg(feature = "approx")]
 #[cfg_attr(miri, ignore)] // Very slow on CI/CD machines
 #[test]
-fn scaled_add_3() {
+fn scaled_add_3()
+{
     use approx::assert_relative_eq;
     use ndarray::{Slice, SliceInfo, SliceInfoElem};
     use std::convert::TryFrom;
@@ -549,7 +569,10 @@ fn scaled_add_3() {
                 let cslice: Vec<SliceInfoElem> = if n == 1 {
                     vec![Slice::from(..).step_by(s2).into()]
                 } else {
-                    vec![Slice::from(..).step_by(s1).into(), Slice::from(..).step_by(s2).into()]
+                    vec![
+                        Slice::from(..).step_by(s1).into(),
+                        Slice::from(..).step_by(s2).into(),
+                    ]
                 };
 
                 let c = range_mat::<f64>(n, q).into_shape_with_order(cdim).unwrap();
@@ -571,7 +594,8 @@ fn scaled_add_3() {
 #[cfg(feature = "approx")]
 #[cfg_attr(miri, ignore)]
 #[test]
-fn gen_mat_mul() {
+fn gen_mat_mul()
+{
     use core::f64;
 
     let alpha = -2.3;
@@ -615,7 +639,8 @@ fn gen_mat_mul() {
 // Test y = A x where A is f-order
 #[cfg(feature = "approx")]
 #[test]
-fn gemm_64_1_f() {
+fn gemm_64_1_f()
+{
     let a = range_mat::<f64>(64, 64).reversed_axes();
     let (m, n) = a.dim();
     // m x n  times n x 1  == m x 1
@@ -627,7 +652,8 @@ fn gemm_64_1_f() {
 }
 
 #[test]
-fn gen_mat_mul_i32() {
+fn gen_mat_mul_i32()
+{
     let alpha = -1;
     let beta = 2;
     let sizes = if cfg!(miri) {
@@ -659,7 +685,8 @@ fn gen_mat_mul_i32() {
 #[cfg(feature = "approx")]
 #[test]
 #[cfg_attr(miri, ignore)] // Takes too long
-fn gen_mat_vec_mul() {
+fn gen_mat_vec_mul()
+{
     use core::f64;
 
     use approx::assert_relative_eq;
@@ -685,7 +712,17 @@ fn gen_mat_vec_mul() {
 
     let alpha = -2.3;
     let beta = f64::consts::PI;
-    let sizes = vec![(4, 4), (8, 8), (17, 15), (4, 17), (17, 3), (19, 18), (16, 17), (15, 16), (67, 63)];
+    let sizes = vec![
+        (4, 4),
+        (8, 8),
+        (17, 15),
+        (4, 17),
+        (17, 3),
+        (19, 18),
+        (16, 17),
+        (15, 16),
+        (67, 63),
+    ];
     // test different strides
     for &s1 in &[1, 2, -1, -2] {
         for &s2 in &[1, 2, -1, -2] {
@@ -717,7 +754,8 @@ fn gen_mat_vec_mul() {
 #[cfg(feature = "approx")]
 #[cfg_attr(miri, ignore)] // Very slow on CI/CD machines
 #[test]
-fn vec_mat_mul() {
+fn vec_mat_mul()
+{
     use approx::assert_relative_eq;
 
     // simple, slow, correct (hopefully) mat mul
@@ -738,7 +776,17 @@ fn vec_mat_mul() {
         .unwrap()
     }
 
-    let sizes = vec![(4, 4), (8, 8), (17, 15), (4, 17), (17, 3), (19, 18), (16, 17), (15, 16), (67, 63)];
+    let sizes = vec![
+        (4, 4),
+        (8, 8),
+        (17, 15),
+        (4, 17),
+        (17, 3),
+        (19, 18),
+        (16, 17),
+        (15, 16),
+        (67, 63),
+    ];
     // test different strides
     for &s1 in &[1, 2, -1, -2] {
         for &s2 in &[1, 2, -1, -2] {
@@ -767,33 +815,52 @@ fn vec_mat_mul() {
 }
 
 #[test]
-fn kron_square_f64() {
+fn kron_square_f64()
+{
     let a = arr2(&[[1.0, 0.0], [0.0, 1.0]]);
     let b = arr2(&[[0.0, 1.0], [1.0, 0.0]]);
 
     assert_eq!(
         kron(&a, &b),
-        arr2(&[[0.0, 1.0, 0.0, 0.0], [1.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 1.0], [0.0, 0.0, 1.0, 0.0]]),
+        arr2(&[
+            [0.0, 1.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 1.0],
+            [0.0, 0.0, 1.0, 0.0]
+        ]),
     );
 
     assert_eq!(
         kron(&b, &a),
-        arr2(&[[0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0], [1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]]),
+        arr2(&[
+            [0.0, 0.0, 1.0, 0.0],
+            [0.0, 0.0, 0.0, 1.0],
+            [1.0, 0.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0, 0.0]
+        ]),
     )
 }
 
 #[test]
-fn kron_square_i64() {
+fn kron_square_i64()
+{
     let a = arr2(&[[1, 0], [0, 1]]);
     let b = arr2(&[[0, 1], [1, 0]]);
 
-    assert_eq!(kron(&a, &b), arr2(&[[0, 1, 0, 0], [1, 0, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0]]),);
+    assert_eq!(
+        kron(&a, &b),
+        arr2(&[[0, 1, 0, 0], [1, 0, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0]]),
+    );
 
-    assert_eq!(kron(&b, &a), arr2(&[[0, 0, 1, 0], [0, 0, 0, 1], [1, 0, 0, 0], [0, 1, 0, 0]]),)
+    assert_eq!(
+        kron(&b, &a),
+        arr2(&[[0, 0, 1, 0], [0, 0, 0, 1], [1, 0, 0, 0], [0, 1, 0, 0]]),
+    )
 }
 
 #[test]
-fn kron_i64() {
+fn kron_i64()
+{
     let a = arr2(&[[1, 0]]);
     let b = arr2(&[[0, 1], [1, 0]]);
     let r = arr2(&[[0, 1, 0, 0], [1, 0, 0, 0]]);
@@ -831,7 +898,8 @@ where
 }
 
 #[test]
-fn dot_3d_by_2d() {
+fn dot_3d_by_2d()
+{
     let lhs: Array3<f64> = ArrayBuilder::new((3, 4, 5)).build();
     let rhs: Array2<f64> = ArrayBuilder::new((5, 6)).build();
 
@@ -843,7 +911,8 @@ fn dot_3d_by_2d() {
 }
 
 #[test]
-fn dot_3d_by_2d_non_contiguous() {
+fn dot_3d_by_2d_non_contiguous()
+{
     // Slice with stride 2 to get a non-contiguous layout.
     let base: Array3<f64> = ArrayBuilder::new((6, 4, 5)).build();
     let lhs = base.slice(s![..;2, .., ..]).to_owned();
@@ -857,7 +926,8 @@ fn dot_3d_by_2d_non_contiguous() {
 }
 
 #[test]
-fn dot_3d_by_2d_integer() {
+fn dot_3d_by_2d_integer()
+{
     let lhs: Array3<i32> = ArrayBuilder::new((2, 3, 4)).build();
     let rhs: Array2<i32> = ArrayBuilder::new((4, 5)).build();
 
@@ -870,14 +940,16 @@ fn dot_3d_by_2d_integer() {
 
 #[test]
 #[should_panic(expected = "not compatible for matrix multiplication")]
-fn dot_3d_by_2d_shape_mismatch() {
+fn dot_3d_by_2d_shape_mismatch()
+{
     let lhs: Array3<f64> = Array3::zeros((3, 4, 5));
     let rhs: Array2<f64> = Array2::zeros((6, 7));
     let _ = lhs.dot(&rhs);
 }
 
 #[test]
-fn dot_4d_by_2d() {
+fn dot_4d_by_2d()
+{
     let lhs: Array4<f64> = ArrayBuilder::new((2, 3, 4, 5)).build();
     let rhs: Array2<f64> = ArrayBuilder::new((5, 6)).build();
 
@@ -890,7 +962,8 @@ fn dot_4d_by_2d() {
 
 // The shapes here match the NumPy example from issue #1587.
 #[test]
-fn dot_5d_by_2d() {
+fn dot_5d_by_2d()
+{
     let lhs: Array5<f64> =
         Array5::from_shape_vec((3, 2, 5, 9, 12), (0..3 * 2 * 5 * 9 * 12).map(|x| x as f64).collect()).unwrap();
     let rhs: Array2<f64> = Array2::from_shape_vec((12, 13), (0..12 * 13).map(|x| x as f64).collect()).unwrap();
@@ -903,7 +976,8 @@ fn dot_5d_by_2d() {
 }
 
 #[test]
-fn dot_6d_by_2d() {
+fn dot_6d_by_2d()
+{
     let lhs: Array6<f64> =
         Array6::from_shape_vec((2, 2, 2, 2, 2, 3), (0..2usize.pow(5) * 3).map(|x| x as f64).collect()).unwrap();
     let rhs: Array2<f64> = Array2::from_shape_vec((3, 4), (0..12).map(|x| x as f64).collect()).unwrap();
@@ -916,7 +990,8 @@ fn dot_6d_by_2d() {
 }
 
 #[test]
-fn dot_dyn_3d_by_2d() {
+fn dot_dyn_3d_by_2d()
+{
     let lhs: ArrayD<f64> = ArrayD::from_shape_vec(IxDyn(&[3, 4, 5]), (0..60).map(|x| x as f64).collect()).unwrap();
     let rhs: Array2<f64> = ArrayBuilder::new((5, 6)).build();
 
@@ -929,7 +1004,8 @@ fn dot_dyn_3d_by_2d() {
 }
 
 #[test]
-fn dot_dyn_5d_by_2d() {
+fn dot_dyn_5d_by_2d()
+{
     let lhs: ArrayD<f64> =
         ArrayD::from_shape_vec(IxDyn(&[3, 2, 5, 9, 12]), (0..3 * 2 * 5 * 9 * 12).map(|x| x as f64).collect()).unwrap();
     let rhs: Array2<f64> = Array2::from_shape_vec((12, 13), (0..12 * 13).map(|x| x as f64).collect()).unwrap();
@@ -944,7 +1020,8 @@ fn dot_dyn_5d_by_2d() {
 
 #[test]
 #[should_panic(expected = "not compatible for matrix multiplication")]
-fn dot_dyn_shape_mismatch() {
+fn dot_dyn_shape_mismatch()
+{
     let lhs: ArrayD<f64> = ArrayD::zeros(IxDyn(&[3, 4, 5]));
     let rhs: Array2<f64> = Array2::zeros((6, 7));
     let _ = lhs.dot(&rhs);


### PR DESCRIPTION
closes #1587

right now calling `.dot()` on anything above `Ix2` doesn't work, so if you have a 3-D or 5-D array and want to multiply it by a matrix you have to manually reshape, dot, then reshape back.

this adds `Dot<ArrayRef<A, Ix2>>` for `Ix3`, `Ix4`, `Ix5`, `Ix6`, and `IxDyn`. the implementation flattens all axes except the last into a single "rows" dimension, delegates to the existing 2-D dot (which already handles BLAS), then reshapes the result back to the correct output shape.

for example:

```rust
use ndarray::prelude::*;
use ndarray::linalg::Dot;

let x = Array5::<f64>::zeros((3, 2, 5, 9, 12));
let y = Array2::<f64>::zeros((12, 13));
let z = x.dot(&y); // shape: (3, 2, 5, 9, 13)
